### PR TITLE
Add memo option to registration

### DIFF
--- a/workspace/data-proxy/src/cli/register.ts
+++ b/workspace/data-proxy/src/cli/register.ts
@@ -17,6 +17,10 @@ export const registerCommand = new Command("register")
 	)
 	.argument("<fee>", "Fee amount per request in SEDA")
 	.option(
+		"--memo <string>",
+		"A custom note to attach to this Data Proxy registration",
+	)
+	.option(
 		"-pkf, --private-key-file <string>",
 		"Path where to create the private key json",
 	)
@@ -55,8 +59,11 @@ export const registerCommand = new Command("register")
 			process.exit(1);
 		}
 
+		const memo = Maybe.of(options.memo).unwrapOr("");
+
 		const hasher = new Keccak256(Buffer.from(aSedaAmount.value));
 		hasher.update(Buffer.from(payoutAddress));
+		hasher.update(Buffer.from(memo));
 		const hash = Buffer.from(hasher.digest());
 
 		const signatureRaw = ecdsaSign(hash, privateKey.value);


### PR DESCRIPTION
## Motivation

This can aid data proxy operators with their bookkeeping, allow custom functionality to be built by others, or just some fun for whoever wants to register something silly.

## Explanation of Changes

Made sure the payload hash is constructed the same way as it is in the Cosmos module.

## Testing

Updated the test vectors on the chain side with newly generated registration information, both with and without a memo.

## Related PRs and Issues

Part-of: #2 