### PR TITLE
feat(header): add support for x-seda-json-path

### DIFF
--- a/workspace/data-proxy-sdk/src/data-proxy.ts
+++ b/workspace/data-proxy-sdk/src/data-proxy.ts
@@ -140,9 +140,8 @@ export class DataProxy {
 	 *
 	 * @param data
 	 */
-	signData(data: unknown): SignedData {
-		const valueToSign = JSON.stringify(data);
-		const signResult = this.sign(Buffer.from(valueToSign));
+	signData(data: string): SignedData {
+		const signResult = this.sign(Buffer.from(data));
 
 		return {
 			publicKey: this.publicKey.toString("hex"),

--- a/workspace/data-proxy/src/cli/run.ts
+++ b/workspace/data-proxy/src/cli/run.ts
@@ -10,10 +10,10 @@ import {
 	PRIVATE_KEY_ENV_KEY,
 	SERVER_PORT,
 } from "../constants";
+import logger from "../logger";
 import { startProxyServer } from "../proxy-server";
 import { tryAsync, trySync } from "../utils/try";
 import { loadPrivateKey } from "./utils/private-key";
-import logger from "../logger";
 
 export const runCommand = new Command("run")
 	.description("Run the Data Proxy node")

--- a/workspace/data-proxy/src/constants.ts
+++ b/workspace/data-proxy/src/constants.ts
@@ -11,6 +11,7 @@ export const DEFAULT_ENVIRONMENT: Environment =
 export const PROOF_HEADER_KEY = "x-seda-proof";
 export const SIGNATURE_HEADER_KEY = "x-seda-signature";
 export const PUBLIC_KEY_HEADER_KEY = "x-seda-publickey";
+export const JSON_PATH_HEADER_KEY = "x-seda-json-path";
 
 export const PRIVATE_KEY_ENV_KEY = "SEDA_DATA_PROXY_PRIVATE_KEY";
 export const PRIVATE_KEY = process.env[PRIVATE_KEY_ENV_KEY];

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -4,6 +4,7 @@ import { Maybe } from "true-myth";
 import { type Config, getHttpMethods } from "./config-parser";
 import {
 	DEFAULT_PROXY_ROUTE_GROUP,
+	JSON_PATH_HEADER_KEY,
 	PROOF_HEADER_KEY,
 	SERVER_PORT,
 } from "./constants";
@@ -48,6 +49,7 @@ export function startProxyServer(
 					routeMethod,
 					route.path,
 					async ({ headers, params, body, query }) => {
+						// Verification with the SEDA chain that the overlay node is eligible
 						if (!serverOptions.disableProof) {
 							const proofHeader = Maybe.of(headers[PROOF_HEADER_KEY]);
 
@@ -70,13 +72,13 @@ export function startProxyServer(
 
 						// Add the request search params (?one=two) to the upstream url
 						const requestSearchParams = createUrlSearchParams(query);
-						let proxyUrl = replaceParams(route.upstreamUrl, params);
-						proxyUrl = injectSearchParamsInUrl(
-							proxyUrl,
+						let upstreamUrl = replaceParams(route.upstreamUrl, params);
+						upstreamUrl = injectSearchParamsInUrl(
+							upstreamUrl,
 							requestSearchParams,
 						).toString();
 
-						const proxyHeaders = new Headers();
+						const upstreamHeaders = new Headers();
 
 						// Redirect all headers given by the requester
 						for (const [key, value] of Object.entries(headers)) {
@@ -84,54 +86,75 @@ export function startProxyServer(
 								continue;
 							}
 
-							proxyHeaders.append(key, value);
+							upstreamHeaders.append(key, value);
 						}
 
 						// Inject all configured headers by the data proxy node configuration
 						for (const [key, value] of Object.entries(route.headers)) {
-							proxyHeaders.append(key, replaceParams(value, params));
+							upstreamHeaders.append(key, replaceParams(value, params));
 						}
 
-						// Required to make it work...
-						proxyHeaders.delete("host");
+						// Host doesn't match since we are proxying. Returning the upstream host while the URL does not match results
+						// in the client to not return the response.
+						upstreamHeaders.delete("host");
 
 						logger.debug(
-							`${routeMethod} ${proxyGroup}${route.path} -> ${proxyUrl}`,
+							`${routeMethod} ${proxyGroup}${route.path} -> ${upstreamUrl}`,
 						);
 
-						const proxyResponse = await tryAsync(async () =>
-							fetch(proxyUrl, {
+						const upstreamResponse = await tryAsync(async () =>
+							fetch(upstreamUrl, {
 								method: routeMethod,
-								headers: proxyHeaders,
+								headers: upstreamHeaders,
 								body: body as BodyInit,
 							}),
 						);
 
-						if (proxyResponse.isErr) {
+						if (upstreamResponse.isErr) {
 							return createErrorResponse(
-								`Proxying URL ${route.path} failed: ${proxyResponse.error}`,
+								`Proxying URL ${route.path} failed: ${upstreamResponse.error}`,
 								500,
 							);
 						}
 
-						const textResponse = await tryAsync(
-							async () => await proxyResponse.value.text(),
+						const upstreamTextResponse = await tryAsync(
+							async () => await upstreamResponse.value.text(),
 						);
 
-						if (textResponse.isErr) {
+						if (upstreamTextResponse.isErr) {
 							return createErrorResponse(
-								`Parsing ${route.path} response to JSON failed: ${textResponse.error}`,
+								`Parsing ${route.path} response to JSON failed: ${upstreamTextResponse.error}`,
 								500,
 							);
 						}
 
-						let responseData: string = textResponse.value;
+						let responseData: string = upstreamTextResponse.value;
 
 						if (route.jsonPath) {
-							const data = queryJson(textResponse.value, route.jsonPath);
+							const data = queryJson(
+								upstreamTextResponse.value,
+								route.jsonPath,
+							);
 
 							if (data.isErr) {
 								return createErrorResponse(data.error, 500);
+							}
+
+							responseData = JSON.stringify(data.value);
+						}
+
+						const jsonPathRequestHeader = Maybe.of(
+							headers[JSON_PATH_HEADER_KEY],
+						);
+
+						// TODO: Would be nice to only parse the JSON once
+						if (jsonPathRequestHeader.isJust) {
+							// We apply the JSON path to the data that's exposed by the data proxy.
+							// This allows operators to specify what data is accessible while the data request program can specify what it wants from the accessible data.
+							const data = queryJson(responseData, jsonPathRequestHeader.value);
+
+							if (data.isErr) {
+								return createErrorResponse(data.error, 400);
 							}
 
 							responseData = JSON.stringify(data.value);
@@ -143,7 +166,7 @@ export function startProxyServer(
 						// Forward all headers that are configured in the config.json
 						for (const forwardHeaderKey of route.forwardRepsonseHeaders) {
 							const forwardHeaderValue =
-								proxyResponse.value.headers.get(forwardHeaderKey);
+								upstreamResponse.value.headers.get(forwardHeaderKey);
 
 							if (forwardHeaderValue) {
 								responseHeaders.append(forwardHeaderKey, forwardHeaderValue);

--- a/workspace/data-proxy/src/utils/query-json.ts
+++ b/workspace/data-proxy/src/utils/query-json.ts
@@ -15,11 +15,15 @@ export function queryJson(
 		return Result.err(`Parsing as JSON failed: ${jsonData.error}`);
 	}
 
-	const data = JSONPath.query(jsonData.value, path);
+	const data = trySync(() => JSONPath.query(jsonData.value, path));
 
-	if (!data.length) {
+	if (data.isErr) {
+		return Result.err(`Could not query JSON: ${data.error}`);
+	}
+
+	if (!data.value.length) {
 		return Result.err(`Quering JSON with ${path} returned null`);
 	}
 
-	return Result.ok(data[0]);
+	return Result.ok(data.value[0]);
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This way a overlay node can use jsonPath to send less information across the wire and do less processing.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

* add x-seda-json-path which comes after the `jsonPath` processing of the config.json