### PR TITLE
Conditionally retry proof verification 

### DIFF
--- a/workspace/data-proxy-sdk/src/constants.ts
+++ b/workspace/data-proxy-sdk/src/constants.ts
@@ -1,4 +1,5 @@
 export const PROOF_HEADER_KEY = "x-seda-proof";
+export const HEIGHT_HEADER_KEY = "x-seda-blockheight";
 export const SIGNATURE_HEADER_KEY = "x-seda-signature";
 export const PUBLIC_KEY_HEADER_KEY = "x-seda-publickey";
 export const SIGNATURE_VERSION_HEADER_KEY = "x-seda-version";

--- a/workspace/data-proxy/src/utils/verify-with-retry.test.ts
+++ b/workspace/data-proxy/src/utils/verify-with-retry.test.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { DataProxy } from "@seda-protocol/data-proxy-sdk";
+import { Maybe, Result } from "true-myth";
+import type { Logger } from "winston";
+import { verifyWithRetry } from "./verify-with-retry";
+
+type VerificationResult = {
+	isValid: boolean;
+	currentHeight: number;
+	status: string;
+};
+
+describe("verifyWithRetry", () => {
+	const loggerStub: Logger = {
+		silly: () => {},
+		warn: () => {},
+	} as unknown as Logger;
+
+	const mockProof = "test-proof";
+
+	let mockDataProxy: DataProxy;
+	beforeEach(() => {
+		mockDataProxy = {
+			verify: mock(() => {}),
+		} as unknown as DataProxy;
+	});
+
+	const testDefaultMaxAttempts = 2;
+	const testDefaultRetryDelay = () => 1;
+
+	it("should return successful verification on first attempt", async () => {
+		const mockVerification = {
+			isValid: true,
+			currentHeight: 100,
+			status: "valid",
+		};
+
+		mockDataProxy.verify = mock(() =>
+			Promise.resolve(Result.ok(mockVerification)),
+		);
+
+		const result = await verifyWithRetry(
+			loggerStub,
+			mockDataProxy,
+			mockProof,
+			Maybe.nothing(),
+			testDefaultMaxAttempts,
+			testDefaultRetryDelay,
+		);
+
+		expect(result.isOk).toBe(true);
+		const verification = result.unwrapOr(null);
+		expect(verification).not.toBeNull();
+		expect(verification).toEqual(mockVerification);
+		expect(mockDataProxy.verify).toHaveBeenCalledTimes(1);
+	});
+
+	it("should retry when the verification request fails", async () => {
+		const mockVerification = {
+			isValid: true,
+			currentHeight: 100,
+			status: "valid",
+		};
+
+		let callCount = 0;
+		mockDataProxy.verify = mock(() => {
+			callCount++;
+			if (callCount === 1) {
+				return Promise.resolve(Result.err("Network error"));
+			}
+			return Promise.resolve(Result.ok(mockVerification));
+		});
+
+		const result = await verifyWithRetry(
+			loggerStub,
+			mockDataProxy,
+			mockProof,
+			Maybe.nothing(),
+			testDefaultMaxAttempts,
+			testDefaultRetryDelay,
+		);
+
+		expect(result.isOk).toBe(true);
+		const verification = result.unwrapOr(null);
+		expect(verification).not.toBeNull();
+		expect(verification as VerificationResult).toEqual(mockVerification);
+		expect(mockDataProxy.verify).toHaveBeenCalledTimes(2);
+	});
+
+	it.each(["not_eligible", "data_request_not_found", "not_staker"])(
+		"should retry for status %s when height is behind but within MAX_HEIGHT_DIFFERENCE",
+		async (status) => {
+			const eligibleHeight = Maybe.just(102);
+
+			mockDataProxy.verify = mock(() => {
+				return Promise.resolve(
+					Result.ok({
+						isValid: false,
+						currentHeight: 100,
+						status,
+					}),
+				);
+			});
+
+			const result = await verifyWithRetry(
+				loggerStub,
+				mockDataProxy,
+				mockProof,
+				eligibleHeight,
+				testDefaultMaxAttempts,
+				testDefaultRetryDelay,
+			);
+
+			expect(result.isOk).toBe(true);
+			const verification = result.unwrapOr(null);
+			expect(verification).not.toBeNull();
+			expect((verification as VerificationResult).status).toBe(status);
+			expect(mockDataProxy.verify).toHaveBeenCalledTimes(2);
+		},
+	);
+
+	it("should not retry when proof is invalid", async () => {
+		const mockVerification = {
+			isValid: false,
+			currentHeight: 100,
+			status: "invalid_signature",
+		};
+		mockDataProxy.verify = mock(() =>
+			Promise.resolve(Result.ok(mockVerification)),
+		);
+
+		const result = await verifyWithRetry(
+			loggerStub,
+			mockDataProxy,
+			mockProof,
+			Maybe.just(102),
+			testDefaultMaxAttempts,
+			testDefaultRetryDelay,
+		);
+
+		expect(result.isOk).toBe(true);
+		const verification = result.unwrapOr(null);
+		expect(verification).not.toBeNull();
+		expect(verification as VerificationResult).toEqual(mockVerification);
+		expect(mockDataProxy.verify).toHaveBeenCalledTimes(1);
+	});
+
+	it("should not retry when eligible height is not provided", async () => {
+		const mockVerification = {
+			isValid: false,
+			currentHeight: 100,
+			status: "height_mismatch",
+		};
+		mockDataProxy.verify = mock(() =>
+			Promise.resolve(Result.ok(mockVerification)),
+		);
+
+		const result = await verifyWithRetry(
+			loggerStub,
+			mockDataProxy,
+			mockProof,
+			Maybe.nothing(),
+			testDefaultMaxAttempts,
+			testDefaultRetryDelay,
+		);
+
+		expect(result.isOk).toBe(true);
+		const verification = result.unwrapOr(null);
+		expect(verification).not.toBeNull();
+		expect(verification as VerificationResult).toEqual(mockVerification);
+		expect(mockDataProxy.verify).toHaveBeenCalledTimes(1);
+	});
+
+	it("should not retry when height difference is too large", async () => {
+		const eligibleHeight = Maybe.just(105);
+		const mockVerification = {
+			isValid: false,
+			currentHeight: 100,
+			status: "height_mismatch",
+		};
+		mockDataProxy.verify = mock(() =>
+			Promise.resolve(Result.ok(mockVerification)),
+		);
+
+		const result = await verifyWithRetry(
+			loggerStub,
+			mockDataProxy,
+			mockProof,
+			eligibleHeight,
+			testDefaultMaxAttempts,
+			testDefaultRetryDelay,
+		);
+
+		expect(result.isOk).toBe(true);
+		const verification = result.unwrapOr(null);
+		expect(verification).not.toBeNull();
+		expect(verification as VerificationResult).toEqual(mockVerification);
+		expect(mockDataProxy.verify).toHaveBeenCalledTimes(1);
+	});
+
+	it("should respect maxAttempts parameter", async () => {
+		const mockVerification = {
+			isValid: false,
+			currentHeight: 100,
+			status: "height_mismatch",
+		};
+		mockDataProxy.verify = mock(() =>
+			Promise.resolve(Result.ok(mockVerification)),
+		);
+
+		const result = await verifyWithRetry(
+			loggerStub,
+			mockDataProxy,
+			mockProof,
+			Maybe.just(101),
+			3,
+			testDefaultRetryDelay,
+		);
+
+		expect(result.isOk).toBe(true);
+		const verification = result.unwrapOr(null);
+		expect(verification).not.toBeNull();
+		expect(verification as VerificationResult).toEqual(mockVerification);
+		expect(mockDataProxy.verify).toHaveBeenCalledTimes(3);
+	});
+
+	it("should use custom retry delay function", async () => {
+		const mockVerification = {
+			isValid: false,
+			currentHeight: 100,
+			status: "not_eligible",
+		};
+		mockDataProxy.verify = mock(() => {
+			return Promise.resolve(Result.ok(mockVerification));
+		});
+
+		const customDelay = mock(() => 2);
+
+		await verifyWithRetry(
+			loggerStub,
+			mockDataProxy,
+			mockProof,
+			Maybe.just(101),
+			4,
+			customDelay,
+		);
+
+		expect(customDelay).toHaveBeenCalledTimes(3);
+		expect(customDelay).toHaveBeenNthCalledWith(1, 2);
+		expect(customDelay).toHaveBeenNthCalledWith(2, 3);
+		expect(customDelay).toHaveBeenNthCalledWith(3, 4);
+	});
+});

