### PR TITLE
feat(config): add option to only allow specified query params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ dist
 # Finder (MacOS) folder config
 .DS_Store
 config.json
+config.*.json
 data-proxy-private-key.json
 
 ubuntu-dind*

--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "1.0.0-rc.1",
+	"version": "1.0.0-rc.6",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"msw": "^2.3.5"

--- a/workspace/data-proxy/src/config-parser.ts
+++ b/workspace/data-proxy/src/config-parser.ts
@@ -19,6 +19,7 @@ const RouteSchema = v.object({
 	upstreamUrl: v.string(),
 	method: v.optional(HttpMethodSchema, DEFAULT_HTTP_METHODS),
 	jsonPath: v.optional(v.pipe(v.string(), v.startsWith("$"))),
+	allowedQueryParams: v.optional(v.array(v.string())),
 	forwardResponseHeaders: v.pipe(
 		v.optional(v.array(v.string()), []),
 		v.transform((methods) => {

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -132,7 +132,10 @@ export function startProxyServer(
 						}
 
 						// Add the request search params (?one=two) to the upstream url
-						const requestSearchParams = createUrlSearchParams(query);
+						const requestSearchParams = createUrlSearchParams(
+							query,
+							route.allowedQueryParams,
+						);
 						let upstreamUrl = replaceParams(route.upstreamUrl, params);
 						const upstreamUrlResult = injectSearchParamsInUrl(
 							upstreamUrl,

--- a/workspace/data-proxy/src/utils/search-params.test.ts
+++ b/workspace/data-proxy/src/utils/search-params.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mergeUrlSearchParams } from "./search-params";
+import { createUrlSearchParams, mergeUrlSearchParams } from "./search-params";
 
 describe("mergeUrlSearchParams", () => {
 	it("should be able to merge two URLSearchParams together", () => {
@@ -39,6 +39,36 @@ describe("mergeUrlSearchParams", () => {
 		});
 
 		expected.append("2", "test");
+
+		expect(result.toString()).toBe(expected.toString());
+	});
+
+	it("should keep only the allowed query params", () => {
+		const result = createUrlSearchParams(
+			{
+				"1": "one",
+				"2": "two",
+			},
+			["1"],
+		);
+
+		const expected = new URLSearchParams({
+			"1": "one",
+		});
+
+		expect(result.toString()).toBe(expected.toString());
+	});
+
+	it("should allow all query params if no allowed query params are provided", () => {
+		const result = createUrlSearchParams({
+			"1": "one",
+			"2": "two",
+		});
+
+		const expected = new URLSearchParams({
+			"1": "one",
+			"2": "two",
+		});
 
 		expect(result.toString()).toBe(expected.toString());
 	});

--- a/workspace/data-proxy/src/utils/search-params.ts
+++ b/workspace/data-proxy/src/utils/search-params.ts
@@ -1,9 +1,14 @@
 export function createUrlSearchParams(
 	queryParams: Record<string, string | undefined>,
+	allowedQueryParams?: string[],
 ): URLSearchParams {
 	const result = new URLSearchParams();
 
 	for (const [key, value] of Object.entries(queryParams)) {
+		if (allowedQueryParams && !allowedQueryParams.includes(key)) {
+			continue;
+		}
+
 		result.append(key, value ?? "");
 	}
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Some APIs dont want all of the query params forwarded. With this you can configure an allow list that blocks all unwanted query params

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

* add config option to only allow certain query params

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Wrote a couple of tests to check if it behaved correctly

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

closes #48 
