### PR TITLE
Distinguish between executor ineligibility and failure to check eligibility

### DIFF
--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -121,9 +121,13 @@ export function startProxyServer(
 							}
 
 							const isValid = await dataProxy.verify(proofHeader.value);
-
-							if (isValid.isErr || !isValid.value) {
-								const message = `Invalid proof ${isValid.isErr ? isValid.error : ""}`;
+							if (isValid.isErr) {
+								const message = `Failed to verify eligibility proof ${isValid.error}`;
+								requestLogger.error(message);
+								return createErrorResponse(message, 401);
+							}
+							if (!isValid.value) {
+								const message = "Ineligible executor";
 								requestLogger.error(message);
 								return createErrorResponse(message, 401);
 							}


### PR DESCRIPTION
Improves clarity of error message by distinguishing between a failure while performing eligibility check and a successful eligibility check with a negative result.