--- a/workspace/data-proxy/src/utils/verify-with-retry.ts
+++ b/workspace/data-proxy/src/utils/verify-with-retry.ts
@@ -1,0 +1,103 @@
+import type { DataProxy } from "@seda-protocol/data-proxy-sdk";
+import type { Maybe } from "true-myth";
+import type { Logger } from "winston";
+
+type RetryDelay = (attempt: number) => number;
+
+const MAX_HEIGHT_DIFFERENCE = 2;
+
+/**
+ * Verifies a proof with retry. Will attempt the verification up to maxAttempts times, and
+ * will always try at least once.
+ *
+ * Will not retry if the proof is invalid.
+ * Will not retry if the eligible height is not provided.
+ * Will not retry if the difference between the eligible height and the current height is greater than 2.
+ *
+ * @param logger - The logger to use.
+ * @param dataProxy - The data proxy to use.
+ * @param proof - The proof to verify.
+ * @param eligibleHeight - The eligible height to verify against if provided.
+ * @param maxAttempts - The maximum number of attempts to make. Default is 2.
+ * @param retryDelay - Function to calculate the delay between attempts. Default is a flat 1 second.
+ * @returns The verification result.
+ */
+export async function verifyWithRetry(
+	logger: Logger,
+	dataProxy: DataProxy,
+	proof: string,
+	eligibleHeight: Maybe<number>,
+	maxAttempts = 2,
+	retryDelay: RetryDelay = () => 1000,
+) {
+	// Start at 0 so at the start of the loop we have attempt = 1
+	let attempt = 0;
+	let verificationResult: Awaited<ReturnType<typeof dataProxy.verify>>;
+
+	do {
+		attempt++;
+		// Only sleep on retries
+		if (attempt > 1) {
+			await sleep(retryDelay(attempt));
+		}
+
+		logger.silly(
+			`Verifying proof with retry (attempt ${attempt}/${maxAttempts})`,
+		);
+
+		verificationResult = await dataProxy.verify(proof);
+		// Something went wrong querying the eligibility, we should retry
+		if (verificationResult.isErr) {
+			logger.silly(`Error while verifying proof: ${verificationResult.error}`);
+			continue;
+		}
+
+		const verification = verificationResult.value;
+
+		// Verification passed, no need to retry
+		if (verification.isValid) {
+			break;
+		}
+
+		// If the proof is invalid there is no point in retrying
+		if (verification.status === "invalid_signature") {
+			break;
+		}
+
+		if (eligibleHeight.isNothing) {
+			logger.silly("No eligibility height provided, skipping retry");
+			break;
+		}
+
+		if (verification.currentHeight >= eligibleHeight.value) {
+			logger.silly(
+				`Proof was eligible at height ${eligibleHeight.value} and current height is ${verification.currentHeight}, skipping retry`,
+			);
+			break;
+		}
+
+		logger.warn(
+			`Received proof for height ${eligibleHeight.value} but current height is ${verification.currentHeight}, the RPC might be out of sync`,
+		);
+
+		if (
+			eligibleHeight.value - verification.currentHeight >
+			MAX_HEIGHT_DIFFERENCE
+		) {
+			logger.warn(
+				`The difference between the eligible height and the current height is greater than ${MAX_HEIGHT_DIFFERENCE}, skipping retry`,
+			);
+			break;
+		}
+	} while (attempt < maxAttempts);
+
+	logger.silly(
+		`Using verification result after ${attempt}/${maxAttempts} attempts`,
+	);
+
+	return verificationResult;
+}
+
+async function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Motivation

We've observed some problems where it seems that the RPC which the
    overlay uses to query eligibility is ahead of the the RPC that the data
    proxy uses to query eligibility. We've added extra log statements to
    help debug this as well as retry logic when we have reason to believe
    the RPC is out of sync.

## Explanation of Changes

Only retry when we have reason to believe that the RPC is out of sync

## Testing

Will add unit tests for the retry behaviour

## Related PRs and Issues

N.A.
