### PR TITLE
chore: better error handling on optional properties

### DIFF
--- a/workspace/data-proxy/src/cli/utils/key-pair.ts
+++ b/workspace/data-proxy/src/cli/utils/key-pair.ts
@@ -1,7 +1,7 @@
 import * as v from "valibot";
 
 export const FileKeyPairSchema = v.object({
-	pubkey: v.string(),
+	pubkey: v.optional(v.string()),
 	privkey: v.string(),
 });
 

--- a/workspace/data-proxy/src/cli/utils/private-key.ts
+++ b/workspace/data-proxy/src/cli/utils/private-key.ts
@@ -48,8 +48,14 @@ export async function loadPrivateKey(
 	);
 
 	if (parsedPrivateKeyFile.isErr) {
+		let resultError = '';
+
+		for (const error of parsedPrivateKeyFile.error) {
+			resultError += `${error.message} on config property "${error.path?.[0].key}" \n`;
+		}
+
 		return Result.err(
-			`Failed to parse private key file: ${JSON.stringify(parsedPrivateKeyFile.error)}`,
+			`Failed to parse private key file: \n ${resultError}`,
 		);
 	}
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

pubkey is an optional property used to easily identify a public key, however it errored when it wasnt available

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

* Made pubkey optional
* Pretty print the valibot error message
