### PR TITLE
Simple handshake endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ The two required attributes are `path` and `upstreamUrl`. These specify how the 
 }
 ```
 
+> [!IMPORTANT]
+> The `OPTIONS` method is reserved and cannot be used for a route.
+
 #### Base URL per route
 
 In addition to specifying the `baseURL` at the root level you can also specify it per `route`. The `baseURL` at the `route` level will take precedence over one at the root level.
@@ -133,8 +136,8 @@ In addition to specifying the `baseURL` at the root level you can also specify i
       "baseURL": "https://btc.data-proxy.com",
       "path": "/btc-usd",
       "upstreamUrl": "https://myapi.com/btc-usd"
-    },
-  ],
+    }
+  ]
 }
 ```
 

--- a/workspace/data-proxy-sdk/src/data-proxy.ts
+++ b/workspace/data-proxy-sdk/src/data-proxy.ts
@@ -33,7 +33,7 @@ export interface SignedData {
 }
 
 export class DataProxy {
-	private version = "0.1.0";
+	public version = "0.1.0";
 	public publicKey: Buffer;
 	private privateKey: Buffer;
 	public options: DataProxyOptions;

--- a/workspace/data-proxy/src/constants.ts
+++ b/workspace/data-proxy/src/constants.ts
@@ -27,6 +27,5 @@ export const DEFAULT_HTTP_METHODS: HTTPMethod[] = [
 	"POST",
 	"PUT",
 	"DELETE",
-	"OPTIONS",
 	"HEAD",
 ];

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -80,9 +80,17 @@ export function startProxyServer(
 		});
 
 		for (const route of config.routes) {
-			const routeMethods = getHttpMethods(route.method);
+			app.route("OPTIONS", route.path, () => {
+				const headers = new Headers({
+					[constants.PUBLIC_KEY_HEADER_KEY]:
+						dataProxy.publicKey.toString("hex"),
+					[constants.SIGNATURE_VERSION_HEADER_KEY]: dataProxy.version,
+				});
+				return new Response(null, { headers });
+			});
 
 			// A route can have multiple methods attach to it
+			const routeMethods = getHttpMethods(route.method);
 			for (const routeMethod of routeMethods) {
 				app.route(
 					routeMethod,

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -189,7 +189,7 @@ export function startProxyServer(
 						let responseData: string = upstreamTextResponse.value;
 
 						if (route.jsonPath) {
-							logger.debug(`Applying route JSONpath ${route.jsonPath}`);
+							requestLogger.debug(`Applying route JSONpath ${route.jsonPath}`);
 							const data = queryJson(
 								upstreamTextResponse.value,
 								route.jsonPath,
@@ -204,7 +204,7 @@ export function startProxyServer(
 							}
 
 							responseData = JSON.stringify(data.value);
-							logger.debug("Successfully applied route JSONpath");
+							requestLogger.debug("Successfully applied route JSONpath");
 						}
 
 						const jsonPathRequestHeader = Maybe.of(
@@ -213,7 +213,7 @@ export function startProxyServer(
 
 						// TODO: Would be nice to only parse the JSON once
 						if (jsonPathRequestHeader.isJust) {
-							logger.debug(
+							requestLogger.debug(
 								`Applying request JSONpath ${jsonPathRequestHeader.value}`,
 							);
 							// We apply the JSON path to the data that's exposed by the data proxy.
@@ -229,7 +229,7 @@ export function startProxyServer(
 							}
 
 							responseData = JSON.stringify(data.value);
-							logger.debug("Successfully applied request JSONpath");
+							requestLogger.debug("Successfully applied request JSONpath");
 						}
 
 						// If the route or proxy has a public endpoint we replace the protocol and host with the public endpoint.
@@ -240,7 +240,7 @@ export function startProxyServer(
 								return `${t}${request.url.slice(pathIndex)}`;
 							});
 
-						logger.debug("Signing data", {
+						requestLogger.debug("Signing data", {
 							calledEndpoint,
 							method: request.method,
 							body: requestBody.unwrapOr(undefined),


### PR DESCRIPTION
## Motivation

Allow the overlay to query the public key for a data proxy.

Still have to update the README, and we should update the docs when we merge this.

## Explanation of Changes

The OPTIONS http method is no longer allowed, as we need this to be able
    to reliably retrieve the data proxy info from the overlay network.

## Testing

Update unit and integration tests.

## Related PRs and Issues

Closes: #34 
