### PR TITLE
Add chain-id to signed registration payload

### DIFF
--- a/workspace/data-proxy-sdk/src/config.ts
+++ b/workspace/data-proxy-sdk/src/config.ts
@@ -6,6 +6,7 @@ export enum Environment {
 }
 
 export interface DataProxyOptions {
+	chainId: string;
 	rpcUrl: string;
 
 	// URL to the explorer page
@@ -18,21 +19,25 @@ export interface DataProxyOptions {
 
 export const defaultConfig: Record<Environment, DataProxyOptions> = {
 	mainnet: {
+		chainId: "seda-1",
 		rpcUrl: "https://rpc.seda.xyz",
 		explorerUrl: "https://explorer.seda.xyz",
 		privateKey: Buffer.from([]),
 	},
 	testnet: {
+		chainId: "seda-1-testnet",
 		rpcUrl: "https://rpc.testnet.seda.xyz",
 		explorerUrl: "https://testnet.explorer.seda.xyz",
 		privateKey: Buffer.from([]),
 	},
 	devnet: {
+		chainId: "seda-1-devnet",
 		rpcUrl: "https://rpc.devnet.seda.xyz",
 		explorerUrl: "https://devnet.explorer.seda.xyz",
 		privateKey: Buffer.from([]),
 	},
 	planet: {
+		chainId: "seda-1-planet",
 		rpcUrl: "https://rpc.planet.seda.xyz",
 		explorerUrl: "https://planet.explorer.seda.xyz",
 		privateKey: Buffer.from([]),


### PR DESCRIPTION
## Motivation

This prevents replay attacks between different networks.

## Explanation of Changes

Also included client side address validation to help users spot errors sooner.

## Testing

Generated new test vectors for https://github.com/sedaprotocol/seda-chain/pull/457 with the mainnet configuration.

## Related PRs and Issues

Closes: #37
