### PR TITLE
Chore/add network config

### DIFF
--- a/workspace/data-proxy-sdk/src/config.ts
+++ b/workspace/data-proxy-sdk/src/config.ts
@@ -2,7 +2,6 @@ export enum Environment {
 	Mainnet = "mainnet",
 	Testnet = "testnet",
 	Devnet = "devnet",
-	Planet = "planet",
 }
 
 export interface DataProxyOptions {
@@ -34,12 +33,6 @@ export const defaultConfig: Record<Environment, DataProxyOptions> = {
 		chainId: "seda-1-devnet",
 		rpcUrl: "https://rpc.devnet.seda.xyz",
 		explorerUrl: "https://devnet.explorer.seda.xyz",
-		privateKey: Buffer.from([]),
-	},
-	planet: {
-		chainId: "seda-1-planet",
-		rpcUrl: "https://rpc.planet.seda.xyz",
-		explorerUrl: "https://planet.explorer.seda.xyz",
 		privateKey: Buffer.from([]),
 	},
 };

--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"msw": "2.3.1"

--- a/workspace/data-proxy/src/cli/run.ts
+++ b/workspace/data-proxy/src/cli/run.ts
@@ -74,10 +74,7 @@ function addCommonOptions(command: Command) {
 			"-pkf, --private-key-file <string>",
 			`Path where to find the private key json (Defaults to either env variable $${PRIVATE_KEY_ENV_KEY} or ${DEFAULT_PRIVATE_KEY_JSON_FILE_NAME})`,
 		)
-		.option(
-			"-n, --network <network>",
-			"The SEDA network to chose",
-		)
+		.option("-n, --network <network>", "The SEDA network to chose")
 		.option(
 			"--skip-registration-check",
 			"Runs the data proxy without checking registration, useful for testing and development",

--- a/workspace/data-proxy/src/cli/utils/key-pair.ts
+++ b/workspace/data-proxy/src/cli/utils/key-pair.ts
@@ -1,6 +1,11 @@
+import { Environment } from "@seda-protocol/data-proxy-sdk";
 import * as v from "valibot";
 
 export const FileKeyPairSchema = v.object({
+	network: v.optional(
+		v.picklist(Object.values(Environment)),
+		Environment.Testnet,
+	),
 	pubkey: v.optional(v.string()),
 	privkey: v.string(),
 });


### PR DESCRIPTION
## Motivation

When deploying a data proxy with a docker image to Mainnet, we realized that it could be easier to have a config parameter in the key file. That should also help avoiding reusing same keys for different environments.

## Explanation of Changes

- Add optional network field in the key file.
   - If not present, testnet will be used.
   - Same behaviour as previous version.
- Modify `init`, `register` and `run` commands so that they read the file
- Add util function to read network from file (there is potential refactor in here because usually the priv key is read from same file).

## Testing

Checked out all commands.

