### PR TITLE
chore: Pin bun version to 1.1.34

### DIFF
--- a/.build/docker/Dockerfile
+++ b/.build/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:alpine
+FROM oven/bun:1.1.34-alpine
 
 ARG TARGET_ARCH
 


### PR DESCRIPTION
Pin `bun` version to 1.1.34

## Motivation

Due to linking issues in the latest bun version we've decided to pin it down to 1.1.34, as it was the last version which worked properly for the type of build we are using at the moment.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tested with our COS instances.
