### PR TITLE
feat(hydromancer): add WS-first module with REST fallback

### DIFF
--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"msw": "2.3.1"

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -408,6 +408,58 @@ describe("parseConfig", () => {
 			process.env.CHAINLINK_KEY = undefined;
 			process.env.CHAINLINK_SECRET = undefined;
 		});
+
+		it("should reject a hydromancer module whose API key env var is unset", () => {
+			process.env.HYDROMANCER_API_KEY = undefined;
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "hydromancer",
+							name: "hydromancer",
+							wsUrl: "wss://api.hydromancer.xyz/ws",
+							restBaseUrl: "https://api.hydromancer.xyz",
+							hydromancerApiKeyEnvKey: "HYDROMANCER_API_KEY",
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				"Module hydromancer requires HYDROMANCER_API_KEY to be set",
+			);
+		});
+
+		it("should resolve a hydromancer module and track its API key as a secret", () => {
+			process.env.HYDROMANCER_API_KEY = "hydromancer-secret";
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "hydromancer",
+							name: "hydromancer",
+							wsUrl: "wss://api.hydromancer.xyz/ws",
+							restBaseUrl: "https://api.hydromancer.xyz",
+							hydromancerApiKeyEnvKey: "HYDROMANCER_API_KEY",
+						},
+					],
+				}),
+			);
+
+			assertIsOkResult(result);
+			const module = result.value.config.modules[0];
+			if (module.type !== "hydromancer") {
+				throw new Error(`expected hydromancer, got ${module.type}`);
+			}
+			expect(module.hydromancerApiKey).toBe("hydromancer-secret");
+			expect(result.value.envSecrets.has("hydromancer-secret")).toBe(true);
+
+			process.env.HYDROMANCER_API_KEY = undefined;
+		});
 	});
 
 	describe("it should fail on unknown properties", () => {

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -22,6 +22,11 @@ import {
 	DxFeedModuleRouteSchema,
 	validateDxFeedModuleRoute,
 } from "./dxfeed-module-config";
+import {
+	type HydromancerModuleRoute,
+	HydromancerModuleRouteSchema,
+	validateHydromancerModuleRoute,
+} from "./hydromancer-module-config";
 import { type Modules, ModulesSchema } from "./module-config";
 import {
 	type PythLazerModuleRoute,
@@ -111,6 +116,7 @@ const ConfigSchema = v.strictObject(
 				PythLazerModuleRouteSchema,
 				ChainlinkStreamsModuleRouteSchema,
 				DxFeedModuleRouteSchema,
+				HydromancerModuleRouteSchema,
 			]),
 		),
 		baseURL: maybe(v.string()),
@@ -143,7 +149,8 @@ export type Route =
 	| UpstreamModuleRoute
 	| PythLazerModuleRoute
 	| ChainlinkStreamsModuleRoute
-	| DxFeedModuleRoute;
+	| DxFeedModuleRoute
+	| HydromancerModuleRoute;
 
 export interface Config extends v.InferOutput<typeof ConfigSchema> {
 	modules: Modules[];
@@ -242,6 +249,11 @@ export const parseConfig = (
 
 			if (route.type === "dxfeed") {
 				yield* validateDxFeedModuleRoute(route);
+				continue;
+			}
+
+			if (route.type === "hydromancer") {
+				yield* validateHydromancerModuleRoute(route);
 				continue;
 			}
 
@@ -429,6 +441,22 @@ export const parseConfig = (
 						return Effect.succeed({
 							...m,
 							dxfeedAuthToken,
+						} satisfies Modules);
+					}),
+					Match.when({ type: "hydromancer" }, (m) => {
+						const hydromancerApiKey = process.env[m.hydromancerApiKeyEnvKey];
+
+						if (!hydromancerApiKey) {
+							return Effect.fail(
+								`Module ${m.type} requires ${m.hydromancerApiKeyEnvKey} to be set`,
+							);
+						}
+
+						envSecrets.add(hydromancerApiKey);
+
+						return Effect.succeed({
+							...m,
+							hydromancerApiKey,
 						} satisfies Modules);
 					}),
 					Match.exhaustive,

--- a/workspace/data-proxy/src/config/hydromancer-module-config.ts
+++ b/workspace/data-proxy/src/config/hydromancer-module-config.ts
@@ -1,0 +1,98 @@
+import { Duration, Effect, Option } from "effect";
+import * as v from "valibot";
+import { RouteSchema } from "./route-config";
+
+export const HydromancerModuleConfigSchema = v.strictObject({
+	name: v.string(),
+	type: v.literal("hydromancer"),
+	wsUrl: v.string(),
+	restBaseUrl: v.string(),
+	hydromancerApiKeyEnvKey: v.string(),
+	staleAfter: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "10 seconds"),
+		v.transform((value) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(value),
+				() => new Error("Invalid staleAfter duration"),
+			),
+		),
+	),
+	subscriptionCoins: v.optional(v.array(v.string()), []),
+	maxCoinsPerRequest: v.optional(v.number(), 20),
+	reconnectMaxBackoff: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((value) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(value),
+				() => new Error("Invalid reconnectMaxBackoff duration"),
+			),
+		),
+	),
+	reconnectStableThreshold: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((value) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(value),
+				() => new Error("Invalid reconnectStableThreshold duration"),
+			),
+		),
+	),
+	coinsCleanupTtl: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "2 minutes"),
+		v.transform((ttl) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(ttl),
+				() => new Error("Invalid coin cleanup TTL"),
+			),
+		),
+	),
+	coinsCleanupInterval: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((interval) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(interval),
+				() => new Error("Invalid coin cleanup interval"),
+			),
+		),
+	),
+	restFetchTimeout: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "15 seconds"),
+		v.transform((value) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(value),
+				() => new Error("Invalid restFetchTimeout duration"),
+			),
+		),
+	),
+});
+
+export interface HydromancerModuleConfig
+	extends v.InferOutput<typeof HydromancerModuleConfigSchema> {
+	hydromancerApiKey: string;
+}
+
+export const HydromancerModuleRouteSchema = v.strictObject({
+	...RouteSchema.entries,
+	type: v.literal("hydromancer"),
+	moduleName: v.string(),
+	fetchFromModule: v.string(),
+});
+
+export type HydromancerModuleRoute = v.InferOutput<
+	typeof HydromancerModuleRouteSchema
+>;
+
+export const validateHydromancerModuleRoute = (route: HydromancerModuleRoute) =>
+	Effect.gen(function* () {
+		return yield* Effect.void;
+	});
+
+export const AssetCtxSchema = v.object({
+	oraclePx: v.nullable(v.string()),
+	markPx: v.nullable(v.string()),
+	midPx: v.nullable(v.string()),
+	impactPxs: v.nullable(v.array(v.string())),
+	openInterest: v.nullable(v.string()),
+});
+
+export type AssetCtx = v.InferOutput<typeof AssetCtxSchema>;

--- a/workspace/data-proxy/src/config/module-config.ts
+++ b/workspace/data-proxy/src/config/module-config.ts
@@ -3,6 +3,8 @@ import type { ChainlinkStreamsModuleConfig } from "./chainlink-streams-module-co
 import { ChainlinkStreamsModuleConfigSchema } from "./chainlink-streams-module-config";
 import type { DxFeedModuleConfig } from "./dxfeed-module-config";
 import { DxFeedModuleConfigSchema } from "./dxfeed-module-config";
+import type { HydromancerModuleConfig } from "./hydromancer-module-config";
+import { HydromancerModuleConfigSchema } from "./hydromancer-module-config";
 import type { PythLazerModuleConfig } from "./pyth-lazer-module-config";
 import { PythLazerModuleConfigSchema } from "./pyth-lazer-module-config";
 
@@ -12,6 +14,7 @@ export const ModulesSchema = v.optional(
 			PythLazerModuleConfigSchema,
 			ChainlinkStreamsModuleConfigSchema,
 			DxFeedModuleConfigSchema,
+			HydromancerModuleConfigSchema,
 		]),
 	),
 	[],
@@ -20,4 +23,5 @@ export const ModulesSchema = v.optional(
 export type Modules =
 	| PythLazerModuleConfig
 	| ChainlinkStreamsModuleConfig
-	| DxFeedModuleConfig;
+	| DxFeedModuleConfig
+	| HydromancerModuleConfig;

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -96,6 +96,16 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 					);
 				}),
 			),
