### PR TITLE
Require signing the intended admin address

### DIFF
--- a/workspace/data-proxy/src/cli/register.ts
+++ b/workspace/data-proxy/src/cli/register.ts
@@ -1,5 +1,4 @@
 import { Command } from "@commander-js/extra-typings";
-import { Keccak256 } from "@cosmjs/crypto";
 import { fromBech32 } from "@cosmjs/encoding";
 import { Environment } from "@seda-protocol/data-proxy-sdk";
 import { defaultConfig } from "@seda-protocol/data-proxy-sdk/src/config";
@@ -8,6 +7,7 @@ import { ecdsaSign, publicKeyCreate } from "secp256k1";
 import { Maybe } from "true-myth";
 import { DEFAULT_ENVIRONMENT, PRIVATE_KEY_ENV_KEY } from "../constants";
 import { sedaToAseda } from "./utils/big";
+import { createHash } from "./utils/create-hash";
 import { loadPrivateKey } from "./utils/private-key";
 
 export const registerCommand = new Command("register")
@@ -82,13 +82,14 @@ export const registerCommand = new Command("register")
 		}
 
 		const memo = Maybe.of(options.memo).unwrapOr("");
-		const hasher = new Keccak256(Buffer.from(aSedaAmount.value));
 
-		hasher.update(Buffer.from(adminAddress));
-		hasher.update(Buffer.from(payoutAddress));
-		hasher.update(Buffer.from(memo));
-		hasher.update(Buffer.from(network.value.chainId));
-		const hash = Buffer.from(hasher.digest());
+		const hash = createHash(
+			fee,
+			adminAddress,
+			payoutAddress,
+			memo,
+			network.value.chainId,
+		);
 
 		const signatureRaw = ecdsaSign(hash, privateKey.value);
 		const signature = Buffer.from(signatureRaw.signature);

--- a/workspace/data-proxy/src/cli/utils/create-hash.ts
+++ b/workspace/data-proxy/src/cli/utils/create-hash.ts
@@ -1,0 +1,18 @@
+import { Keccak256 } from "@cosmjs/crypto";
+
+export function createHash(
+	fee: string,
+	adminAddress: string,
+	payoutAddress: string,
+	memo: string,
+	chainId: string,
+) {
+	const hasher = new Keccak256(Buffer.from(fee));
+	hasher.update(Buffer.from(adminAddress));
+	hasher.update(Buffer.from(payoutAddress));
+	hasher.update(Buffer.from(memo));
+	hasher.update(Buffer.from(chainId));
+	const hash = Buffer.from(hasher.digest());
+
+	return hash;
+}

--- a/workspace/data-proxy/src/scripts/generate-test-vectors.ts
+++ b/workspace/data-proxy/src/scripts/generate-test-vectors.ts
@@ -1,0 +1,59 @@
+import { Secp256k1 } from "@cosmjs/crypto";
+import { ecdsaSign } from "secp256k1";
+import { createHash } from "../cli/utils/create-hash";
+
+// Test vectors are generated for a specific chain id.
+const CHAIN_ID = "seda-1-testvectors";
+
+const privateKeyBuff = Buffer.from(new Array(32).fill(1));
+const keyPair = await Secp256k1.makeKeypair(privateKeyBuff);
+
+const testCases = [
+	{
+		name: "Happy path",
+		fee: "10000000000000000000aseda",
+		adminAddress: "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+		payoutAddress: "seda1wyzxdtpl0c99c92n397r3drlhj09qfjvf6teyh",
+		memo: "",
+	},
+	{
+		name: "Happy path with memo",
+		fee: "9000000000000000000aseda",
+		adminAddress: "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+		payoutAddress: "seda1wyzxdtpl0c99c92n397r3drlhj09qfjvf6teyh",
+		memo: "This is a sweet proxy",
+	},
+	{
+		name: "Registering an already existing data proxy should fail",
+		fee: "10000000000000000000aseda",
+		adminAddress: "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+		payoutAddress: "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+		memo: "",
+	},
+];
+
+for (const testCase of testCases) {
+	const hash = createHash(
+		testCase.fee,
+		testCase.adminAddress,
+		testCase.payoutAddress,
+		testCase.memo,
+		CHAIN_ID,
+	);
+	const signatureRaw = ecdsaSign(hash, keyPair.privkey);
+	const signature = Buffer.from(signatureRaw.signature);
+	const publicKey = Buffer.from(keyPair.pubkey);
+
+	console.log(`name: "${testCase.name}",`);
+	console.log("msg: &types.MsgRegisterDataProxy{");
+	console.log(`    AdminAddress: "${testCase.adminAddress}",`);
+	console.log(`    PayoutAddress: "${testCase.payoutAddress}",`);
+	console.log(
+		`    Fee: s.NewFeeFromString("${testCase.fee.replace("aseda", "")}"),`,
+	);
+	console.log(`    Memo: "${testCase.memo}",`);
+	console.log(`    PubKey: "${publicKey.toString("hex")}",`);
+	console.log(`    Signature: "${signature.toString("hex")}",`);
+	console.log("},");
+	console.log("");
+}


### PR DESCRIPTION
## Motivation

Prevent front-running the data proxy registration.

## Explanation of Changes

Require the admin address to be provided when registering and have the payout address default to the admin. It can be specified separately.

## Testing

Ran the register command locally:
```sh
❯ bun run start register seda1wyzxdtpl0c99c92n397r3drlhj09qfjvf6teyh 9 -n planet --memo "This is a sweet proxy" --payout-address seda1lyfkj6xwecq3462qa683s78weexhp7d72ku3qf

$ bun run ./workspace/data-proxy register "seda1wyzxdtpl0c99c92n397r3drlhj09qfjvf6teyh" "9" -n planet --memo "This is a sweet proxy" --payout-address "seda1lyfkj6xwecq3462qa683s78weexhp7d72ku3qf"

Fee amount: 		9 SEDA (9000000000000000000aseda)
Admin address: 		seda1wyzxdtpl0c99c92n397r3drlhj09qfjvf6teyh
Payout address: 	seda1lyfkj6xwecq3462qa683s78weexhp7d72ku3qf
Signed hash: 		ffc2adecf6a7f923f38ce0e82dcaa17e1a795910495ad4f80e9a58511037789f
Public key: 		0235697aaf54b1e2b8dc99667742c58a293d90da91758e24bfecd197443df65881
Signature: 		7e1dbe7fd792b47a8c51f250882d9107c74dfda1705ff79492907bf21de071dc30c5310969424f3ef6bf8fbbb8aefde5793830c6064e054a1373fefd2d8127d3
Signature recovery id: 	1

Submit your transaction on:
https://planet.explorer.seda.xyz/data-proxy/register?fee=9000000000000000000aseda&adminAddress=seda1wyzxdtpl0c99c92n397r3drlhj09qfjvf6teyh&payoutAddress=seda1lyfkj6xwecq3462qa683s78weexhp7d72ku3qf&publicKey=0235697aaf54b1e2b8dc99667742c58a293d90da91758e24bfecd197443df65881&signature=7e1dbe7fd792b47a8c51f250882d9107c74dfda1705ff79492907bf21de071dc30c5310969424f3ef6bf8fbbb8aefde5793830c6064e054a1373fefd2d8127d3&recoveryId=1&memo=This+is+a+sweet+proxy
```

Will generate test vectors with this code to implement the chain side, only when that passes we can consider this PR ready to merge.

## Related PRs and Issues

Chain PR: https://github.com/sedaprotocol/seda-chain/pull/529
