### PR TITLE
fix: default to testnet when using private key env

### DIFF
--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"msw": "2.3.1"

--- a/workspace/data-proxy/src/cli/utils/private-key.ts
+++ b/workspace/data-proxy/src/cli/utils/private-key.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import type { Environment } from "@seda-protocol/data-proxy-sdk";
+import { Environment } from "@seda-protocol/data-proxy-sdk";
 import { tryAsync, tryParseSync, trySync } from "@seda-protocol/utils";
 import { Result } from "true-myth";
 import {
@@ -19,6 +19,11 @@ async function readPrivateKeyFile(
 export async function loadNetworkFromKeyFile(
 	privateKeyFilePath?: string,
 ): Promise<Result<Environment, string>> {
+	// If no private key file path is provided and PRIVATE_KEY is set, use default network Testnet
+	if (!privateKeyFilePath && PRIVATE_KEY) {
+		return Result.ok(Environment.Testnet);
+	}
+
 	const filePath = privateKeyFilePath ?? DEFAULT_PRIVATE_KEY_JSON_FILE_NAME;
 	const privateKeyFile = await readPrivateKeyFile(filePath);
 


### PR DESCRIPTION

## Motivation

If a data proxy operator is using `PRIVATE_KEY` env variable, then the data proxy would fail because it cannot retrieve the default network.

## Explanation of Changes

Keep old behaviour of allowing using `PRIVATE_KEY` env var, without specifying the network as a flag.