+			Match.when({ type: "hydromancer" }, (hydromancerModuleRoute) =>
+				Effect.gen(function* () {
+					yield* Effect.logDebug("Handling Hydromancer request");
+					return yield* moduleService.handleRequest(
+						hydromancerModuleRoute,
+						params,
+						request,
+					);
+				}),
+			),
 			Match.when({ type: "upstream" }, (upstreamModuleRoute) =>
 				Effect.gen(function* () {
 					yield* Effect.logDebug("Handling upstream request");

--- a/workspace/data-proxy/src/modules/hydromancer/asset-cache.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/asset-cache.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Option } from "effect";
+import { createAssetCache } from "./asset-cache";
+
+const ctx = {
+	oraclePx: "1",
+	markPx: "2",
+	midPx: "3",
+	impactPxs: ["4", "5"],
+	openInterest: "6",
+};
+
+describe("createAssetCache", () => {
+	it("returns None for an unset coin", () =>
+		Effect.runPromise(
+			Effect.gen(function* () {
+				const cache = yield* createAssetCache();
+				expect(Option.isNone(yield* cache.get("BTC"))).toBe(true);
+				expect(yield* cache.isFresh("BTC", 1000, 0)).toBe(false);
+			}),
+		));
+
+	it("considers an entry fresh within the staleness window", () =>
+		Effect.runPromise(
+			Effect.gen(function* () {
+				const cache = yield* createAssetCache();
+				yield* cache.set("BTC", ctx, 1000);
+				expect(yield* cache.isFresh("BTC", 5000, 1000)).toBe(true);
+				expect(yield* cache.isFresh("BTC", 5000, 6000)).toBe(true);
+			}),
+		));
+
+	it("considers an entry stale once the staleness window has elapsed", () =>
+		Effect.runPromise(
+			Effect.gen(function* () {
+				const cache = yield* createAssetCache();
+				yield* cache.set("BTC", ctx, 1000);
+				expect(yield* cache.isFresh("BTC", 5000, 6001)).toBe(false);
+			}),
+		));
+
+	it("set overwrites the previous entry and refreshes lastUpdate", () =>
+		Effect.runPromise(
+			Effect.gen(function* () {
+				const cache = yield* createAssetCache();
+				yield* cache.set("BTC", ctx, 1000);
+				yield* cache.set("BTC", { ...ctx, oraclePx: "999" }, 4000);
+				const entry = yield* cache.get("BTC");
+				expect(Option.isSome(entry)).toBe(true);
+				if (Option.isSome(entry)) {
+					expect(entry.value.lastUpdate).toBe(4000);
+					expect(entry.value.ctx.oraclePx).toBe("999");
+				}
+			}),
+		));
+});

--- a/workspace/data-proxy/src/modules/hydromancer/asset-cache.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/asset-cache.ts
@@ -1,0 +1,43 @@
+import { Effect, MutableHashMap, Option } from "effect";
+import type { AssetCtx } from "../../config/hydromancer-module-config";
+
+export interface AssetCacheEntry {
+	ctx: AssetCtx;
+	lastUpdate: number;
+}
+
+export const createAssetCache = () =>
+	Effect.gen(function* () {
+		const entries = MutableHashMap.empty<string, AssetCacheEntry>();
+
+		const set = (coin: string, ctx: AssetCtx, now: number) =>
+			Effect.sync(() => {
+				MutableHashMap.set(entries, coin, { ctx, lastUpdate: now });
+			});
+
+		const get = (coin: string) =>
+			Effect.sync(() => MutableHashMap.get(entries, coin));
+
+		const remove = (coin: string) =>
+			Effect.sync(() => {
+				MutableHashMap.remove(entries, coin);
+			});
+
+		const isFresh = (coin: string, staleAfterMillis: number, now: number) =>
+			Effect.sync(() => {
+				const entry = MutableHashMap.get(entries, coin);
+				if (Option.isNone(entry)) return false;
+				return now - entry.value.lastUpdate <= staleAfterMillis;
+			});
+
+		return {
+			set,
+			get,
+			remove,
+			isFresh,
+		};
+	});
+
+export type AssetCache = Effect.Effect.Success<
+	ReturnType<typeof createAssetCache>
+>;

--- a/workspace/data-proxy/src/modules/hydromancer/errors.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+export class FailedToHandleHydromancerRequestError extends Data.TaggedError(
+	"FailedToHandleHydromancerRequestError",
+)<{ error: string; status: number }> {
+	message = `Hydromancer error: ${this.error}`;
+}

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
@@ -1,0 +1,543 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Duration, Effect } from "effect";
+import * as v from "valibot";
+import {
+	type HydromancerModuleConfig,
+	HydromancerModuleRouteSchema,
+} from "../../config/hydromancer-module-config";
+import { ModuleService } from "../module";
+import { HydromancerModuleService } from "./hydromancer";
+import { buildSubscribeFrame, buildUnsubscribeFrame } from "./ws-client";
+
+const baseConfig: HydromancerModuleConfig = {
+	name: "hydromancer",
+	type: "hydromancer",
+	wsUrl: "wss://api.hydromancer.test/ws",
+	restBaseUrl: "https://api.hydromancer.test",
+	hydromancerApiKeyEnvKey: "HYDROMANCER_API_KEY",
+	hydromancerApiKey: "test-api-key",
+	staleAfter: Duration.seconds(10),
+	subscriptionCoins: [],
+	maxCoinsPerRequest: 20,
+	reconnectMaxBackoff: Duration.seconds(30),
+	reconnectStableThreshold: Duration.seconds(30),
+	coinsCleanupTtl: Duration.minutes(2),
+	coinsCleanupInterval: Duration.seconds(30),
+	restFetchTimeout: Duration.seconds(15),
+};
+
+const btcCtx = {
+	oraclePx: "96500.50",
+	markPx: "96485.25",
+	midPx: "96490.50",
+	impactPxs: ["96490", "96491"],
+	openInterest: "25401.1214",
+};
+
+const ethCtx = {
+	oraclePx: "3450.10",
+	markPx: "3448.75",
+	midPx: "3449.50",
+	impactPxs: ["3449", "3450"],
+	openInterest: "192841.521",
+};
+
+const buildRoute = (fetchFromModule: string) =>
+	v.parse(HydromancerModuleRouteSchema, {
+		type: "hydromancer",
+		moduleName: "hydromancer",
+		path: "/hydromancer/:coin",
+		fetchFromModule,
+	});
+
+const callHandle = (
+	config: HydromancerModuleConfig,
+	fetchFromModule: string,
+	params: Record<string, string>,
+) => {
+	const route = buildRoute(fetchFromModule);
+	const program = Effect.gen(function* () {
+		const svc = yield* ModuleService;
+		return yield* svc.handleRequest(
+			route,
+			params,
+			new Request("http://proxy.local/hydromancer/BTC"),
+		);
+	});
+	return Effect.runPromise(
+		program.pipe(Effect.provide(HydromancerModuleService(config))),
+	);
+};
+
+type CallSpec = { fetchFromModule: string; params: Record<string, string> };
+
+// Runs multiple handleRequest invocations against the SAME module instance,
+// so cache state carries across calls. Returns responses in order.
+const callHandleSequence = (
+	config: HydromancerModuleConfig,
+	calls: CallSpec[],
+	between?: () => Promise<void>,
+) => {
+	const program = Effect.gen(function* () {
+		const svc = yield* ModuleService;
+		const responses: Response[] = [];
+		for (const call of calls) {
+			const route = buildRoute(call.fetchFromModule);
+			const response = yield* svc.handleRequest(
+				route,
+				call.params,
+				new Request("http://proxy.local/hydromancer"),
+			);
+			responses.push(response);
+			if (between) {
+				yield* Effect.promise(() => between());
+			}
+		}
+		return responses;
+	});
+	return Effect.runPromise(
+		program.pipe(Effect.provide(HydromancerModuleService(config))),
+	);
+};
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
+	it("issues a single batch POST and returns one entry per resolved coin", async () => {
+		const fetchMock = mock(
+			async (input: URL | RequestInfo, init?: RequestInit) => {
+				const url =
+					input instanceof URL
+						? input.toString()
+						: ((input as Request).url ?? input);
+				expect(String(url)).toContain("/info");
+				expect(init?.method).toBe("POST");
+				expect(JSON.parse(init?.body as string)).toEqual({
+					type: "assetContext",
+					coins: ["BTC", "ETH"],
+				});
+				expect((init?.headers as Record<string, string>).Authorization).toBe(
+					"Bearer test-api-key",
+				);
+				return new Response(JSON.stringify({ BTC: btcCtx, ETH: ethCtx }), {
+					status: 200,
+				});
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, "BTC,ETH", {});
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const body = await response.json();
+		expect(body).toEqual({ BTC: btcCtx, ETH: ethCtx });
+	});
+
+	it("filters out coins that come back null", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ BTC: btcCtx, ZZZ: null }), {
+					status: 200,
+				}),
+		) as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, "BTC,ZZZ", {});
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({ BTC: btcCtx });
+	});
+
+	it("returns an empty object when every coin is unknown", async () => {
+		globalThis.fetch = mock(
+			async () => new Response(JSON.stringify({ ZZZ: null }), { status: 200 }),
+		) as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, "ZZZ", {});
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({});
+	});
+
+	it("substitutes path params into fetchFromModule", async () => {
+		const captured: { body?: unknown } = {};
+		globalThis.fetch = mock(
+			async (_input: URL | RequestInfo, init?: RequestInit) => {
+				captured.body = JSON.parse(init?.body as string);
+				return new Response(JSON.stringify({ BTC: btcCtx }), { status: 200 });
+			},
+		) as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, "{:coin}", { coin: "BTC" });
+		expect(response.status).toBe(200);
+		expect(captured.body).toEqual({ type: "assetContext", coins: ["BTC"] });
+	});
+
+	it("passes through a 4xx upstream status", async () => {
+		globalThis.fetch = mock(
+			async () => new Response("Bad request", { status: 400 }),
+		) as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, "BTC", {});
+		expect(response.status).toBe(400);
+	});
+
+	it("maps a 5xx upstream status to 502", async () => {
+		globalThis.fetch = mock(
+			async () => new Response("internal", { status: 500 }),
+		) as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, "BTC", {});
+		expect(response.status).toBe(502);
+	});
+
+	it("returns 504 when the fetch times out", async () => {
+		globalThis.fetch = mock(async () => {
+			const error = new Error("aborted");
+			error.name = "TimeoutError";
+			throw error;
+		}) as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, "BTC", {});
+		expect(response.status).toBe(504);
+	});
+
+	it("returns 502 when the response shape is invalid", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ BTC: { oraclePx: 1 } }), {
+					status: 200,
+				}),
+		) as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, "BTC", {});
+		expect(response.status).toBe(502);
+	});
+
+	it("rejects when more coins than maxCoinsPerRequest are requested", async () => {
+		const tightConfig: HydromancerModuleConfig = {
+			...baseConfig,
+			maxCoinsPerRequest: 2,
+		};
+		globalThis.fetch = mock(
+			async () => new Response("{}", { status: 200 }),
+		) as unknown as typeof fetch;
+
+		const response = await callHandle(tightConfig, "BTC,ETH,SOL", {});
+		expect(response.status).toBe(400);
+	});
+});
+
+describe("HydromancerModuleService cache behavior", () => {
+	it("serves a repeat request from cache without hitting REST", async () => {
+		const fetchMock = mock(
+			async () =>
+				new Response(JSON.stringify({ BTC: btcCtx }), { status: 200 }),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const [r1, r2] = await callHandleSequence(baseConfig, [
+			{ fetchFromModule: "BTC", params: {} },
+			{ fetchFromModule: "BTC", params: {} },
+		]);
+
+		expect(r1.status).toBe(200);
+		expect(r2.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(await r1.json()).toEqual({ BTC: btcCtx });
+		expect(await r2.json()).toEqual({ BTC: btcCtx });
+	});
+
+	it("refetches via REST once the entry is older than staleAfter", async () => {
+		const tightConfig: HydromancerModuleConfig = {
+			...baseConfig,
+			staleAfter: Duration.millis(20),
+		};
+		const fetchMock = mock(
+			async () =>
+				new Response(JSON.stringify({ BTC: btcCtx }), { status: 200 }),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		await callHandleSequence(
+			tightConfig,
+			[
+				{ fetchFromModule: "BTC", params: {} },
+				{ fetchFromModule: "BTC", params: {} },
+			],
+			() => new Promise((r) => setTimeout(r, 60)),
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("only batches the coins that need REST, leaving cached coins untouched", async () => {
+		const fetchedBatches: string[][] = [];
+		const fetchMock = mock(
+			async (_input: URL | RequestInfo, init?: RequestInit) => {
+				const body = JSON.parse(init?.body as string);
+				fetchedBatches.push(body.coins);
+				const responseBody: Record<string, typeof btcCtx> = {};
+				for (const coin of body.coins) {
+					if (coin === "BTC") responseBody[coin] = btcCtx;
+					if (coin === "ETH") responseBody[coin] = ethCtx;
+				}
+				return new Response(JSON.stringify(responseBody), { status: 200 });
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const [r1, r2] = await callHandleSequence(baseConfig, [
+			{ fetchFromModule: "BTC", params: {} },
+			{ fetchFromModule: "BTC,ETH", params: {} },
+		]);
+
+		expect(r1.status).toBe(200);
+		expect(r2.status).toBe(200);
+		expect(fetchedBatches).toEqual([["BTC"], ["ETH"]]);
+		expect(await r2.json()).toEqual({ BTC: btcCtx, ETH: ethCtx });
+	});
+});
+
+class FakeWebSocket extends EventTarget {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: FakeWebSocket[] = [];
+
+	url: string;
+	readyState = FakeWebSocket.CONNECTING;
+	sent: string[] = [];
+
+	constructor(url: string) {
+		super();
+		this.url = url;
+		FakeWebSocket.instances.push(this);
+	}
+
+	send(data: string): void {
+		this.sent.push(data);
+	}
+
+	close(): void {
+		this.readyState = FakeWebSocket.CLOSED;
+		this.dispatchEvent(new Event("close"));
+	}
+
+	triggerOpen(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.dispatchEvent(new Event("open"));
+	}
+}
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("HydromancerModuleService demand-driven subscriptions", () => {
+	const originalWebSocket = globalThis.WebSocket;
+
+	beforeEach(() => {
+		FakeWebSocket.instances = [];
+		globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+	});
+
+	afterEach(() => {
+		globalThis.WebSocket = originalWebSocket;
+	});
+
+	it("subscribes via WS for a coin first seen via handleRequest", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ BTC: btcCtx }), { status: 200 }),
+		) as unknown as typeof fetch;
+
+		const config: HydromancerModuleConfig = {
+			...baseConfig,
+			subscriptionCoins: [],
+		};
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			yield* svc.start();
+			const route = buildRoute("BTC");
+			return yield* svc.handleRequest(
+				route,
+				{},
+				new Request("http://proxy.local/hydromancer"),
+			);
+		});
+
+		const response = await Effect.runPromise(
+			program.pipe(Effect.provide(HydromancerModuleService(config))),
+		);
+		expect(response.status).toBe(200);
+
+		await flush();
+		await flush();
+		expect(FakeWebSocket.instances.length).toBe(1);
+		const ws = FakeWebSocket.instances[0];
+
+		ws.triggerOpen();
+		await flush();
+
+		expect(ws.sent).toEqual([buildSubscribeFrame("BTC")]);
+	});
+
+	it("does not enqueue a coin a second time on a repeat handleRequest", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ BTC: btcCtx }), { status: 200 }),
+		) as unknown as typeof fetch;
+
+		const config: HydromancerModuleConfig = {
+			...baseConfig,
+			subscriptionCoins: [],
+		};
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			yield* svc.start();
+			const route = buildRoute("BTC");
+			yield* svc.handleRequest(
+				route,
+				{},
+				new Request("http://proxy.local/hydromancer"),
+			);
+			yield* svc.handleRequest(
+				route,
+				{},
+				new Request("http://proxy.local/hydromancer"),
+			);
+		});
+
+		await Effect.runPromise(
+			program.pipe(Effect.provide(HydromancerModuleService(config))),
+		);
+
+		await flush();
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		// Only one subscribe frame, even though handleRequest was called twice.
+		expect(ws.sent).toEqual([buildSubscribeFrame("BTC")]);
+	});
+
+	it("unsubscribes a coin once it has been idle past coinsCleanupTtl", async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ BTC: btcCtx }), { status: 200 }),
+		) as unknown as typeof fetch;
+
+		const config: HydromancerModuleConfig = {
+			...baseConfig,
+			subscriptionCoins: [],
+			// TTL must be long enough that the cleanup pass cannot fire before the
+			// WS is opened by the test setup; interval is short to keep the test fast.
+			coinsCleanupTtl: Duration.millis(150),
+			coinsCleanupInterval: Duration.millis(20),
+		};
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			yield* svc.start();
+			const route = buildRoute("BTC");
+			yield* svc.handleRequest(
+				route,
+				{},
+				new Request("http://proxy.local/hydromancer"),
+			);
+		});
+
+		await Effect.runPromise(
+			program.pipe(Effect.provide(HydromancerModuleService(config))),
+		);
+
+		await flush();
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		expect(ws.sent).toEqual([buildSubscribeFrame("BTC")]);
+
+		// Wait past TTL + at least one cleanup tick.
+		await new Promise<void>((r) => setTimeout(r, 250));
+
+		expect(ws.sent).toEqual([
+			buildSubscribeFrame("BTC"),
+			buildUnsubscribeFrame("BTC"),
+		]);
+	});
+});
+
+describe("HydromancerModuleService REST fallback when WS is errored", () => {
+	const originalWebSocket = globalThis.WebSocket;
+
+	beforeEach(() => {
+		FakeWebSocket.instances = [];
+		globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+	});
+
+	afterEach(() => {
+		globalThis.WebSocket = originalWebSocket;
+	});
+
+	it("falls through to REST when the WS has been marked errored, even with a fresh cache entry", async () => {
+		const restCalls: string[][] = [];
+		globalThis.fetch = mock(
+			async (_url: URL | RequestInfo, init?: RequestInit) => {
+				const body = JSON.parse((init?.body as string) ?? "{}");
+				restCalls.push(body.coins);
+				return new Response(JSON.stringify({ BTC: btcCtx }), { status: 200 });
+			},
+		) as unknown as typeof fetch;
+
+		const config: HydromancerModuleConfig = {
+			...baseConfig,
+			subscriptionCoins: [],
+		};
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			yield* svc.start();
+
+			// Let the WS daemon construct a FakeWebSocket and then bring it up.
+			yield* Effect.sleep(Duration.millis(0));
+			yield* Effect.sleep(Duration.millis(0));
+			const ws = FakeWebSocket.instances[0];
+			ws.triggerOpen();
+			yield* Effect.sleep(Duration.millis(0));
+
+			const route = buildRoute("BTC");
+
+			// Request 1: cache miss, REST populates BTC.
+			yield* svc.handleRequest(
+				route,
+				{},
+				new Request("http://proxy.local/hydromancer"),
+			);
+
+			// Drop the socket: cache.markSocketError fires, currentWS clears.
+			ws.close();
+			yield* Effect.sleep(Duration.millis(0));
+
+			// Request 2: BTC is fresh in cache but socketError forces another REST.
+			yield* svc.handleRequest(
+				route,
+				{},
+				new Request("http://proxy.local/hydromancer"),
+			);
+		});
+
+		await Effect.runPromise(
+			program.pipe(Effect.provide(HydromancerModuleService(config))),
+		);
+
+		expect(restCalls).toEqual([["BTC"], ["BTC"]]);
+	});
+});

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
@@ -1,0 +1,136 @@
+import { Clock, Duration, Effect, Layer, MutableHashMap, Option } from "effect";
+import type { Route } from "../../config/config-parser";
+import type {
+	AssetCtx,
+	HydromancerModuleConfig,
+} from "../../config/hydromancer-module-config";
+import { createErrorResponse } from "../../controllers/create-error-response";
+import { forkIdleCleanup } from "../../utils/idle-cleanup";
+import { replaceParams } from "../../utils/replace-params";
+import { FailedToHandleRequest, ModuleService } from "../module";
+import { createAssetCache } from "./asset-cache";
+import { FailedToHandleHydromancerRequestError } from "./errors";
+import { fetchAssetContextsFromRest } from "./rest-fallback";
+import { createHydromancerWS } from "./ws-client";
+
+export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
+	Layer.effect(
+		ModuleService,
+		Effect.gen(function* () {
+			yield* Effect.logInfo("Initializing Hydromancer module", {
+				name: config.name,
+				wsUrl: config.wsUrl,
+				restBaseUrl: config.restBaseUrl,
+			});
+
+			const cache = yield* createAssetCache();
+			const ws = yield* createHydromancerWS(config, cache);
+			const staleAfterMillis = Duration.toMillis(config.staleAfter);
+			const lastRequestToCoin = MutableHashMap.empty<string, number>();
+
+			const start = () =>
+				Effect.gen(function* () {
+					yield* Effect.logInfo("Hydromancer module started", {
+						name: config.name,
+					});
+
+					yield* ws.start();
+
+					for (const coin of config.subscriptionCoins) {
+						yield* ws.subscribe(coin);
+					}
+
+					yield* forkIdleCleanup({
+						lastRequest: lastRequestToCoin,
+						ttl: config.coinsCleanupTtl,
+						interval: config.coinsCleanupInterval,
+						onExpire: (coin) =>
+							Effect.gen(function* () {
+								yield* Effect.logInfo("Cleaning up idle coin", { coin });
+								yield* cache.remove(coin);
+								yield* ws.unsubscribe(coin);
+							}),
+					});
+				}).pipe(Effect.annotateLogs("_name", "hydromancer"));
+
+			const handleRequest = (
+				route: Route,
+				params: Record<string, string>,
+				_request: Request,
+			) =>
+				Effect.gen(function* () {
+					if (route.type !== "hydromancer") {
+						return yield* Effect.fail(
+							new FailedToHandleRequest({
+								msg: "Route is not a Hydromancer module",
+							}),
+						);
+					}
+
+					const coins = replaceParams(route.fetchFromModule, params).split(",");
+
+					if (coins.length > config.maxCoinsPerRequest) {
+						return yield* Effect.fail(
+							new FailedToHandleHydromancerRequestError({
+								error: `Too many coins, max is ${config.maxCoinsPerRequest} but got ${coins.length}`,
+								status: 400,
+							}),
+						);
+					}
+
+					const now = yield* Clock.currentTimeMillis;
+					const socketHealthy = !(yield* ws.hasError());
+
+					for (const coin of coins) {
+						yield* ws.subscribe(coin);
+						MutableHashMap.set(lastRequestToCoin, coin, now);
+					}
+
+					const resolved: Record<string, AssetCtx> = {};
+					const toFetch: string[] = [];
+
+					for (const coin of coins) {
+						if (
+							socketHealthy &&
+							(yield* cache.isFresh(coin, staleAfterMillis, now))
+						) {
+							const entry = yield* cache.get(coin);
+							if (Option.isSome(entry)) {
+								resolved[coin] = entry.value.ctx;
+								continue;
+							}
+						}
+						toFetch.push(coin);
+					}
+
+					if (toFetch.length > 0) {
+						const restBatch = yield* fetchAssetContextsFromRest(
+							config,
+							toFetch,
+						);
+						for (const coin of toFetch) {
+							const ctx = restBatch[coin];
+							if (ctx) {
+								yield* cache.set(coin, ctx, now);
+								resolved[coin] = ctx;
+							}
+						}
+					}
+
+					return new Response(JSON.stringify(resolved), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}).pipe(
+					Effect.withSpan("handleHydromancerRequest"),
+					Effect.catchAll((error) =>
+						Effect.succeed(createErrorResponse(error, error.status)),
+					),
+				);
+
+			return {
+				start,
+				handleRequest,
+			};
+		}),
+	);

--- a/workspace/data-proxy/src/modules/hydromancer/rest-fallback.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/rest-fallback.ts
@@ -1,0 +1,86 @@
+import { tryParseSync } from "@seda-protocol/utils";
+import { Duration, Effect } from "effect";
+import * as v from "valibot";
+import {
+	AssetCtxSchema,
+	type HydromancerModuleConfig,
+} from "../../config/hydromancer-module-config";
+import { FailedToHandleHydromancerRequestError } from "./errors";
+
+const BatchResponseSchema = v.record(v.string(), v.nullable(AssetCtxSchema));
+
+export type BatchAssetContexts = v.InferOutput<typeof BatchResponseSchema>;
+
+export const fetchAssetContextsFromRest = (
+	config: HydromancerModuleConfig,
+	coins: string[],
+): Effect.Effect<BatchAssetContexts, FailedToHandleHydromancerRequestError> =>
+	Effect.gen(function* () {
+		const url = new URL("/info", config.restBaseUrl);
+		const timeoutMs = Duration.toMillis(config.restFetchTimeout);
+
+		const response = yield* Effect.tryPromise({
+			try: () =>
+				fetch(url, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: `Bearer ${config.hydromancerApiKey}`,
+					},
+					body: JSON.stringify({ type: "assetContext", coins }),
+					signal: AbortSignal.timeout(timeoutMs),
+				}),
+			catch: (error) => {
+				const isTimeout =
+					error instanceof Error && error.name === "TimeoutError";
+				return new FailedToHandleHydromancerRequestError({
+					error: isTimeout
+						? `Hydromancer REST timed out after ${timeoutMs}ms`
+						: `Failed to fetch from Hydromancer: ${error}`,
+					status: isTimeout ? 504 : 502,
+				});
+			},
+		});
+
+		const responseText = yield* Effect.tryPromise({
+			try: () => response.text(),
+			catch: (error) =>
+				new FailedToHandleHydromancerRequestError({
+					error: `Failed to read Hydromancer response: ${error}`,
+					status: 500,
+				}),
+		});
+
+		if (!response.ok) {
+			const upstreamStatus = response.status;
+			return yield* Effect.fail(
+				new FailedToHandleHydromancerRequestError({
+					error: `Hydromancer responded ${upstreamStatus}: ${responseText}`,
+					status: upstreamStatus >= 500 ? 502 : upstreamStatus,
+				}),
+			);
+		}
+
+		const parsedJson = yield* Effect.try({
+			try: () => JSON.parse(responseText) as unknown,
+			catch: (error) =>
+				new FailedToHandleHydromancerRequestError({
+					error: `Hydromancer returned non-JSON body: ${error}`,
+					status: 502,
+				}),
+		});
+
+		const validated = tryParseSync(BatchResponseSchema, parsedJson);
+		if (validated.isErr) {
+			return yield* Effect.fail(
+				new FailedToHandleHydromancerRequestError({
+					error: `Invalid Hydromancer response shape: ${validated.error
+						.map((e) => e.message)
+						.join(", ")}`,
+					status: 502,
+				}),
+			);
+		}
+
+		return validated.value;
+	});

