### PR TITLE
feat(modules): add Chainlink Data Streams module

### DIFF
--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -208,6 +208,129 @@ describe("parseConfig", () => {
 		},
 	);
 
+	describe("module validation", () => {
+		it("should reject a pyth-lazer module whose API key env var is unset", () => {
+			process.env.PYTH_API_KEY = undefined;
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "pyth-lazer",
+							name: "pyth",
+							pythLazerApiKeyEnvKey: "PYTH_API_KEY",
+							priceFeedIds: [{ name: "BTC/USD", id: 1 }],
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				"Module pyth-lazer requires PYTH_API_KEY to be set",
+			);
+		});
+
+		it("should resolve a pyth-lazer module when its API key is set", () => {
+			process.env.PYTH_API_KEY = "pyth-secret";
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "pyth-lazer",
+							name: "pyth",
+							pythLazerApiKeyEnvKey: "PYTH_API_KEY",
+							priceFeedIds: [{ name: "BTC/USD", id: 1 }],
+						},
+					],
+				}),
+			);
+
+			assertIsOkResult(result);
+			const module = result.value.config.modules[0];
+			if (module.type !== "pyth-lazer") {
+				throw new Error(`expected pyth-lazer, got ${module.type}`);
+			}
+			expect(module.pythLazerApiKey).toBe("pyth-secret");
+			process.env.PYTH_API_KEY = undefined;
+		});
+
+		it.each([
+			{
+				missing: "key" as const,
+				env: { CHAINLINK_KEY: undefined, CHAINLINK_SECRET: "secret" },
+				expected: "Module chainlink-streams requires CHAINLINK_KEY to be set",
+			},
+			{
+				missing: "secret" as const,
+				env: { CHAINLINK_KEY: "key", CHAINLINK_SECRET: undefined },
+				expected:
+					"Module chainlink-streams requires CHAINLINK_SECRET to be set",
+			},
+		])(
+			"should reject a chainlink-streams module when the $missing env var is unset",
+			({ env, expected }) => {
+				process.env.CHAINLINK_KEY = env.CHAINLINK_KEY;
+				process.env.CHAINLINK_SECRET = env.CHAINLINK_SECRET;
+
+				const [result] = Effect.runSync(
+					parseConfig({
+						routes: [],
+						modules: [
+							{
+								type: "chainlink-streams",
+								name: "chainlink",
+								chainlinkKeyEnvKey: "CHAINLINK_KEY",
+								chainlinkApiSecretEnvKey: "CHAINLINK_SECRET",
+								baseUrl: "https://api.chainlink.example",
+							},
+						],
+					}),
+				);
+
+				expect(result).toBeErrResult(expected);
+
+				process.env.CHAINLINK_KEY = undefined;
+				process.env.CHAINLINK_SECRET = undefined;
+			},
+		);
+
+		it("should resolve a chainlink-streams module and track both env vars as secrets", () => {
+			process.env.CHAINLINK_KEY = "key";
+			process.env.CHAINLINK_SECRET = "secret";
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "chainlink-streams",
+							name: "chainlink",
+							chainlinkKeyEnvKey: "CHAINLINK_KEY",
+							chainlinkApiSecretEnvKey: "CHAINLINK_SECRET",
+							baseUrl: "https://api.chainlink.example",
+						},
+					],
+				}),
+			);
+
+			assertIsOkResult(result);
+			const module = result.value.config.modules[0];
+			if (module.type !== "chainlink-streams") {
+				throw new Error(`expected chainlink-streams, got ${module.type}`);
+			}
+			expect(module.chainlinkKey).toBe("key");
+			expect(module.chainlinkApiSecret).toBe("secret");
+			expect(result.value.envSecrets.has("key")).toBe(true);
+			expect(result.value.envSecrets.has("secret")).toBe(true);
+
+			process.env.CHAINLINK_KEY = undefined;
+			process.env.CHAINLINK_SECRET = undefined;
+		});
+	});
+
 	describe("it should fail on unknown properties", () => {
 		it("at the root", () => {
 			const [result] = Effect.runSync(

--- a/workspace/data-proxy/src/config/chainlink-streams-module-config.ts
+++ b/workspace/data-proxy/src/config/chainlink-streams-module-config.ts
@@ -1,0 +1,39 @@
+import { Effect } from "effect";
+import * as v from "valibot";
+import { RouteSchema } from "./route-config";
+
+// `baseUrl` is required: Chainlink exposes distinct testnet and mainnet
+// endpoints, and the wrong one returns a valid-looking response with data
+// from the wrong network. No default.
+export const ChainlinkStreamsModuleConfigSchema = v.strictObject({
+	name: v.string(),
+	type: v.literal("chainlink-streams"),
+	chainlinkKeyEnvKey: v.string(),
+	chainlinkApiSecretEnvKey: v.string(),
+	baseUrl: v.string(),
+});
+
+export interface ChainlinkStreamsModuleConfig
+	extends v.InferOutput<typeof ChainlinkStreamsModuleConfigSchema> {
+	chainlinkKey: string;
+	chainlinkApiSecret: string;
+}
+
+export const ChainlinkStreamsModuleRouteSchema = v.strictObject({
+	...RouteSchema.entries,
+	type: v.literal("chainlink-streams"),
+	moduleName: v.string(),
+	// Appended to baseUrl; supports {:param} placeholders filled from route match.
+	upstreamPath: v.string(),
+});
+
+export type ChainlinkStreamsModuleRoute = v.InferOutput<
+	typeof ChainlinkStreamsModuleRouteSchema
+>;
+
+export const validateChainlinkStreamsModuleRoute = (
+	route: ChainlinkStreamsModuleRoute,
+) =>
+	Effect.gen(function* () {
+		return yield* Effect.void;
+	});

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -1,7 +1,7 @@
 import { Secp256k1 } from "@cosmjs/crypto";
 import { tryParseSync } from "@seda-protocol/utils";
 import { maybe } from "@seda-protocol/utils/valibot";
-import { Effect } from "effect";
+import { Effect, Either, Match } from "effect";
 import type { HTTPMethod } from "elysia";
 import { Result } from "true-myth";
 import * as v from "valibot";
@@ -12,6 +12,11 @@ import {
 	DEFAULT_VERIFICATION_RETRY_DELAY,
 } from "../constants";
 import { replaceParams } from "../utils/replace-params";
+import {
+	type ChainlinkStreamsModuleRoute,
+	ChainlinkStreamsModuleRouteSchema,
+	validateChainlinkStreamsModuleRoute,
+} from "./chainlink-streams-module-config";
 import { type Modules, ModulesSchema } from "./module-config";
 import {
 	type PythLazerModuleRoute,
@@ -99,6 +104,7 @@ const ConfigSchema = v.strictObject(
 			v.variant("type", [
 				UpstreamModuleRouteSchema,
 				PythLazerModuleRouteSchema,
+				ChainlinkStreamsModuleRouteSchema,
 			]),
 		),
 		baseURL: maybe(v.string()),
@@ -127,7 +133,10 @@ const ConfigSchema = v.strictObject(
 );
 
 // export type Route = v.InferOutput<typeof RouteSchema>;
-export type Route = UpstreamModuleRoute | PythLazerModuleRoute;
+export type Route =
+	| UpstreamModuleRoute
+	| PythLazerModuleRoute
+	| ChainlinkStreamsModuleRoute;
 export interface Config extends v.InferOutput<typeof ConfigSchema> {
 	modules: Modules[];
 }
@@ -215,6 +224,11 @@ export const parseConfig = (
 		for (const [index, route] of config.routes.entries()) {
 			if (route.type === "pyth-lazer") {
 				yield* validatePythLazerModuleRoute(route);
+				continue;
+			}
+
+			if (route.type === "chainlink-streams") {
+				yield* validateChainlinkStreamsModuleRoute(route);
 				continue;
 			}
 
@@ -348,24 +362,51 @@ export const parseConfig = (
 
 		const modules: Modules[] = [];
 
-		// Check if the modules are valid
 		for (const module of config.modules) {
-			if (module.type === "pyth-lazer") {
-				const pythLazerApiKey = process.env[module.pythLazerApiKeyEnvKey];
-				if (!pythLazerApiKey) {
-					return [
-						Result.err(
-							`Module ${module.type} requires ${module.pythLazerApiKeyEnvKey} to be set`,
-						),
-						hasWarnings,
-					];
-				}
+			const resolved = yield* Effect.either(
+				Match.value(module).pipe(
+					Match.when({ type: "pyth-lazer" }, (m) => {
+						const pythLazerApiKey = process.env[m.pythLazerApiKeyEnvKey];
+						if (!pythLazerApiKey) {
+							return Effect.fail(
+								`Module ${m.type} requires ${m.pythLazerApiKeyEnvKey} to be set`,
+							);
+						}
+						return Effect.succeed({ ...m, pythLazerApiKey } satisfies Modules);
+					}),
+					Match.when({ type: "chainlink-streams" }, (m) => {
+						const chainlinkKey = process.env[m.chainlinkKeyEnvKey];
+						const chainlinkApiSecret = process.env[m.chainlinkApiSecretEnvKey];
 
-				modules.push({
-					...module,
-					pythLazerApiKey,
-				});
+						if (!chainlinkKey) {
+							return Effect.fail(
+								`Module ${m.type} requires ${m.chainlinkKeyEnvKey} to be set`,
+							);
+						}
+
+						if (!chainlinkApiSecret) {
+							return Effect.fail(
+								`Module ${m.type} requires ${m.chainlinkApiSecretEnvKey} to be set`,
+							);
+						}
+
+						envSecrets.add(chainlinkKey);
+						envSecrets.add(chainlinkApiSecret);
+
+						return Effect.succeed({
+							...m,
+							chainlinkKey,
+							chainlinkApiSecret,
+						} satisfies Modules);
+					}),
+					Match.exhaustive,
+				),
+			);
+
+			if (Either.isLeft(resolved)) {
+				return [Result.err(resolved.left), hasWarnings];
 			}
+			modules.push(resolved.right);
 		}
 
 		if (config.sedaFast?.enable) {

--- a/workspace/data-proxy/src/config/module-config.ts
+++ b/workspace/data-proxy/src/config/module-config.ts
@@ -1,10 +1,17 @@
 import * as v from "valibot";
+import type { ChainlinkStreamsModuleConfig } from "./chainlink-streams-module-config";
+import { ChainlinkStreamsModuleConfigSchema } from "./chainlink-streams-module-config";
 import type { PythLazerModuleConfig } from "./pyth-lazer-module-config";
 import { PythLazerModuleConfigSchema } from "./pyth-lazer-module-config";
 
 export const ModulesSchema = v.optional(
-	v.array(PythLazerModuleConfigSchema),
+	v.array(
+		v.variant("type", [
+			PythLazerModuleConfigSchema,
+			ChainlinkStreamsModuleConfigSchema,
+		]),
+	),
 	[],
 );
 
-export type Modules = PythLazerModuleConfig;
+export type Modules = PythLazerModuleConfig | ChainlinkStreamsModuleConfig;

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -75,6 +75,16 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 					);
 				}),
 			),
+			Match.when({ type: "chainlink-streams" }, (chainlinkStreamsModuleRoute) =>
+				Effect.gen(function* () {
+					yield* Effect.logDebug("Handling Chainlink Streams request");
+					return yield* moduleService.handleRequest(
+						chainlinkStreamsModuleRoute,
+						params,
+						request,
+					);
+				}),
+			),
 			Match.when({ type: "upstream" }, (upstreamModuleRoute) =>
 				Effect.gen(function* () {
 					yield* Effect.logDebug("Handling upstream request");

--- a/workspace/data-proxy/src/modules/chainlink-streams/chainlink-streams.test.ts
+++ b/workspace/data-proxy/src/modules/chainlink-streams/chainlink-streams.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import * as v from "valibot";
+import { ChainlinkStreamsModuleConfigSchema } from "../../config/chainlink-streams-module-config";
+import { FailedToHandleChainlinkStreamsRequestError } from "./errors";
+import { generateHmacAuth } from "./hmac-auth";
+
+describe("generateHmacAuth", () => {
+	it("produces a deterministic SHA256 HMAC for a known GET request", () => {
+		const apiKey = "test-api-key-uuid";
+		const apiSecret = "test-api-secret";
+		const method = "GET";
+		const path = "/api/v1/reports/latest?feedID=0xabc";
+		const body = "";
+		const timestamp = "1700000000000";
+
+		const result = generateHmacAuth(
+			apiKey,
+			apiSecret,
+			method,
+			path,
+			body,
+			timestamp,
+		);
+
+		expect(result.signature).toMatch(/^[0-9a-f]{64}$/);
+		expect(result.authorization).toBe(apiKey);
+		expect(result.timestamp).toBe(timestamp);
+
+		const second = generateHmacAuth(
+			apiKey,
+			apiSecret,
+			method,
+			path,
+			body,
+			timestamp,
+		);
+		expect(second.signature).toBe(result.signature);
+	});
+
+	it("produces different signatures when the timestamp changes", () => {
+		const base = generateHmacAuth("k", "s", "GET", "/x", "", "1700000000000");
+		const shifted = generateHmacAuth(
+			"k",
+			"s",
+			"GET",
+			"/x",
+			"",
+			"1700000000001",
+		);
+		expect(base.signature).not.toBe(shifted.signature);
+	});
+
+	it("produces different signatures when the path changes", () => {
+		const base = generateHmacAuth("k", "s", "GET", "/x", "", "1700000000000");
+		const shifted = generateHmacAuth(
+			"k",
+			"s",
+			"GET",
+			"/y",
+			"",
+			"1700000000000",
+		);
+		expect(base.signature).not.toBe(shifted.signature);
+	});
+
+	it("hashes the body for POST requests (empty body vs non-empty differs)", () => {
+		const empty = generateHmacAuth("k", "s", "POST", "/x", "", "1700000000000");
+		const withBody = generateHmacAuth(
+			"k",
+			"s",
+			"POST",
+			"/x",
+			'{"a":1}',
+			"1700000000000",
+		);
+		expect(empty.signature).not.toBe(withBody.signature);
+	});
+});
+
+describe("chainlink-streams module config schema", () => {
+	it("accepts a valid config", () => {
+		const input = {
+			name: "chainlinkStreams",
+			type: "chainlink-streams",
+			chainlinkKeyEnvKey: "CHAINLINK_KEY",
+			chainlinkApiSecretEnvKey: "CHAINLINK_API_SECRET",
+			baseUrl: "https://api.dataengine.chain.link",
+		};
+		const parsed = v.parse(ChainlinkStreamsModuleConfigSchema, input);
+		expect(parsed.name).toBe("chainlinkStreams");
+		expect(parsed.chainlinkKeyEnvKey).toBe("CHAINLINK_KEY");
+		expect(parsed.chainlinkApiSecretEnvKey).toBe("CHAINLINK_API_SECRET");
+		expect(parsed.baseUrl).toBe("https://api.dataengine.chain.link");
+	});
+
+	it("rejects a config missing chainlinkKeyEnvKey", () => {
+		const input = {
+			name: "chainlinkStreams",
+			type: "chainlink-streams",
+			chainlinkApiSecretEnvKey: "CHAINLINK_API_SECRET",
+			baseUrl: "https://api.dataengine.chain.link",
+		};
+		expect(() => v.parse(ChainlinkStreamsModuleConfigSchema, input)).toThrow();
+	});
+
+	it("rejects a config missing chainlinkApiSecretEnvKey", () => {
+		const input = {
+			name: "chainlinkStreams",
+			type: "chainlink-streams",
+			chainlinkKeyEnvKey: "CHAINLINK_KEY",
+			baseUrl: "https://api.dataengine.chain.link",
+		};
+		expect(() => v.parse(ChainlinkStreamsModuleConfigSchema, input)).toThrow();
+	});
+
+	it("rejects a config missing baseUrl", () => {
+		const input = {
+			name: "chainlinkStreams",
+			type: "chainlink-streams",
+			chainlinkKeyEnvKey: "CHAINLINK_KEY",
+			chainlinkApiSecretEnvKey: "CHAINLINK_API_SECRET",
+		};
+		expect(() => v.parse(ChainlinkStreamsModuleConfigSchema, input)).toThrow();
+	});
+});
+
+describe("FailedToHandleChainlinkStreamsRequestError", () => {
+	it("carries status and error, and stringifies with a prefix", () => {
+		const err = new FailedToHandleChainlinkStreamsRequestError({
+			error: "upstream 502",
+			status: 502,
+		});
+		expect(err._tag).toBe("FailedToHandleChainlinkStreamsRequestError");
+		expect(err.error).toBe("upstream 502");
+		expect(err.status).toBe(502);
+		expect(err.message).toContain("Chainlink Streams error");
+	});
+});

--- a/workspace/data-proxy/src/modules/chainlink-streams/chainlink-streams.ts
+++ b/workspace/data-proxy/src/modules/chainlink-streams/chainlink-streams.ts
@@ -1,0 +1,143 @@
+import { Clock, Effect, Layer } from "effect";
+import type { ChainlinkStreamsModuleConfig } from "../../config/chainlink-streams-module-config";
+import type { Route } from "../../config/config-parser";
+import { createErrorResponse } from "../../controllers/create-error-response";
+import { replaceParams } from "../../utils/replace-params";
+import { FailedToHandleRequest, ModuleService } from "../module";
+import { FailedToHandleChainlinkStreamsRequestError } from "./errors";
+import { generateHmacAuth } from "./hmac-auth";
+
+const FETCH_TIMEOUT_MS = 15_000;
+
+export const ChainlinkStreamsModuleService = (
+	config: ChainlinkStreamsModuleConfig,
+) =>
+	Layer.effect(
+		ModuleService,
+		Effect.gen(function* () {
+			yield* Effect.logInfo("Initializing Chainlink Streams module", {
+				name: config.name,
+				baseUrl: config.baseUrl,
+			});
+
+			const start = () =>
+				Effect.gen(function* () {
+					yield* Effect.logInfo("Chainlink Streams module started", {
+						name: config.name,
+					});
+				}).pipe(Effect.annotateLogs("_name", "chainlink-streams"));
+
+			const handleRequest = (
+				route: Route,
+				params: Record<string, string>,
+				request: Request,
+			) =>
+				Effect.gen(function* () {
+					if (route.type !== "chainlink-streams") {
+						return yield* Effect.fail(
+							new FailedToHandleRequest({
+								msg: "Route is not a Chainlink Streams module",
+							}),
+						);
+					}
+
+					const signedPath =
+						replaceParams(route.upstreamPath, params) +
+						new URL(request.url).search;
+					const upstreamUrl = new URL(signedPath, config.baseUrl);
+
+					let body = "";
+					if (request.method !== "GET") {
+						body = yield* Effect.tryPromise({
+							try: () => request.clone().text(),
+							catch: () =>
+								new FailedToHandleChainlinkStreamsRequestError({
+									error: "Failed to read request body",
+									status: 400,
+								}),
+						});
+					}
+
+					const nowMs = yield* Clock.currentTimeMillis;
+					const timestamp = nowMs.toString();
+
+					const auth = generateHmacAuth(
+						config.chainlinkKey,
+						config.chainlinkApiSecret,
+						request.method,
+						signedPath,
+						body,
+						timestamp,
+					);
+
+					yield* Effect.logDebug("Making Chainlink Streams request", {
+						url: upstreamUrl.toString(),
+						method: request.method,
+						path: signedPath,
+					});
+
+					const response = yield* Effect.tryPromise({
+						try: () =>
+							fetch(upstreamUrl, {
+								method: request.method,
+								headers: {
+									"Content-Type": "application/json",
+									Accept: "application/json",
+									Authorization: auth.authorization,
+									"X-Authorization-Timestamp": auth.timestamp,
+									"X-Authorization-Signature-SHA256": auth.signature,
+								},
+								body: body || undefined,
+								signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+							}),
+						catch: (error) => {
+							const isTimeout =
+								error instanceof Error && error.name === "TimeoutError";
+							return new FailedToHandleChainlinkStreamsRequestError({
+								error: isTimeout
+									? `Chainlink Streams request timed out after ${FETCH_TIMEOUT_MS}ms`
+									: `Failed to fetch from Chainlink: ${error}`,
+								status: isTimeout ? 504 : 502,
+							});
+						},
+					});
+
+					const responseBody = yield* Effect.tryPromise({
+						try: () => response.text(),
+						catch: (error) =>
+							new FailedToHandleChainlinkStreamsRequestError({
+								error: `Failed to read response: ${error}`,
+								status: 500,
+							}),
+					});
+
+					if (!response.ok) {
+						yield* Effect.logError("Chainlink Streams request failed", {
+							status: response.status,
+							body: responseBody,
+						});
+					}
+
+					// Preserve upstream Content-Type: error bodies are often text/plain.
+					const upstreamContentType =
+						response.headers.get("content-type") ?? "application/json";
+
+					return yield* Effect.succeed(
+						new Response(responseBody, {
+							status: response.status,
+							headers: { "Content-Type": upstreamContentType },
+						}),
+					);
+				}).pipe(
+					Effect.withSpan("handleChainlinkStreamsRequest"),
+					Effect.catchAll((error) => {
+						return Effect.succeed(createErrorResponse(error, error.status));
+					}),
+				);
+
+			return {
+				start,
+				handleRequest,
+			};
+		}),
+	);

--- a/workspace/data-proxy/src/modules/chainlink-streams/errors.ts
+++ b/workspace/data-proxy/src/modules/chainlink-streams/errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+export class FailedToHandleChainlinkStreamsRequestError extends Data.TaggedError(
+	"FailedToHandleChainlinkStreamsRequestError",
+)<{ error: string; status: number }> {
+	message = `Chainlink Streams error: ${this.error}`;
+}

--- a/workspace/data-proxy/src/modules/chainlink-streams/hmac-auth.ts
+++ b/workspace/data-proxy/src/modules/chainlink-streams/hmac-auth.ts
@@ -1,0 +1,37 @@
+import crypto from "node:crypto";
+
+/**
+ * Generate HMAC authentication headers for Chainlink Data Streams API.
+ *
+ * stringToSign = "${method} ${path} ${bodyHash} ${apiKey} ${timestamp}"
+ * signature = HMAC-SHA256(apiSecret, stringToSign)
+ *
+ * `timestamp` is a parameter so tests can inject a fixed value.
+ *
+ * Spec: https://docs.chain.link/data-streams/reference/data-streams-api/authentication
+ */
+export function generateHmacAuth(
+	apiKey: string,
+	apiSecret: string,
+	method: string,
+	path: string,
+	body: string,
+	timestamp: string,
+): {
+	authorization: string;
+	timestamp: string;
+	signature: string;
+} {
+	const bodyHash = crypto.createHash("sha256").update(body).digest("hex");
+	const stringToSign = `${method} ${path} ${bodyHash} ${apiKey} ${timestamp}`;
+	const signature = crypto
+		.createHmac("sha256", apiSecret)
+		.update(stringToSign)
+		.digest("hex");
+
+	return {
+		authorization: apiKey,
+		timestamp,
+		signature,
+	};
+}

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -6,6 +6,7 @@ import {
 	Effect,
 	HashMap,
 	Layer,
+	Match,
 	MutableHashMap,
 	Option,
 	Runtime,
@@ -15,6 +16,7 @@ import { Elysia } from "elysia";
 import { type Config, getHttpMethods } from "./config/config-parser";
 import { DEFAULT_PROXY_ROUTE_GROUP } from "./constants";
 import { handleProxyRequest } from "./controllers/proxy/handle-proxy-request";
+import { ChainlinkStreamsModuleService } from "./modules/chainlink-streams/chainlink-streams";
 import { EmptyModuleService, ModuleService } from "./modules/module";
 import { PythLazerModuleService } from "./modules/pyth-lazer/pyth-lazer";
 import type { HttpClientService } from "./services/http-client";
@@ -40,13 +42,19 @@ export const startProxyServer = (
 		const runtime = yield* Effect.runtime<HttpClientService>();
 		const modules = MutableHashMap.empty<
 			string,
-			Layer.Layer<ModuleService, never, never>
+			Layer.Layer<ModuleService, unknown, never>
 		>();
 
 		// Initialize the modules and start them
 		for (const moduleConfig of config.modules) {
-			const moduleLayer = yield* Layer.memoize(
-				PythLazerModuleService(moduleConfig),
+			const moduleLayer = yield* Match.value(moduleConfig).pipe(
+				Match.when({ type: "pyth-lazer" }, (m) =>
+					Layer.memoize(PythLazerModuleService(m)),
+				),
+				Match.when({ type: "chainlink-streams" }, (m) =>
+					Layer.memoize(ChainlinkStreamsModuleService(m)),
+				),
+				Match.exhaustive,
 			);
 
 			yield* Effect.gen(function* () {
@@ -59,7 +67,7 @@ export const startProxyServer = (
 
 		// Make sure that all routes are correctly configured with their respective module
 		for (const route of config.routes) {
-			if (route.type === "pyth-lazer") {
+			if (route.type === "pyth-lazer" || route.type === "chainlink-streams") {
 				const moduleLayer = MutableHashMap.get(modules, route.moduleName);
 				if (Option.isNone(moduleLayer)) {
 					return yield* Effect.die(`Module ${route.moduleName} not found`);


### PR DESCRIPTION
## Summary

Adds a new chainlink-streams module to the data proxy, enabling SEDA oracle programs to proxy requests to Chainlink Data Streams with HMAC-SHA256 authentication.

- New config schema chainlink-streams-module-config.ts (Valibot-validated)
- New module implementation modules/chainlink-streams/chainlink-streams.ts that computes the dynamic X-Authorization-Signature-SHA256 header per request
- Config parser, module registry, proxy request handler, and proxy-server wiring updated to recognise the chainlink-streams type
- Pattern mirrors the existing pyth-lazer module

## Why a dedicated module

Chainlink Data Streams does not accept static Bearer tokens — every request requires a signature:

HMAC_SHA256(apiSecret, "METHOD PATH sha256(body) apiKey timestamp")

A generic proxy passthrough cannot inject this, so t module handles it in-proxy using CHAINLINK_STREAMS_API_KEY + CHAINLINK_STREAMS_API_SECRET env vars.

## Test plan

- [ ] bun run lint clean
- [ ] bun run build clean
- [ ] Valid config with type: chainlink-streams loads without parser errors
- [ ] Invalid config (missing apiKeyEnvKey) surfaces a clear Valibot error
- [ ] Live request against api.testnet-dataengine.chain.link returns 2xx with correct signature headers
- [ ] Pattern parity with pyth-lazer confirmed

## Notes

- Auth docs: https://docs.chain.link/data-streams/reference/data-streams-api/authentication
- Addition-only; no breaking changes