### PR TITLE
Improve upstream error logging

### DIFF
--- a/workspace/data-proxy/src/controllers/create-error-response.ts
+++ b/workspace/data-proxy/src/controllers/create-error-response.ts
@@ -10,6 +10,7 @@ export function createErrorResponse(error: TaggedError, status: number) {
 		...error,
 		error: undefined,
 		message: undefined,
+		data: undefined, // can be very large for errors like QueryJsonError
 	};
 
 	return new Response(

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -5,6 +5,7 @@ import { JSON_PATH_HEADER_KEY } from "../../constants";
 import {
 	FailedToParseResponseBodyError,
 	NotOkUpstreamResponseError,
+	QueryJsonError,
 	UpstreamRequestFailedError,
 } from "../../errors";
 import { ModuleService } from "../../modules/module";
@@ -12,7 +13,7 @@ import type { ProxyServerOptions } from "../../proxy-server";
 import { HttpClientService } from "../../services/http-client";
 import { createSignedResponseHeaders } from "../../utils/create-headers";
 import { maybeToOption } from "../../utils/effect-utils";
-import { QueryJsonError, queryJson } from "../../utils/query-json";
+import { queryJson } from "../../utils/query-json";
 import { replaceParams } from "../../utils/replace-params";
 import { createUrlSearchParams } from "../../utils/search-params";
 import { injectSearchParamsInUrl } from "../../utils/url";
@@ -213,6 +214,7 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 					(error) =>
 						new QueryJsonError({
 							error: error.message,
+							data: error.data,
 							type: "config",
 							status: 500,
 						}),
@@ -243,6 +245,7 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 					(error) =>
 						new QueryJsonError({
 							error: error.message,
+							data: error.data,
 							type: "header",
 							// Fault is from the user side
 							status: 400,
@@ -302,58 +305,28 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 		});
 	}).pipe(
 		Effect.withSpan("handleProxyRequest"),
-		Effect.catchTag("VerifyProofError", (error) =>
+		Effect.tapError((error) =>
 			Effect.gen(function* () {
 				yield* Effect.logError(error);
-				return createErrorResponse(error, 400);
 			}),
 		),
-		Effect.catchTag("IneligibleProofError", (error) =>
-			Effect.gen(function* () {
-				yield* Effect.logError(error);
-				return createErrorResponse(error, 401);
-			}),
-		),
-		Effect.catchTag("UnknownError", (error) =>
-			Effect.gen(function* () {
-				yield* Effect.logError(error);
-				return createErrorResponse(error, 500);
-			}),
-		),
-		Effect.catchTag("FailedToParseTargetUrlError", (error) =>
-			Effect.gen(function* () {
-				yield* Effect.logError(error);
-				return createErrorResponse(error, 500);
-			}),
-		),
-		Effect.catchTag("UpstreamRequestFailedError", (error) =>
-			Effect.gen(function* () {
-				yield* Effect.logError(error);
-				return createErrorResponse(error, 500);
-			}),
-		),
-		Effect.catchTag("FailedToParseResponseBodyError", (error) =>
-			Effect.gen(function* () {
-				yield* Effect.logError(error);
-				return createErrorResponse(error, 500);
-			}),
-		),
-		Effect.catchTag("NotOkUpstreamResponseError", (error) =>
-			Effect.gen(function* () {
-				yield* Effect.logError(error);
-				return createErrorResponse(error, error.status);
-			}),
-		),
-		Effect.catchTag("QueryJsonError", (error) =>
-			Effect.gen(function* () {
-				yield* Effect.logError(error);
-				return createErrorResponse(error, error.status ?? 500);
-			}),
-		),
-		Effect.catchTag("FailedToHandleRequest", (error) =>
-			Effect.gen(function* () {
-				yield* Effect.logError(error);
-				return createErrorResponse(error, error.status);
-			}),
-		),
+		Effect.catchTags({
+			VerifyProofError: (error) =>
+				Effect.succeed(createErrorResponse(error, 400)),
+			IneligibleProofError: (error) =>
+				Effect.succeed(createErrorResponse(error, 401)),
+			UnknownError: (error) => Effect.succeed(createErrorResponse(error, 500)),
+			FailedToParseTargetUrlError: (error) =>
+				Effect.succeed(createErrorResponse(error, 500)),
+			UpstreamRequestFailedError: (error) =>
+				Effect.succeed(createErrorResponse(error, 500)),
+			FailedToParseResponseBodyError: (error) =>
+				Effect.succeed(createErrorResponse(error, 500)),
+			NotOkUpstreamResponseError: (error) =>
+				Effect.succeed(createErrorResponse(error, error.status)),
+			QueryJsonError: (error) =>
+				Effect.succeed(createErrorResponse(error, error.status ?? 500)),
+			FailedToHandleRequest: (error) =>
+				Effect.succeed(createErrorResponse(error, error.status)),
+		}),
 	);

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -260,7 +260,11 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 				Effect.mapError(
 					(error) =>
 						new QueryJsonError({
-							error: error.message,
+							// Attach result of operator supplied JSON path, which should
+							// limit the size of data returned to the user.
+							error: error.message.concat(
+								`for input ${JSON.stringify(responseData)}`,
+							),
 							data: error.data,
 							type: "header",
 							// Fault is from the user side

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -91,8 +91,10 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 					yield* Effect.logDebug("Handling upstream request");
 					const upstreamHeaders = new Headers();
 
+					const url = replaceParams(upstreamModuleRoute.upstreamUrl, params);
+
 					const upstreamUrl = yield* injectSearchParamsInUrl(
-						replaceParams(upstreamModuleRoute.upstreamUrl, params),
+						url,
 						requestSearchParams,
 					).pipe(Effect.map((url) => url.toString()));
 
@@ -101,7 +103,6 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 						if (!value || key === constants.PROOF_HEADER_KEY) {
 							continue;
 						}
-
 						upstreamHeaders.append(key, value);
 					}
 
@@ -117,7 +118,7 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 
 					yield* Effect.logDebug(`Fetching ${upstreamUrl}..`, {
 						headers: upstreamHeaders,
-						body,
+						body: Option.getOrUndefined(body),
 						upstreamUrl,
 					});
 
@@ -129,6 +130,17 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 							body: Option.getOrUndefined(body),
 						})
 						.pipe(
+							Effect.tapError((error) =>
+								Effect.logError("Upstream HTTP request failed", {
+									routePath: path,
+									method: request.method,
+									clientRequestUrl: request.url,
+									upstreamRequestUrl: upstreamUrl,
+									upstreamRequestHeaders: upstreamHeaders,
+									routeParams: params,
+									requestBody: Option.getOrUndefined(body),
+								}),
+							),
 							Effect.mapError(
 								(error) =>
 									new UpstreamRequestFailedError({ error, routePath: path }),
@@ -145,6 +157,7 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 			const upstreamResponseBody = yield* httpClient
 				.parseBodyAsText(upstreamResponse)
 				.pipe(
+					// Attach the status to the error.
 					Effect.mapError(
 						(error) =>
 							new FailedToParseResponseBodyError({
@@ -156,11 +169,14 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 				.pipe(
 					Effect.tapError((error) =>
 						Effect.logError(
-							`Upstream response body parsing failed for ${route.path} is not ok: ${upstreamResponse.status} err: ${error}`,
+							`Upstream response body parsing failed with status: ${upstreamResponse.status} err: ${error}`,
 							{
-								requestBody: Option.getOrUndefined(body),
+								routePath: path,
 								method: request.method,
-								upstreamUrl: upstreamResponse.url,
+								clientRequestUrl: request.url,
+								upstreamResponseUrl: upstreamResponse.url,
+								routeParams: params,
+								requestBody: Option.getOrUndefined(body),
 							},
 						),
 					),
@@ -307,7 +323,20 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 		Effect.withSpan("handleProxyRequest"),
 		Effect.tapError((error) =>
 			Effect.gen(function* () {
-				yield* Effect.logError(error);
+				const { message, ...errorRest } = error as unknown as {
+					message: string;
+				} & Record<string, unknown>;
+
+				yield* Effect.logError(error.message, {
+					...errorRest,
+					headers: inputParams.headers,
+					params: inputParams.params,
+					body: Option.getOrUndefined(inputParams.body),
+					path: inputParams.path,
+					method: inputParams.request.method,
+					requestUrl: inputParams.request.url,
+					requestBody: Option.getOrUndefined(inputParams.body),
+				});
 			}),
 		),
 		Effect.catchTags({

--- a/workspace/data-proxy/src/errors.ts
+++ b/workspace/data-proxy/src/errors.ts
@@ -45,3 +45,12 @@ export class FailedToParseConfigError extends Data.TaggedError(
 )<{ error: string | unknown }> {
 	message = `Failed to parse config: ${this.error}`;
 }
+
+export class QueryJsonError extends Data.TaggedError("QueryJsonError")<{
+	error: string | unknown;
+	data?: string;
+	type?: "config" | "header";
+	status?: number;
+}> {
+	message = `Query JSON (originator: ${this.type ?? "unknown"}) error: ${this.error} `;
+}

--- a/workspace/data-proxy/src/logger.ts
+++ b/workspace/data-proxy/src/logger.ts
@@ -31,7 +31,7 @@ function redactEnvSecrets(message: string | unknown) {
 
 	let result = message;
 	for (const secret of envSecrets) {
-		result = result.replace(secret, "<redacted>");
+		result = result.replaceAll(secret, "<redacted>");
 	}
 	return result;
 }

--- a/workspace/data-proxy/src/proxy-server.test.ts
+++ b/workspace/data-proxy/src/proxy-server.test.ts
@@ -82,6 +82,7 @@ describe("proxy server", () => {
 							useLegacyJsonPath: true,
 						},
 					],
+					fastOnly: false,
 				},
 				dataProxy,
 				{
@@ -147,6 +148,7 @@ describe("proxy server", () => {
 							useLegacyJsonPath: true,
 						},
 					],
+					fastOnly: false,
 				},
 				dataProxy,
 				{
@@ -209,6 +211,7 @@ describe("proxy server", () => {
 								useLegacyJsonPath: true,
 							},
 						],
+						fastOnly: false,
 					},
 					dataProxy,
 					{
@@ -287,6 +290,7 @@ describe("proxy server", () => {
 								useLegacyJsonPath: true,
 							},
 						],
+						fastOnly: false,
 					},
 					dataProxy,
 					{
@@ -366,6 +370,7 @@ describe("proxy server", () => {
 								useLegacyJsonPath: true,
 							},
 						],
+						fastOnly: false,
 					},
 					dataProxy,
 					{
@@ -391,6 +396,80 @@ describe("proxy server", () => {
 			);
 		});
 	});
+
+	describe("QueryJsonError responses", () => {
+		it("does not leak QueryJsonError.data (upstream body snapshot) into the JSON error body", async () => {
+			const sensitiveData = "SENSITIVE_DATA_FROM_THE_UPSTREAM";
+			const upstreamBody = {
+				padHead: "x".repeat(20),
+				sensitiveData,
+				padTail: "x".repeat(20),
+			};
+
+			const { upstreamUrl, proxyUrl, path, port } = registerHandler(
+				"get",
+				"/query-json-privacy",
+				async () => HttpResponse.json(upstreamBody),
+			);
+
+			const proxy = await Effect.runPromise(
+				startProxyServer(
+					{
+						verificationMaxRetries: 2,
+						verificationRetryDelay: 1000,
+						routeGroup: "",
+						modules: [],
+						sedaFast: {
+							enable: true,
+							maxProofAgeMs: 1000,
+							allowedClients: [],
+						},
+						statusEndpoints: {
+							root: "status",
+						},
+						baseURL: Maybe.nothing(),
+						routes: [
+							{
+								baseURL: Maybe.nothing(),
+								method: "GET",
+								path,
+								upstreamUrl,
+								forwardResponseHeaders: new Set([]),
+								headers: {},
+								jsonPath: "$.noSuchProperty",
+								type: "upstream",
+								moduleName: "upstream",
+								useLegacyJsonPath: true,
+							},
+						],
+						fastOnly: false,
+					},
+					dataProxy,
+					{
+						disableProof: true,
+						port,
+						enableKeepAliveFiber: false,
+					},
+				)
+					.pipe(Effect.scoped)
+					.pipe(Effect.provide(HttpClientService.Default()))
+					.pipe(Logger.withMinimumLogLevel(LogLevel.None)),
+			);
+
+			const response = await fetch(proxyUrl);
+			expect(response.status).toBe(500);
+
+			const raw = await response.text();
+			const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+			expect(parsed).not.toHaveProperty("data");
+			expect(parsed._tag).toBe("QueryJsonError");
+			expect(raw).not.toContain(sensitiveData);
+
+			await proxy.stop();
+		});
+	});
+
 	describe("status endpoints", () => {
 		it("should return the status of the proxy for <statusRoot>/health", async () => {
 			const { upstreamUrl, proxyUrl, path, port } = registerHandler(
@@ -438,6 +517,7 @@ describe("proxy server", () => {
 								useLegacyJsonPath: true,
 							},
 						],
+						fastOnly: false,
 					},
 					dataProxy,
 					{
@@ -533,6 +613,7 @@ describe("proxy server", () => {
 								useLegacyJsonPath: true,
 							},
 						],
+						fastOnly: false,
 					},
 					dataProxy,
 					{
@@ -608,6 +689,7 @@ describe("proxy server", () => {
 								useLegacyJsonPath: true,
 							},
 						],
+						fastOnly: false,
 					},
 					dataProxy,
 					{

--- a/workspace/data-proxy/src/proxy-server.test.ts
+++ b/workspace/data-proxy/src/proxy-server.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@seda-protocol/data-proxy-sdk";
 import { Effect, LogLevel, Logger } from "effect";
 import { Maybe } from "true-myth";
+import { JSON_PATH_HEADER_KEY } from "./constants";
 import { startProxyServer } from "./proxy-server";
 import { HttpClientService } from "./services/http-client";
 import {
@@ -468,6 +469,85 @@ describe("proxy server", () => {
 
 			await proxy.stop();
 		});
+	});
+
+	it("when user-supplied JSON path is invalid, the result of operator-supplied JSON path should be returned with a 400 status", async () => {
+		const picked = "PICKED_BY_OPERATOR_SUPPLIED_JSON_PATH";
+		const notPicked = "NOT_PICKED_BY_OPERATOR_SUPPLIED_JSON_PATH";
+		const upstreamBody = {
+			picked,
+			notPicked,
+		};
+		const validPath = "$.picked";
+		const invalidPath = "$.invalidPath";
+
+		const { upstreamUrl, proxyUrl, path, port } = registerHandler(
+			"get",
+			"/query-json-privacy",
+			async () => HttpResponse.json(upstreamBody),
+		);
+
+		const proxy = await Effect.runPromise(
+			startProxyServer(
+				{
+					verificationMaxRetries: 2,
+					verificationRetryDelay: 1000,
+					routeGroup: "",
+					modules: [],
+					sedaFast: {
+						enable: true,
+						maxProofAgeMs: 1000,
+						allowedClients: [],
+					},
+					statusEndpoints: {
+						root: "status",
+					},
+					baseURL: Maybe.nothing(),
+					routes: [
+						{
+							baseURL: Maybe.nothing(),
+							method: "GET",
+							path,
+							upstreamUrl,
+							forwardResponseHeaders: new Set([]),
+							headers: {},
+							jsonPath: validPath,
+							type: "upstream",
+							moduleName: "upstream",
+							useLegacyJsonPath: true,
+						},
+					],
+					fastOnly: false,
+				},
+				dataProxy,
+				{
+					disableProof: true,
+					port,
+					enableKeepAliveFiber: false,
+				},
+			)
+				.pipe(Effect.scoped)
+				.pipe(Effect.provide(HttpClientService.Default()))
+				.pipe(Logger.withMinimumLogLevel(LogLevel.None)),
+		);
+
+		const response = await fetch(proxyUrl, {
+			headers: {
+				[JSON_PATH_HEADER_KEY]: invalidPath,
+			},
+		});
+		expect(response.status).toBe(400);
+
+		const raw = await response.text();
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+		expect(parsed).not.toHaveProperty("data");
+		expect(parsed._tag).toBe("QueryJsonError");
+		expect(raw).toContain(invalidPath);
+		expect(raw).toContain(picked);
+		expect(raw).not.toContain(notPicked);
+
+		await proxy.stop();
 	});
 
 	describe("status endpoints", () => {

--- a/workspace/data-proxy/src/utils/query-json.test.ts
+++ b/workspace/data-proxy/src/utils/query-json.test.ts
@@ -26,9 +26,7 @@ describe("queryJson", () => {
 		});
 
 		const result = Effect.runSync(Effect.either(program));
-		expect(result.toString()).toInclude(
-			"Quering JSON with $.a.b.b returned null",
-		);
+		expect(result.toString()).toInclude("JSONPath $.a.b.b returned null");
 	});
 
 	it("should return an error when the JSON body is not an object", () => {
@@ -39,7 +37,7 @@ describe("queryJson", () => {
 		const result = Effect.runSync(Effect.either(program));
 
 		expect(result.toString()).toInclude(
-			"Quering JSON with $.a.b.b returned not an array: undefined",
+			"JSONPath $.a.b.b did not return an array",
 		);
 	});
 });

--- a/workspace/data-proxy/src/utils/query-json.ts
+++ b/workspace/data-proxy/src/utils/query-json.ts
@@ -19,10 +19,9 @@ export const queryJson = (
 		const data: unknown = yield* Effect.try({
 			try: () => JSONPath({ path, json: jsonData }),
 			catch: (error) => {
-				const jsonInput = JSON.stringify(input);
 				return new QueryJsonError({
-					error: `Could not query JSON: ${error} with input ${jsonInput.slice(0, 100)}...`,
-					data: jsonInput,
+					error: `JSONPath ${path} could not be evaluated: ${error}`,
+					data: JSON.stringify(input),
 				});
 			},
 		});
@@ -32,21 +31,19 @@ export const queryJson = (
 		}
 
 		if (!Array.isArray(data)) {
-			const jsonInput = JSON.stringify(input);
 			return yield* Effect.fail(
 				new QueryJsonError({
-					error: `Quering JSON with ${path} returned not an array: ${JSON.stringify(data)} with input ${jsonInput.slice(0, 100)}...`,
-					data: jsonInput,
+					error: `JSONPath ${path} did not return an array`,
+					data: JSON.stringify(input),
 				}),
 			);
 		}
 
 		if (data.length === 0) {
-			const jsonInput = JSON.stringify(input);
 			return yield* Effect.fail(
 				new QueryJsonError({
-					error: `Quering JSON with ${path} returned null with input ${jsonInput.slice(0, 100)}...`,
-					data: jsonInput,
+					error: `JSONPath ${path} returned null`,
+					data: JSON.stringify(input),
 				}),
 			);
 		}

--- a/workspace/data-proxy/src/utils/query-json.ts
+++ b/workspace/data-proxy/src/utils/query-json.ts
@@ -1,15 +1,6 @@
-import { trySync } from "@seda-protocol/utils";
-import { Data, Effect, Match } from "effect";
+import { Effect } from "effect";
 import { JSONPath } from "jsonpath-plus";
-import { Result } from "true-myth";
-
-export class QueryJsonError extends Data.TaggedError("QueryJsonError")<{
-	error: string | unknown;
-	type?: "config" | "header";
-	status?: number;
-}> {
-	message = `Query JSON (originator: ${this.type ?? "unknown"}) error: ${this.error} `;
-}
+import { QueryJsonError } from "../errors";
 
 export const queryJson = (
 	input: string | object,
@@ -28,9 +19,10 @@ export const queryJson = (
 		const data: unknown = yield* Effect.try({
 			try: () => JSONPath({ path, json: jsonData }),
 			catch: (error) => {
-				const slicedInput = JSON.stringify(input).slice(0, 100);
+				const jsonInput = JSON.stringify(input);
 				return new QueryJsonError({
-					error: `Could not query JSON: ${error} with input ${slicedInput}...`,
+					error: `Could not query JSON: ${error} with input ${jsonInput.slice(0, 100)}...`,
+					data: jsonInput,
 				});
 			},
 		});
@@ -40,19 +32,21 @@ export const queryJson = (
 		}
 
 		if (!Array.isArray(data)) {
-			const slicedInput = JSON.stringify(input).slice(0, 100);
+			const jsonInput = JSON.stringify(input);
 			return yield* Effect.fail(
 				new QueryJsonError({
-					error: `Quering JSON with ${path} returned not an array: ${JSON.stringify(data)} with input ${slicedInput}...`,
+					error: `Quering JSON with ${path} returned not an array: ${JSON.stringify(data)} with input ${jsonInput.slice(0, 100)}...`,
+					data: jsonInput,
 				}),
 			);
 		}
 
 		if (data.length === 0) {
-			const slicedInput = JSON.stringify(input).slice(0, 100);
+			const jsonInput = JSON.stringify(input);
 			return yield* Effect.fail(
 				new QueryJsonError({
-					error: `Quering JSON with ${path} returned null with input ${slicedInput}...`,
+					error: `Quering JSON with ${path} returned null with input ${jsonInput.slice(0, 100)}...`,
+					data: jsonInput,
 				}),
 			);
 		}


### PR DESCRIPTION
## Explanation of Changes

- Adds more context to upstream error logs.
- For JSON path error (`QueryJsonError`), we now also log the full JSON data. => We may want to impose some limit on data size here.
- Also fixes the bug where not all sensitive values from environment variables were redacted.

When an upstream HTTP fetch fails:
```
2026-04-28T17:57:16.820Z ERROR #5 [/proxy/random2] [30a9f2a7-5972-4bf8-a7b5-0983af5f4705] [GET] {
  "message": "Upstream HTTP request failed",
  "routePath": "/proxy/random2",
  "method": "GET",
  "clientRequestUrl": "http://localhost:5384/proxy/random2",
  "upstreamRequestUrl": "https://invalid.com/test?api_key=<redacted>",
  "upstreamRequestHeaders": {
    "user-agent": "curl/8.7.1",
    "accept": "*/*",
    "content-type": "application/json",
    "authorization": "Bearer <redacted>"
  }
}
2026-04-28T17:57:16.821Z ERROR #5 [/proxy/random2] [30a9f2a7-5972-4bf8-a7b5-0983af5f4705] [GET] {
  "error": {
    "error": {
      "error": {
        "code": "ConnectionRefused",
        "path": "https://invalid.com/test?api_key=<redacted>",
        "errno": 0
      },
      "_tag": "HttpClientRequestFailedError",
      "message": "HTTP client request failed: Error: Unable to connect. Is the computer able to access the url?"
    },
    "routePath": "/proxy/random2",
    "_tag": "UpstreamRequestFailedError",
    "message": "Upstream request failed for route /proxy/random2: HttpClientRequestFailedError: HTTP client request failed: Error: Unable to connect. Is the computer able to access the url?"
  },
  "headers": {
    "host": "localhost:5384",
    "user-agent": "curl/8.7.1",
    "accept": "*/*"
  },
  "path": "/proxy/random2",
  "method": "GET",
  "requestUrl": "http://localhost:5384/proxy/random2"
}
```


## Related PRs and Issues

Closes: #94