--- a/workspace/data-proxy/src/modules/hydromancer/ws-client.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/ws-client.test.ts
@@ -1,0 +1,445 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Duration, Effect, Fiber, Option, Schedule } from "effect";
+import type { HydromancerModuleConfig } from "../../config/hydromancer-module-config";
+import { createAssetCache } from "./asset-cache";
+import {
+	buildSubscribeFrame,
+	buildUnsubscribeFrame,
+	createHydromancerWS,
+	parseInboundFrame,
+} from "./ws-client";
+
+const validCtx = {
+	oraclePx: "1",
+	markPx: "2",
+	midPx: "3",
+	impactPxs: ["4", "5"],
+	openInterest: "6",
+};
+
+describe("buildSubscribeFrame / buildUnsubscribeFrame", () => {
+	it("produces the documented subscribe shape", () => {
+		expect(JSON.parse(buildSubscribeFrame("BTC"))).toEqual({
+			method: "subscribe",
+			subscription: { type: "activeAssetCtx", coin: "BTC" },
+		});
+	});
+
+	it("produces the documented unsubscribe shape", () => {
+		expect(JSON.parse(buildUnsubscribeFrame("ETH"))).toEqual({
+			method: "unsubscribe",
+			subscription: { type: "activeAssetCtx", coin: "ETH" },
+		});
+	});
+});
+
+describe("parseInboundFrame", () => {
+	it("extracts {coin, ctx} from a valid activeAssetCtx frame", () => {
+		const frame = JSON.stringify({
+			channel: "activeAssetCtx",
+			seq: 1,
+			cursor: "x",
+			data: { coin: "ETH", ctx: validCtx },
+		});
+		expect(parseInboundFrame(frame)).toEqual({ coin: "ETH", ctx: validCtx });
+	});
+
+	it("returns null for a non-activeAssetCtx channel", () => {
+		expect(parseInboundFrame(JSON.stringify({ channel: "pong" }))).toBeNull();
+	});
+
+	it("returns null for malformed JSON", () => {
+		expect(parseInboundFrame("not json")).toBeNull();
+	});
+
+	it("returns null when data is missing", () => {
+		expect(
+			parseInboundFrame(JSON.stringify({ channel: "activeAssetCtx" })),
+		).toBeNull();
+	});
+
+	it("returns null when ctx fields have the wrong types", () => {
+		expect(
+			parseInboundFrame(
+				JSON.stringify({
+					channel: "activeAssetCtx",
+					data: { coin: "BTC", ctx: { oraclePx: 123 } },
+				}),
+			),
+		).toBeNull();
+	});
+
+	it("accepts null openInterest (testnet returns it)", () => {
+		const ctxNullOI = { ...validCtx, openInterest: null };
+		const frame = JSON.stringify({
+			channel: "activeAssetCtx",
+			data: { coin: "BTC", ctx: ctxNullOI },
+		});
+		expect(parseInboundFrame(frame)).toEqual({ coin: "BTC", ctx: ctxNullOI });
+	});
+
+	it("accepts null midPx and impactPxs (some non-perp assets return them)", () => {
+		const ctxPartial = {
+			oraclePx: "151.81",
+			markPx: "374.5",
+			midPx: null,
+			impactPxs: null,
+			openInterest: null,
+		};
+		const frame = JSON.stringify({
+			channel: "activeAssetCtx",
+			data: { coin: "bmx:TSLA", ctx: ctxPartial },
+		});
+		expect(parseInboundFrame(frame)).toEqual({
+			coin: "bmx:TSLA",
+			ctx: ctxPartial,
+		});
+	});
+});
+
+class FakeWebSocket extends EventTarget {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: FakeWebSocket[] = [];
+	static sendImpl?: (instance: FakeWebSocket, data: string) => void;
+
+	url: string;
+	readyState = FakeWebSocket.CONNECTING;
+	sent: string[] = [];
+
+	constructor(url: string) {
+		super();
+		this.url = url;
+		FakeWebSocket.instances.push(this);
+	}
+
+	send(data: string): void {
+		if (FakeWebSocket.sendImpl) {
+			FakeWebSocket.sendImpl(this, data);
+			return;
+		}
+		this.sent.push(data);
+	}
+
+	close(): void {
+		if (this.readyState === FakeWebSocket.CLOSED) return;
+		this.readyState = FakeWebSocket.CLOSED;
+		this.dispatchEvent(new Event("close"));
+	}
+
+	triggerOpen(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.dispatchEvent(new Event("open"));
+	}
+
+	triggerMessage(data: string): void {
+		this.dispatchEvent(new MessageEvent("message", { data }));
+	}
+
+	triggerClose(): void {
+		if (this.readyState === FakeWebSocket.CLOSED) return;
+		this.readyState = FakeWebSocket.CLOSED;
+		this.dispatchEvent(new Event("close"));
+	}
+}
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+const baseConfig: HydromancerModuleConfig = {
+	name: "hydromancer",
+	type: "hydromancer",
+	wsUrl: "wss://api.hydromancer.test/ws",
+	restBaseUrl: "https://api.hydromancer.test",
+	hydromancerApiKeyEnvKey: "HYDROMANCER_API_KEY",
+	hydromancerApiKey: "test-api-key",
+	staleAfter: Duration.seconds(10),
+	subscriptionCoins: ["BTC", "ETH"],
+	maxCoinsPerRequest: 20,
+	reconnectMaxBackoff: Duration.seconds(30),
+	reconnectStableThreshold: Duration.seconds(30),
+	coinsCleanupTtl: Duration.minutes(2),
+	coinsCleanupInterval: Duration.seconds(30),
+	restFetchTimeout: Duration.seconds(15),
+};
+
+const originalWebSocket = globalThis.WebSocket;
+
+beforeEach(() => {
+	FakeWebSocket.instances = [];
+	FakeWebSocket.sendImpl = undefined;
+	globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+	globalThis.WebSocket = originalWebSocket;
+});
+
+const startService = (
+	config: HydromancerModuleConfig,
+	preSubscribed: string[] = config.subscriptionCoins,
+	options?: Parameters<typeof createHydromancerWS>[2],
+) =>
+	Effect.gen(function* () {
+		const cache = yield* createAssetCache();
+		const ws = yield* createHydromancerWS(
+			config,
+			cache,
+			options ?? { reconnectSchedule: Schedule.spaced(Duration.minutes(10)) },
+		);
+		for (const coin of preSubscribed) {
+			yield* ws.subscribe(coin);
+		}
+		const fiber = yield* ws.start();
+		return { cache, ws, fiber };
+	});
+
+describe("createHydromancerWS", () => {
+	it("opens the WS with the token query and sends subscribe frames on open", async () => {
+		const { fiber, ws: service } = await Effect.runPromise(
+			startService(baseConfig),
+		);
+		await flush();
+
+		expect(FakeWebSocket.instances.length).toBe(1);
+		const ws = FakeWebSocket.instances[0];
+		expect(ws.url).toBe("wss://api.hydromancer.test/ws?token=test-api-key");
+
+		ws.triggerOpen();
+		await flush();
+
+		expect(ws.sent).toEqual([
+			buildSubscribeFrame("BTC"),
+			buildSubscribeFrame("ETH"),
+		]);
+		expect(await Effect.runPromise(service.hasError())).toBe(false);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("writes inbound frames for desired coins into the cache", async () => {
+		const { cache, fiber } = await Effect.runPromise(startService(baseConfig));
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		ws.triggerMessage(
+			JSON.stringify({
+				channel: "activeAssetCtx",
+				seq: 1,
+				data: { coin: "BTC", ctx: validCtx },
+			}),
+		);
+		await flush();
+
+		const entry = await Effect.runPromise(cache.get("BTC"));
+		expect(Option.isSome(entry)).toBe(true);
+		if (Option.isSome(entry)) {
+			expect(entry.value.ctx).toEqual(validCtx);
+		}
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("drops inbound frames for coins not in the desired set", async () => {
+		const { cache, fiber } = await Effect.runPromise(
+			startService(baseConfig, ["BTC"]),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		ws.triggerMessage(
+			JSON.stringify({
+				channel: "activeAssetCtx",
+				seq: 1,
+				data: { coin: "ETH", ctx: validCtx },
+			}),
+		);
+		await flush();
+
+		expect(Option.isNone(await Effect.runPromise(cache.get("ETH")))).toBe(true);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("marks hasError after the socket closes", async () => {
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+		expect(await Effect.runPromise(service.hasError())).toBe(false);
+
+		ws.triggerClose();
+		await flush();
+
+		expect(await Effect.runPromise(service.hasError())).toBe(true);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("ignores frames whose channel is not activeAssetCtx", async () => {
+		const { cache, fiber } = await Effect.runPromise(startService(baseConfig));
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		ws.triggerMessage(JSON.stringify({ channel: "pong" }));
+		ws.triggerMessage("not json");
+		await flush();
+
+		const entry = await Effect.runPromise(cache.get("BTC"));
+		expect(Option.isNone(entry)).toBe(true);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("subscribe is idempotent: a duplicate call sends no extra frame", async () => {
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, ["BTC"]),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+		expect(ws.sent).toEqual([buildSubscribeFrame("BTC")]);
+
+		await Effect.runPromise(service.subscribe("BTC"));
+		await Effect.runPromise(service.subscribe("BTC"));
+		await flush();
+
+		expect(ws.sent).toEqual([buildSubscribeFrame("BTC")]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("unsubscribe is idempotent: a call for an unknown coin sends no frame", async () => {
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, ["BTC"]),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		await Effect.runPromise(service.unsubscribe("ETH"));
+		await flush();
+		expect(ws.sent).toEqual([buildSubscribeFrame("BTC")]);
+
+		await Effect.runPromise(service.unsubscribe("BTC"));
+		await flush();
+		expect(ws.sent).toEqual([
+			buildSubscribeFrame("BTC"),
+			buildUnsubscribeFrame("BTC"),
+		]);
+
+		await Effect.runPromise(service.unsubscribe("BTC"));
+		await flush();
+		expect(ws.sent).toEqual([
+			buildSubscribeFrame("BTC"),
+			buildUnsubscribeFrame("BTC"),
+		]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("reconnects after a close, producing a second WebSocket instance", async () => {
+		const fastSchedule = Schedule.spaced(Duration.millis(10));
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, baseConfig.subscriptionCoins, {
+				reconnectSchedule: fastSchedule,
+			}),
+		);
+		await flush();
+
+		expect(FakeWebSocket.instances.length).toBe(1);
+		const ws1 = FakeWebSocket.instances[0];
+		ws1.triggerOpen();
+		await flush();
+
+		ws1.triggerClose();
+		await new Promise<void>((r) => setTimeout(r, 40));
+
+		expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+		const ws2 = FakeWebSocket.instances[1];
+		expect(ws2).not.toBe(ws1);
+
+		ws2.triggerOpen();
+		await flush();
+		expect(await Effect.runPromise(service.hasError())).toBe(false);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("re-subscribes every desired coin after reconnect", async () => {
+		const fastSchedule = Schedule.spaced(Duration.millis(10));
+		const { fiber } = await Effect.runPromise(
+			startService(baseConfig, baseConfig.subscriptionCoins, {
+				reconnectSchedule: fastSchedule,
+			}),
+		);
+		await flush();
+
+		const ws1 = FakeWebSocket.instances[0];
+		ws1.triggerOpen();
+		await flush();
+		expect(ws1.sent).toEqual([
+			buildSubscribeFrame("BTC"),
+			buildSubscribeFrame("ETH"),
+		]);
+
+		ws1.triggerClose();
+		await new Promise<void>((r) => setTimeout(r, 40));
+
+		const ws2 = FakeWebSocket.instances[1];
+		ws2.triggerOpen();
+		await flush();
+
+		expect(ws2.sent).toEqual([
+			buildSubscribeFrame("BTC"),
+			buildSubscribeFrame("ETH"),
+		]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("recovers from a send error by closing the socket and reconnecting", async () => {
+		const fastSchedule = Schedule.spaced(Duration.millis(10));
+		// First instance throws on send; second instance accepts normally.
+		FakeWebSocket.sendImpl = (instance, data) => {
+			if (FakeWebSocket.instances.indexOf(instance) === 0) {
+				throw new Error("send-blew-up");
+			}
+			instance.sent.push(data);
+		};
+
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, ["BTC"], {
+				reconnectSchedule: fastSchedule,
+			}),
+		);
+		await flush();
+
+		const ws1 = FakeWebSocket.instances[0];
+		ws1.triggerOpen();
+		await flush();
+
+		await new Promise<void>((r) => setTimeout(r, 40));
+		expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+		const ws2 = FakeWebSocket.instances[1];
+		ws2.triggerOpen();
+		await flush();
+
+		expect(ws2.sent).toEqual([buildSubscribeFrame("BTC")]);
+		expect(await Effect.runPromise(service.hasError())).toBe(false);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+});

--- a/workspace/data-proxy/src/modules/hydromancer/ws-client.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/ws-client.ts
@@ -1,0 +1,216 @@
+import { tryParseSync } from "@seda-protocol/utils";
+import {
+	Clock,
+	Deferred,
+	Duration,
+	Effect,
+	type Fiber,
+	MutableHashMap,
+	Option,
+	Runtime,
+	Schedule,
+} from "effect";
+import * as v from "valibot";
+import {
+	type AssetCtx,
+	AssetCtxSchema,
+	type HydromancerModuleConfig,
+} from "../../config/hydromancer-module-config";
+import type { AssetCache } from "./asset-cache";
+
+const InboundFrameSchema = v.object({
+	channel: v.string(),
+	data: v.optional(
+		v.object({
+			coin: v.string(),
+			ctx: AssetCtxSchema,
+		}),
+	),
+});
+
+export interface InboundActiveAssetCtx {
+	coin: string;
+	ctx: AssetCtx;
+}
+
+export const buildSubscribeFrame = (coin: string): string =>
+	JSON.stringify({
+		method: "subscribe",
+		subscription: { type: "activeAssetCtx", coin },
+	});
+
+export const buildUnsubscribeFrame = (coin: string): string =>
+	JSON.stringify({
+		method: "unsubscribe",
+		subscription: { type: "activeAssetCtx", coin },
+	});
+
+export const parseInboundFrame = (
+	raw: string,
+): InboundActiveAssetCtx | null => {
+	let json: unknown;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	const parsed = tryParseSync(InboundFrameSchema, json);
+	if (parsed.isErr) return null;
+	if (parsed.value.channel !== "activeAssetCtx" || !parsed.value.data) {
+		return null;
+	}
+	return parsed.value.data;
+};
+
+export const defaultReconnectSchedule = (config: HydromancerModuleConfig) =>
+	Schedule.exponential(Duration.seconds(1)).pipe(
+		Schedule.either(Schedule.spaced(config.reconnectMaxBackoff)),
+		Schedule.resetAfter(config.reconnectStableThreshold),
+	);
+
+export interface HydromancerWS {
+	/** Forks the WS daemon. The daemon owns reconnect with backoff and resubscribes on each open. */
+	start(): Effect.Effect<Fiber.RuntimeFiber<unknown, unknown>, never, never>;
+	/** Adds the coin to the desired set and sends a subscribe frame if connected. Idempotent. */
+	subscribe(coin: string): Effect.Effect<void, never, never>;
+	/** Removes the coin from the desired set and sends an unsubscribe frame if connected. Idempotent. */
+	unsubscribe(coin: string): Effect.Effect<void, never, never>;
+	/** True while the socket is disconnected, errored, or has a pending send failure. */
+	hasError(): Effect.Effect<boolean, never, never>;
+}
+
+export interface CreateHydromancerWSOptions {
+	reconnectSchedule?: Schedule.Schedule<unknown, unknown, never>;
+}
+
+export const createHydromancerWS = (
+	config: HydromancerModuleConfig,
+	cache: AssetCache,
+	options?: CreateHydromancerWSOptions,
+): Effect.Effect<HydromancerWS, never, never> =>
+	Effect.gen(function* () {
+		const runtime = yield* Effect.runtime<never>();
+		const desiredCoins = MutableHashMap.empty<string, true>();
+		let currentWS: WebSocket | null = null;
+		let socketError: string | undefined;
+		const schedule =
+			options?.reconnectSchedule ?? defaultReconnectSchedule(config);
+
+		const trySend = (frame: string) =>
+			Effect.gen(function* () {
+				const ws = currentWS;
+				if (ws === null || ws.readyState !== WebSocket.OPEN) return;
+				try {
+					ws.send(frame);
+				} catch (err) {
+					socketError = `ws send failed: ${String(err)}`;
+					yield* Effect.logWarning("Hydromancer WS send failed", {
+						error: String(err),
+					});
+					try {
+						ws.close();
+					} catch {
+						// best-effort; the close listener will trigger the reconnect loop.
+					}
+				}
+			});
+
+		const subscribe = (coin: string) =>
+			Effect.gen(function* () {
+				if (Option.isSome(MutableHashMap.get(desiredCoins, coin))) return;
+				MutableHashMap.set(desiredCoins, coin, true);
+				yield* trySend(buildSubscribeFrame(coin));
+			});
+
+		const unsubscribe = (coin: string) =>
+			Effect.gen(function* () {
+				if (Option.isNone(MutableHashMap.get(desiredCoins, coin))) return;
+				MutableHashMap.remove(desiredCoins, coin);
+				yield* trySend(buildUnsubscribeFrame(coin));
+			});
+
+		const hasError = () => Effect.sync(() => socketError !== undefined);
+
+		const handleOpen = (ws: WebSocket) =>
+			Effect.gen(function* () {
+				yield* Effect.logInfo("Hydromancer WS open", { name: config.name });
+				socketError = undefined;
+				currentWS = ws;
+				for (const [coin] of desiredCoins) {
+					yield* trySend(buildSubscribeFrame(coin));
+				}
+			});
+
+		const handleInboundMessage = (raw: string) =>
+			Effect.gen(function* () {
+				const frame = parseInboundFrame(raw);
+				if (!frame) return;
+				if (Option.isNone(MutableHashMap.get(desiredCoins, frame.coin))) {
+					return;
+				}
+				const now = yield* Clock.currentTimeMillis;
+				yield* cache.set(frame.coin, frame.ctx, now);
+			});
+
+		const handleDisconnect = (
+			reason: "close" | "error",
+			closed: Deferred.Deferred<void, "close" | "error">,
+		) =>
+			Effect.gen(function* () {
+				yield* Effect.logWarning("Hydromancer WS disconnected", { reason });
+				socketError = `ws ${reason}`;
+				currentWS = null;
+				yield* Deferred.fail(closed, reason);
+			});
+
+		const connectOnce = Effect.gen(function* () {
+			const wsUrl = `${config.wsUrl}?token=${encodeURIComponent(
+				config.hydromancerApiKey,
+			)}`;
+			const closed = yield* Deferred.make<void, "close" | "error">();
+
+			yield* Effect.logInfo("Hydromancer WS connecting", {
+				name: config.name,
+			});
+
+			const ws = yield* Effect.acquireRelease(
+				Effect.sync(() => new WebSocket(wsUrl)),
+				(socket) =>
+					Effect.sync(() => {
+						if (socket.readyState !== WebSocket.CLOSED) {
+							socket.close();
+						}
+					}),
+			);
+
+			ws.addEventListener("open", () => {
+				Runtime.runSync(runtime, handleOpen(ws));
+			});
+			ws.addEventListener("message", (event) => {
+				if (typeof event.data !== "string") return;
+				Runtime.runSync(runtime, handleInboundMessage(event.data));
+			});
+			ws.addEventListener("close", () => {
+				Runtime.runSync(runtime, handleDisconnect("close", closed));
+			});
+			ws.addEventListener("error", () => {
+				Runtime.runSync(runtime, handleDisconnect("error", closed));
+			});
+
+			yield* Deferred.await(closed);
+		}).pipe(Effect.scoped);
+
+		const loop = connectOnce.pipe(
+			Effect.tapError((error) =>
+				Effect.sync(() => {
+					socketError = `ws connect failed: ${String(error)}`;
+				}),
+			),
+			Effect.retry(schedule),
+		);
+
+		const cachedStart = yield* Effect.cached(Effect.forkDaemon(loop));
+		const start = () => cachedStart;
+
+		return { start, subscribe, unsubscribe, hasError } satisfies HydromancerWS;
+	});

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -6,18 +6,17 @@ import {
 import {
 	Clock,
 	Data,
-	Duration,
 	Effect,
 	Layer,
 	MutableHashMap,
 	Option,
 	Queue,
 	Runtime,
-	Schedule,
 } from "effect";
 import type { Route } from "../../config/config-parser";
 import type { PythLazerModuleConfig } from "../../config/pyth-lazer-module-config";
 import { createErrorResponse } from "../../controllers/create-error-response";
+import { forkIdleCleanup } from "../../utils/idle-cleanup";
 import { replaceParams } from "../../utils/replace-params";
 import { FailedToHandleRequest, ModuleService } from "../module";
 import {
@@ -229,59 +228,34 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 						}).pipe(Effect.forever),
 					);
 
-					yield* Effect.forkDaemon(
-						Effect.gen(function* () {
-							const now = yield* Clock.currentTimeMillis;
-							yield* Effect.logDebug(
-								`Cleaning up price feeds (currently running ${priceCache.size()} price feeds)..`,
-							);
+					yield* forkIdleCleanup({
+						lastRequest: lastRequestToPriceFeed,
+						ttl: config.priceFeedsCleanupTtl,
+						interval: config.priceFeedsCleanupInterval,
+						onExpire: (priceFeedId) =>
+							Effect.gen(function* () {
+								yield* Effect.logInfo(`Cleaning up price feed ${priceFeedId}`);
+								yield* priceCache.deletePrice(priceFeedId);
 
-							for (const [
-								priceFeedId,
-								lastRequestTimestamp,
-							] of lastRequestToPriceFeed) {
-								const cleanupInterval = Duration.toMillis(
-									config.priceFeedsCleanupTtl,
+								const subscriptionId = MutableHashMap.get(
+									subscriptions,
+									priceFeedId,
 								);
-								const timeSinceLastRequest = now - lastRequestTimestamp;
+								if (Option.isSome(subscriptionId)) {
+									lazerClient.unsubscribe(subscriptionId.value);
+									MutableHashMap.remove(subscriptions, priceFeedId);
 
-								yield* Effect.logDebug(
-									`Time since last request for price feed ${priceFeedId}: ${Duration.format(Duration.decode(timeSinceLastRequest))}`,
-								);
-
-								if (timeSinceLastRequest > cleanupInterval) {
-									yield* Effect.logInfo(
-										`Cleaning up price feed ${priceFeedId}`,
-									);
-									MutableHashMap.remove(lastRequestToPriceFeed, priceFeedId);
-									yield* priceCache.deletePrice(priceFeedId);
-
-									const subscriptionId = MutableHashMap.get(
-										subscriptions,
-										priceFeedId,
-									);
-
-									if (Option.isSome(subscriptionId)) {
-										lazerClient.unsubscribe(subscriptionId.value);
-										MutableHashMap.remove(subscriptions, priceFeedId);
-
-										const symbol = getSymbolByPriceFeedId(priceFeedId);
-										if (Option.isSome(symbol)) {
-											MutableHashMap.remove(symbolsToId, symbol.value);
-										}
-
-										yield* Effect.logInfo(
-											`Unsubscribed from price feed ${priceFeedId}`,
-										);
+									const symbol = getSymbolByPriceFeedId(priceFeedId);
+									if (Option.isSome(symbol)) {
+										MutableHashMap.remove(symbolsToId, symbol.value);
 									}
+
+									yield* Effect.logInfo(
+										`Unsubscribed from price feed ${priceFeedId}`,
+									);
 								}
-							}
-						}).pipe(
-							Effect.schedule(
-								Schedule.spaced(config.priceFeedsCleanupInterval),
-							),
-						),
-					);
+							}),
+					});
 				}).pipe(Effect.annotateLogs("_name", "pyth-lazer"));
 
 			const handleRequest = (

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -18,6 +18,7 @@ import { DEFAULT_PROXY_ROUTE_GROUP } from "./constants";
 import { handleProxyRequest } from "./controllers/proxy/handle-proxy-request";
 import { ChainlinkStreamsModuleService } from "./modules/chainlink-streams/chainlink-streams";
 import { DxFeedModuleService } from "./modules/dxfeed/dxfeed";
+import { HydromancerModuleService } from "./modules/hydromancer/hydromancer";
 import { EmptyModuleService, ModuleService } from "./modules/module";
 import { PythLazerModuleService } from "./modules/pyth-lazer/pyth-lazer";
 import type { HttpClientService } from "./services/http-client";
@@ -52,6 +53,9 @@ export const startProxyServer = (
 				Match.when({ type: "dxfeed" }, (m) =>
 					Layer.memoize(DxFeedModuleService(m)),
 				),
+				Match.when({ type: "hydromancer" }, (m) =>
+					Layer.memoize(HydromancerModuleService(m)),
+				),
 				Match.exhaustive,
 			);
 
@@ -68,7 +72,8 @@ export const startProxyServer = (
 			if (
 				route.type === "pyth-lazer" ||
 				route.type === "chainlink-streams" ||
-				route.type === "dxfeed"
+				route.type === "dxfeed" ||
+				route.type === "hydromancer"
 			) {
 				const moduleLayer = MutableHashMap.get(modules, route.moduleName);
 				if (Option.isNone(moduleLayer)) {

--- a/workspace/data-proxy/src/utils/idle-cleanup.test.ts
+++ b/workspace/data-proxy/src/utils/idle-cleanup.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "bun:test";
+import {
+	Clock,
+	Duration,
+	Effect,
+	Fiber,
+	MutableHashMap,
+	Option,
+	TestClock,
+	TestContext,
+} from "effect";
+import { forkIdleCleanup } from "./idle-cleanup";
+
+const provideTestClock = <A, E>(effect: Effect.Effect<A, E, never>) =>
+	Effect.runPromise(effect.pipe(Effect.provide(TestContext.TestContext)));
+
+describe("forkIdleCleanup", () => {
+	it("removes an entry that has been idle past the TTL and calls onExpire once", async () => {
+		const lastRequest = MutableHashMap.empty<string, number>();
+		const expired: string[] = [];
+
+		await provideTestClock(
+			Effect.gen(function* () {
+				const now = yield* Clock.currentTimeMillis;
+				MutableHashMap.set(lastRequest, "BTC", now);
+
+				const fiber = yield* forkIdleCleanup({
+					lastRequest,
+					ttl: Duration.seconds(60),
+					interval: Duration.seconds(30),
+					onExpire: (key) =>
+						Effect.sync(() => {
+							expired.push(key);
+						}),
+				});
+
+				yield* TestClock.adjust(Duration.seconds(91));
+
+				expect(Option.isNone(MutableHashMap.get(lastRequest, "BTC"))).toBe(
+					true,
+				);
+				expect(expired).toEqual(["BTC"]);
+
+				yield* Fiber.interrupt(fiber);
+			}),
+		);
+	});
+
+	it("leaves a fresh entry alone within the TTL window", async () => {
+		const lastRequest = MutableHashMap.empty<string, number>();
+		const expired: string[] = [];
+
+		await provideTestClock(
+			Effect.gen(function* () {
+				const now = yield* Clock.currentTimeMillis;
+				MutableHashMap.set(lastRequest, "BTC", now);
+
+				const fiber = yield* forkIdleCleanup({
+					lastRequest,
+					ttl: Duration.seconds(60),
+					interval: Duration.seconds(30),
+					onExpire: (key) =>
+						Effect.sync(() => {
+							expired.push(key);
+						}),
+				});
+
+				yield* TestClock.adjust(Duration.seconds(45));
+
+				expect(Option.isSome(MutableHashMap.get(lastRequest, "BTC"))).toBe(
+					true,
+				);
+				expect(expired).toEqual([]);
+
+				yield* Fiber.interrupt(fiber);
+			}),
+		);
+	});
+
+	it("preserves an entry whose timestamp is refreshed before the next pass", async () => {
+		const lastRequest = MutableHashMap.empty<string, number>();
+		const expired: string[] = [];
+
+		await provideTestClock(
+			Effect.gen(function* () {
+				const start = yield* Clock.currentTimeMillis;
+				MutableHashMap.set(lastRequest, "BTC", start);
+
+				const fiber = yield* forkIdleCleanup({
+					lastRequest,
+					ttl: Duration.seconds(60),
+					interval: Duration.seconds(30),
+					onExpire: (key) =>
+						Effect.sync(() => {
+							expired.push(key);
+						}),
+				});
+
+				yield* TestClock.adjust(Duration.seconds(45));
+				const refreshed = yield* Clock.currentTimeMillis;
+				MutableHashMap.set(lastRequest, "BTC", refreshed);
+
+				yield* TestClock.adjust(Duration.seconds(45));
+
+				expect(Option.isSome(MutableHashMap.get(lastRequest, "BTC"))).toBe(
+					true,
+				);
+				expect(expired).toEqual([]);
+
+				yield* Fiber.interrupt(fiber);
+			}),
+		);
+	});
+
+	it("expires only the stale entries when both ages are present at start", async () => {
+		const lastRequest = MutableHashMap.empty<string, number>();
+		const expired: string[] = [];
+
+		await provideTestClock(
+			Effect.gen(function* () {
+				yield* TestClock.adjust(Duration.seconds(100));
+				const now = yield* Clock.currentTimeMillis;
+				MutableHashMap.set(lastRequest, "STALE", now - 90_000);
+				MutableHashMap.set(lastRequest, "FRESH", now - 5_000);
+
+				const fiber = yield* forkIdleCleanup({
+					lastRequest,
+					ttl: Duration.seconds(60),
+					interval: Duration.seconds(30),
+					onExpire: (key) =>
+						Effect.sync(() => {
+							expired.push(key);
+						}),
+				});
+
+				yield* TestClock.adjust(Duration.seconds(31));
+
+				expect(Option.isNone(MutableHashMap.get(lastRequest, "STALE"))).toBe(
+					true,
+				);
+				expect(Option.isSome(MutableHashMap.get(lastRequest, "FRESH"))).toBe(
+					true,
+				);
+				expect(expired).toEqual(["STALE"]);
+
+				yield* Fiber.interrupt(fiber);
+			}),
+		);
+	});
+
+	it("does not call onExpire while every entry is still fresh", async () => {
+		const lastRequest = MutableHashMap.empty<string, number>();
+
+		await provideTestClock(
+			Effect.gen(function* () {
+				const now = yield* Clock.currentTimeMillis;
+				MutableHashMap.set(lastRequest, "BTC", now);
+				MutableHashMap.set(lastRequest, "ETH", now);
+
+				const fiber = yield* forkIdleCleanup({
+					lastRequest,
+					ttl: Duration.seconds(60),
+					interval: Duration.seconds(30),
+					onExpire: () =>
+						Effect.die("onExpire must not be called while entries are fresh"),
+				});
+
+				yield* TestClock.adjust(Duration.seconds(45));
+
+				expect(MutableHashMap.size(lastRequest)).toBe(2);
+
+				yield* Fiber.interrupt(fiber);
+			}),
+		);
+	});
+
+	it("retains an entry on onExpire failure and removes it on the next pass", async () => {
+		const lastRequest = MutableHashMap.empty<string, number>();
+		const expired: string[] = [];
+		let failOnce = true;
+
+		await provideTestClock(
+			Effect.gen(function* () {
+				yield* TestClock.adjust(Duration.seconds(100));
+				const now = yield* Clock.currentTimeMillis;
+				MutableHashMap.set(lastRequest, "BTC", now - 90_000);
+
+				const fiber = yield* forkIdleCleanup({
+					lastRequest,
+					ttl: Duration.seconds(60),
+					interval: Duration.seconds(30),
+					onExpire: (key) =>
+						Effect.gen(function* () {
+							if (failOnce) {
+								failOnce = false;
+								return yield* Effect.fail(new Error("boom"));
+							}
+							expired.push(key);
+						}),
+				});
+
+				yield* TestClock.adjust(Duration.seconds(31));
+				expect(Option.isSome(MutableHashMap.get(lastRequest, "BTC"))).toBe(
+					true,
+				);
+				expect(expired).toEqual([]);
+
+				yield* TestClock.adjust(Duration.seconds(30));
+				expect(Option.isNone(MutableHashMap.get(lastRequest, "BTC"))).toBe(
+					true,
+				);
+				expect(expired).toEqual(["BTC"]);
+
+				yield* Fiber.interrupt(fiber);
+			}),
+		);
+	});
+});

--- a/workspace/data-proxy/src/utils/idle-cleanup.ts
+++ b/workspace/data-proxy/src/utils/idle-cleanup.ts
@@ -1,0 +1,49 @@
+import {
+	Clock,
+	Duration,
+	Effect,
+	type Fiber,
+	MutableHashMap,
+	Schedule,
+} from "effect";
+
+export interface ForkIdleCleanupOptions<K> {
+	/** Map of key to "last requested at" timestamp in milliseconds. */
+	lastRequest: MutableHashMap.MutableHashMap<K, number>;
+	/** Entries older than this are considered stale and removed. */
+	ttl: Duration.Duration;
+	/** Cadence at which the cleanup pass runs. */
+	interval: Duration.Duration;
+	/** Called once per stale key. The entry is removed only after this succeeds, so a failure is retried on the next pass. */
+	onExpire: (key: K) => Effect.Effect<void, unknown>;
+}
+
+/**
+ * Runs a forked daemon that periodically removes idle entries from
+ * `lastRequest` and calls `onExpire` for each removed key.
+ *
+ * Used by stream-subscription modules to drop subscriptions for
+ * keys nobody has asked for in a while.
+ */
+export const forkIdleCleanup = <K>(
+	options: ForkIdleCleanupOptions<K>,
+): Effect.Effect<Fiber.RuntimeFiber<unknown, unknown>, never, never> =>
+	Effect.forkDaemon(
+		Effect.gen(function* () {
+			const now = yield* Clock.currentTimeMillis;
+			const ttlMs = Duration.toMillis(options.ttl);
+			for (const [key, lastTs] of options.lastRequest) {
+				if (now - lastTs > ttlMs) {
+					const result = yield* Effect.either(options.onExpire(key));
+					if (result._tag === "Left") {
+						yield* Effect.logWarning(
+							"idle-cleanup onExpire failed; will retry next pass",
+							{ error: result.left },
+						);
+						continue;
+					}
+					MutableHashMap.remove(options.lastRequest, key);
+				}
+			}
+		}).pipe(Effect.schedule(Schedule.spaced(options.interval))),
+	);


### PR DESCRIPTION
Adds a `hydromancer` module type. The WS connection holds a per-coin `activeAssetCtx` cache; the first request for a coin enqueues a subscribe and is served via the batch REST endpoint until the cache warms, then subsequent requests within the staleness window serve from memory. When the WS is down or the cached frame is stale, the request falls through to REST. Response shape is `{coin: ctx}`, matching the upstream batch endpoint and the existing passthrough route, so callers can swap between the two without reshaping.

- Demand-driven subscribe pattern mirrors `pyth-lazer` (Queue + forkDaemon, single subscribe call site). Idle cleanup is also factored into a shared `forkIdleCleanup` helper used by both modules.
