### PR TITLE
LO:TECH WebSocket module

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "workspace/data-proxy": {
       "name": "@seda-protocol/data-proxy",
-      "version": "2.2.0",
+      "version": "2.4.0",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",
         "@cosmjs/crypto": "^0.33.1",
@@ -44,9 +44,13 @@
         "secp256k1": "^5.0.1",
         "true-myth": "9.0.1",
         "valibot": "1.1.0",
+        "winston": "^3.17.0",
+        "winston-daily-rotate-file": "^5.0.0",
+        "ws": "^8.20.0",
       },
       "devDependencies": {
         "@types/big.js": "^6.2.2",
+        "@types/ws": "^8.18.1",
         "msw": "2.3.1",
       },
     },
@@ -95,6 +99,8 @@
 
     "@bundled-es-modules/statuses": ["@bundled-es-modules/statuses@1.0.1", "", { "dependencies": { "statuses": "^2.0.1" } }, "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg=="],
 
+    "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
+
     "@commander-js/extra-typings": ["@commander-js/extra-typings@12.1.0", "", { "peerDependencies": { "commander": "~12.1.0" } }, "sha512-wf/lwQvWAA0goIghcb91dQYpkLBcyhOhQNqG/VgWhnKzgt+UOMvra7EX/2fv70arm5RW+PUHoQHHDa6/p77Eqg=="],
 
     "@cosmjs/amino": ["@cosmjs/amino@0.33.1", "", { "dependencies": { "@cosmjs/crypto": "^0.33.1", "@cosmjs/encoding": "^0.33.1", "@cosmjs/math": "^0.33.1", "@cosmjs/utils": "^0.33.1" } }, "sha512-WfWiBf2EbIWpwKG9AOcsIIkR717SY+JdlXM/SL/bI66BdrhniAF+/ZNis9Vo9HF6lP2UU5XrSmFA4snAvEgdrg=="],
@@ -121,6 +127,8 @@
 
     "@cosmjs/utils": ["@cosmjs/utils@0.33.1", "", {}, "sha512-UnLHDY6KMmC+UXf3Ufyh+onE19xzEXjT4VZ504Acmk4PXxqyvG4cCPprlKUFnGUX7f0z8Or9MAOHXBx41uHBcg=="],
 
+    "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
+
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.65.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.4", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-v4FA/Lw3pTEloLxBqTOaYDX6MNo0Jo7lGBsPZhwnJBqRJp0AzQg1ZZNxrFsh6HVC6QWeWrfIKLn0y2eyIXaVDg=="],
 
     "@dxfeed/dxlink-api": ["@dxfeed/dxlink-api@0.8.0", "", { "dependencies": { "@dxfeed/dxlink-core": "0.8.0", "@dxfeed/dxlink-dom": "0.8.0", "@dxfeed/dxlink-feed": "0.8.0", "@dxfeed/dxlink-indichart": "0.8.0", "@dxfeed/dxlink-rpc": "0.8.0", "@dxfeed/dxlink-websocket-client": "0.8.0" } }, "sha512-4HOxakXuqGojFksEki75zISNK+16XsAwNxW4pIYUUaz8Z9zMGcsLBtkCR/oHq29/aRGU5Pez+euK2uEQtG/UHA=="],
@@ -141,8 +149,6 @@
 
     "@effect/cluster": ["@effect/cluster@0.56.4", "", { "dependencies": { "kubernetes-types": "^1.30.0" }, "peerDependencies": { "@effect/platform": "^0.94.5", "@effect/rpc": "^0.73.1", "@effect/sql": "^0.49.0", "@effect/workflow": "^0.16.0", "effect": "^3.19.17" } }, "sha512-7Je5/JlbZOlsSxsbKjr97dJed2cNGWsb+TLNgMcr5mRDbcWlFOTUGvsrisEJV6waosYLIg+2omPdvnvRoYKdhA=="],
 
-    "@effect/experimental": ["@effect/experimental@0.58.0", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/platform": "^0.94.0", "effect": "^3.19.13", "ioredis": "^5", "lmdb": "^3" }, "optionalPeers": ["ioredis", "lmdb"] }, "sha512-IEP9sapjF6rFy5TkoqDPc86st/fnqUfjT7Xa3pWJrFGr1hzaMXHo+mWsYOZS9LAOVKnpHuVziDK97EP5qsCHVA=="],
-
     "@effect/opentelemetry": ["@effect/opentelemetry@0.61.0", "", { "peerDependencies": { "@effect/platform": "^0.94.2", "@opentelemetry/api": "^1.9", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0", "@opentelemetry/sdk-metrics": "^2.0.0", "@opentelemetry/sdk-trace-base": "^2.0.0", "@opentelemetry/sdk-trace-node": "^2.0.0", "@opentelemetry/sdk-trace-web": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.33.0", "effect": "^3.19.15" } }, "sha512-aTg4qWzMxGDoUZKSyws/dMZqVNoSCQIvHaPDJnWitUAVuWDAPOXiaiHJDWO39cwDlySBTCSF6rEanm3+nR/2Mg=="],
 
     "@effect/platform": ["@effect/platform@0.94.5", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.4", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.19.17" } }, "sha512-z05APUiDDPbodhTkH/RJqOLoCU11bU2IZLfcwLFrld03+ob1VeqRnELQlmueLIYm6NZifHAtjl32V+GRt34y4A=="],
@@ -154,8 +160,6 @@
     "@effect/rpc": ["@effect/rpc@0.73.2", "", { "dependencies": { "msgpackr": "^1.11.4" }, "peerDependencies": { "@effect/platform": "^0.94.5", "effect": "^3.19.18" } }, "sha512-td7LHDgBOYKg+VgGWEelD8rSAmvjXz7am17vfxZROX5qIYuvH7drL/z4p5xQFadhHZ7DYdlFpqdO9ggc77OCIw=="],
 
     "@effect/sql": ["@effect/sql@0.49.0", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.58.0", "@effect/platform": "^0.94.0", "effect": "^3.19.13" } }, "sha512-9UEKR+z+MrI/qMAmSvb/RiD9KlgIazjZUCDSpwNgm0lEK9/Q6ExEyfziiYFVCPiptp52cBw8uBHRic8hHnwqXA=="],
-
-    "@effect/workflow": ["@effect/workflow@0.16.0", "", { "peerDependencies": { "@effect/experimental": "^0.58.0", "@effect/platform": "^0.94.0", "@effect/rpc": "^0.73.0", "effect": "^3.19.13" } }, "sha512-MiAdlxx3TixkgHdbw+Yf1Z3tHAAE0rOQga12kIydJqj05Fnod+W/I+kQGRMY/XWRg+QUsVxhmh1qTr7Ype6lrw=="],
 
     "@elysiajs/node": ["@elysiajs/node@1.4.5", "", { "dependencies": { "crossws": "^0.4.1", "srvx": "^0.11.2" }, "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-K58HEre7RQWZOkLcMNl2RFnuZFzmUUyxHRBSfC2XaJz4j2AjrpHKu/f26tN9LRi3nx1L0PbH22vgZ4O2Fqppbw=="],
 
@@ -207,8 +211,6 @@
 
     "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.205.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg=="],
 
-    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.7.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ=="],
-
     "@opentelemetry/core": ["@opentelemetry/core@2.5.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA=="],
 
     "@opentelemetry/exporter-prometheus": ["@opentelemetry/exporter-prometheus@0.212.0", "", { "dependencies": { "@opentelemetry/core": "2.5.1", "@opentelemetry/resources": "2.5.1", "@opentelemetry/sdk-metrics": "2.5.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-hJFLhCJba5MW5QHexZMHZdMhBfNqNItxOsN0AZojwD1W2kU9xM+BEICowFGJFo/vNV+I2BJvTtmuKafeDSAo7Q=="],
@@ -226,10 +228,6 @@
     "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.5.1", "", { "dependencies": { "@opentelemetry/core": "2.5.1", "@opentelemetry/resources": "2.5.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-RKMn3QKi8nE71ULUo0g/MBvq1N4icEBo7cQSKnL3URZT16/YH3nSVgWegOjwx7FRBTrjOIkMJkCUn/ZFIEfn4A=="],
 
     "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
-
-    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.7.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.7.1", "@opentelemetry/core": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg=="],
-
-    "@opentelemetry/sdk-trace-web": ["@opentelemetry/sdk-trace-web@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
@@ -297,6 +295,8 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
+    "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
@@ -311,13 +311,17 @@
 
     "@types/mute-stream": ["@types/mute-stream@0.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow=="],
 
-    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
     "@types/secp256k1": ["@types/secp256k1@4.0.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-Rcvjl6vARGAKRO6jHeKMatGrvOMGrR/AR11N1x2LqintPCyDZ7NBhrh238Z2VZc7aM7KIwnFpFQ7fnfK4H/9Qw=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
+    "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
+
     "@types/wrap-ansi": ["@types/wrap-ansi@3.0.0", "", {}, "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "agent-base": ["agent-base@9.0.0", "", {}, "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA=="],
 
@@ -326,6 +330,8 @@
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -353,9 +359,13 @@
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
+    "color": ["color@5.0.3", "", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
@@ -401,6 +411,8 @@
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
+
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
@@ -421,9 +433,15 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fecha": ["fecha@4.2.3", "", {}, "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="],
+
+    "file-stream-rotator": ["file-stream-rotator@0.6.1", "", { "dependencies": { "moment": "^2.29.1" } }, "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ=="],
+
     "file-type": ["file-type@22.0.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA=="],
 
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
+    "fn.name": ["fn.name@1.1.0", "", {}, "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="],
 
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
@@ -493,9 +511,13 @@
 
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
+    "kuler": ["kuler@2.0.0", "", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
+
     "libsodium-sumo": ["libsodium-sumo@0.7.16", "", {}, "sha512-x6atrz2AdXCJg6G709x9W9TTJRI6/0NcL5dD0l5GGVqNE48UJmDsjO4RUWYTeyXXUpg+NXZ2SHECaZnFRYzwGA=="],
 
     "libsodium-wrappers-sumo": ["libsodium-wrappers-sumo@0.7.16", "", { "dependencies": { "libsodium-sumo": "^0.7.16" } }, "sha512-gR0JEFPeN3831lB9+ogooQk0KH4K5LSMIO5Prd5Q5XYR2wHFtZfPg0eP7t1oJIWq+UIzlU4WVeBxZ97mt28tXw=="],
+
+    "logform": ["logform@2.7.0", "", { "dependencies": { "@colors/colors": "1.6.0", "@types/triple-beam": "^1.3.2", "fecha": "^4.2.0", "ms": "^2.1.1", "safe-stable-stringify": "^2.3.1", "triple-beam": "^1.3.0" } }, "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
@@ -517,6 +539,8 @@
 
     "minimalistic-crypto-utils": ["minimalistic-crypto-utils@1.0.1", "", {}, "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="],
 
+    "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
@@ -537,9 +561,13 @@
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
+    "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "object-treeify": ["object-treeify@1.1.33", "", {}, "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="],
+
+    "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
@@ -555,17 +583,23 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "protobufjs": ["protobufjs@7.5.6", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg=="],
+    "protobufjs": ["protobufjs@7.5.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readonly-date": ["readonly-date@1.0.0", "", {}, "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "secp256k1": ["secp256k1@5.0.1", "", { "dependencies": { "elliptic": "^6.5.7", "node-addon-api": "^5.0.0", "node-gyp-build": "^4.2.0" } }, "sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA=="],
 
@@ -577,11 +611,15 @@
 
     "srvx": ["srvx@0.11.15", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg=="],
 
+    "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -593,7 +631,11 @@
 
     "symbol-observable": ["symbol-observable@2.0.3", "", {}, "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="],
 
+    "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
+
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "triple-beam": ["triple-beam@1.4.1", "", {}, "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="],
 
     "true-myth": ["true-myth@9.0.1", "", {}, "sha512-8ePgamjgV3CKDI43o6eUtid+9iadfEKUiu2WTucbeCnPTyDOQpZ4svCuozLwm9S4hzUolOclsUCJf3yjQg3g/Q=="],
 
@@ -609,13 +651,21 @@
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "valibot": ["valibot@1.1.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw=="],
 
     "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
+
+    "winston": ["winston@3.19.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.8", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="],
+
+    "winston-daily-rotate-file": ["winston-daily-rotate-file@5.0.0", "", { "dependencies": { "file-stream-rotator": "^0.6.1", "object-hash": "^3.0.0", "triple-beam": "^1.4.1", "winston-transport": "^4.7.0" }, "peerDependencies": { "winston": "^3" } }, "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw=="],
+
+    "winston-transport": ["winston-transport@4.9.0", "", { "dependencies": { "logform": "^2.7.0", "readable-stream": "^3.6.2", "triple-beam": "^1.3.0" } }, "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A=="],
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
@@ -645,7 +695,7 @@
 
     "@inquirer/core/@inquirer/type": ["@inquirer/type@2.0.0", "", { "dependencies": { "mute-stream": "^1.0.0" } }, "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag=="],
 
-    "@inquirer/core/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
+    "@inquirer/core/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -673,15 +723,15 @@
 
     "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
 
-    "@opentelemetry/sdk-trace-node/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
-
-    "@opentelemetry/sdk-trace-web/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
-
     "@parcel/watcher/node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "color/color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
+
+    "color-string/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -690,6 +740,8 @@
     "msw/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@inquirer/core/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "color/color-convert/color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
   }

--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -4,6 +4,7 @@
 	"version": "2.4.0",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
+		"@types/ws": "^8.18.1",
 		"msw": "2.3.1"
 	},
 	"dependencies": {
@@ -16,10 +17,10 @@
 		"@effect/platform": "^0.94.5",
 		"@effect/platform-node": "^0.104.1",
 		"@elysiajs/openapi": "^1.4.14",
+		"@pythnetwork/pyth-lazer-sdk": "^6.2.1",
 		"@seda-protocol/data-proxy-sdk": "workspace:*",
 		"@seda-protocol/rotating-file-logger": "2.1.0",
 		"@seda-protocol/telemetry": "1.1.0",
-		"@pythnetwork/pyth-lazer-sdk": "^6.2.1",
 		"@seda-protocol/utils": "^2.0.0",
 		"big.js": "7.0.1",
 		"chalk": "^5.3.0",
@@ -32,6 +33,9 @@
 		"jsonpath-plus": "^10.3.0",
 		"secp256k1": "^5.0.1",
 		"true-myth": "9.0.1",
-		"valibot": "1.1.0"
+		"valibot": "1.1.0",
+		"winston": "^3.17.0",
+		"winston-daily-rotate-file": "^5.0.0",
+		"ws": "^8.20.0"
 	}
 }

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -330,6 +330,58 @@ describe("parseConfig", () => {
 			process.env.DXFEED_TOKEN = undefined;
 		});
 
+		it("should reject a lo-tech module whose API key env var is unset", () => {
+			process.env.LOTECH_API_KEY = undefined;
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "lo-tech",
+							name: "lotech",
+							baseUrl: "wss://data.lo.tech/ws/v1",
+							exchange: "binance",
+							loTechApiKeyEnvKey: "LOTECH_API_KEY",
+							priceFeeds: [{ symbol: "BTC-USDT:SPOT", dataType: "PRICE" }],
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				"Module lo-tech requires LOTECH_API_KEY to be set",
+			);
+		});
+
+		it("should resolve a lo-tech module when its API key is set", () => {
+			process.env.LOTECH_API_KEY = "lo-tech-secret";
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "lo-tech",
+							name: "lotech",
+							baseUrl: "wss://data.lo.tech/ws/v1",
+							exchange: "binance",
+							loTechApiKeyEnvKey: "LOTECH_API_KEY",
+							priceFeeds: [{ symbol: "BTC-USDT:SPOT", dataType: "PRICE" }],
+						},
+					],
+				}),
+			);
+
+			assertIsOkResult(result);
+			const module = result.value.config.modules[0];
+			if (module.type !== "lo-tech") {
+				throw new Error(`expected lo-tech, got ${module.type}`);
+			}
+			expect(module.loTechApiKey).toBe("lo-tech-secret");
+			process.env.LOTECH_API_KEY = undefined;
+		});
+
 		it.each([
 			{
 				missing: "key" as const,

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -27,6 +27,11 @@ import {
 	HydromancerModuleRouteSchema,
 	validateHydromancerModuleRoute,
 } from "./hydromancer-module-config";
+import {
+	type LoTechModuleRoute,
+	LoTechModuleRouteSchema,
+	validateLoTechModuleRoute,
+} from "./lo-tech-module-config";
 import { type Modules, ModulesSchema } from "./module-config";
 import {
 	type PythLazerModuleRoute,
@@ -117,6 +122,7 @@ const ConfigSchema = v.strictObject(
 				ChainlinkStreamsModuleRouteSchema,
 				DxFeedModuleRouteSchema,
 				HydromancerModuleRouteSchema,
+				LoTechModuleRouteSchema,
 			]),
 		),
 		baseURL: maybe(v.string()),
@@ -150,7 +156,8 @@ export type Route =
 	| PythLazerModuleRoute
 	| ChainlinkStreamsModuleRoute
 	| DxFeedModuleRoute
-	| HydromancerModuleRoute;
+	| HydromancerModuleRoute
+	| LoTechModuleRoute;
 
 export interface Config extends v.InferOutput<typeof ConfigSchema> {
 	modules: Modules[];
@@ -254,6 +261,11 @@ export const parseConfig = (
 
 			if (route.type === "hydromancer") {
 				yield* validateHydromancerModuleRoute(route);
+				continue;
+			}
+
+			if (route.type === "lo-tech") {
+				yield* validateLoTechModuleRoute(route);
 				continue;
 			}
 
@@ -458,6 +470,16 @@ export const parseConfig = (
 							...m,
 							hydromancerApiKey,
 						} satisfies Modules);
+					}),
+					Match.when({ type: "lo-tech" }, (m) => {
+						const loTechApiKey = process.env[m.loTechApiKeyEnvKey];
+						if (!loTechApiKey) {
+							return Effect.fail(
+								`Module ${m.type} requires ${m.loTechApiKeyEnvKey} to be set`,
+							);
+						}
+						envSecrets.add(loTechApiKey);
+						return Effect.succeed({ ...m, loTechApiKey } satisfies Modules);
 					}),
 					Match.exhaustive,
 				),

--- a/workspace/data-proxy/src/config/lo-tech-module-config.ts
+++ b/workspace/data-proxy/src/config/lo-tech-module-config.ts
@@ -1,0 +1,68 @@
+import { Duration, Effect, Option } from "effect";
+import * as v from "valibot";
+import { RouteSchema } from "./route-config";
+
+export const LO_TECH_DATA_TYPE_PRICE = "PRICE" as const;
+
+export const LoTechDataTypeSchema = v.picklist([LO_TECH_DATA_TYPE_PRICE]);
+
+export type LoTechDataType = v.InferOutput<typeof LoTechDataTypeSchema>;
+
+export const LoTechModulePriceFeedSchema = v.object({
+	// LO:TECH normalized symbol, e.g. BTC-USDT:SPOT (see the symbology section in the LO:TECH API docs).
+	symbol: v.string(),
+	// Type of data to subscribe to.
+	dataType: v.optional(LoTechDataTypeSchema, LO_TECH_DATA_TYPE_PRICE),
+});
+
+export type LoTechModulePriceFeed = v.InferOutput<
+	typeof LoTechModulePriceFeedSchema
+>;
+
+export const LoTechModuleConfigSchema = v.strictObject({
+	name: v.string(),
+	baseUrl: v.string(),
+	exchange: v.string(),
+	priceFeeds: v.array(LoTechModulePriceFeedSchema),
+	maxFeedsPerRequest: v.optional(v.number(), 100),
+	loTechApiKeyEnvKey: v.string(),
+	priceFeedsCleanupTtl: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "2 minutes"),
+		v.transform((ttl) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(ttl),
+				() => new Error("Invalid price feed cleanup TTL"),
+			),
+		),
+	),
+	priceFeedsCleanupInterval: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((interval) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(interval),
+				() => new Error("Invalid price feed cleanup interval"),
+			),
+		),
+	),
+	reconnectDelayMs: v.optional(v.number(), 1000),
+	type: v.literal("lo-tech"),
+});
+
+export interface LoTechModuleConfig
+	extends v.InferOutput<typeof LoTechModuleConfigSchema> {
+	loTechApiKey: string;
+}
+
+export const LoTechModuleRouteSchema = v.strictObject({
+	...RouteSchema.entries,
+	moduleName: v.string(),
+	fetchFromModule: v.string(),
+	type: v.literal("lo-tech"),
+});
+
+export type LoTechModuleRoute = v.InferOutput<typeof LoTechModuleRouteSchema>;
+
+export const validateLoTechModuleRoute = (_route: LoTechModuleRoute) =>
+	Effect.gen(function* () {
+		return yield* Effect.void;
+	});

--- a/workspace/data-proxy/src/config/module-config.ts
+++ b/workspace/data-proxy/src/config/module-config.ts
@@ -5,6 +5,8 @@ import type { DxFeedModuleConfig } from "./dxfeed-module-config";
 import { DxFeedModuleConfigSchema } from "./dxfeed-module-config";
 import type { HydromancerModuleConfig } from "./hydromancer-module-config";
 import { HydromancerModuleConfigSchema } from "./hydromancer-module-config";
+import type { LoTechModuleConfig } from "./lo-tech-module-config";
+import { LoTechModuleConfigSchema } from "./lo-tech-module-config";
 import type { PythLazerModuleConfig } from "./pyth-lazer-module-config";
 import { PythLazerModuleConfigSchema } from "./pyth-lazer-module-config";
 
@@ -15,6 +17,7 @@ export const ModulesSchema = v.optional(
 			ChainlinkStreamsModuleConfigSchema,
 			DxFeedModuleConfigSchema,
 			HydromancerModuleConfigSchema,
+			LoTechModuleConfigSchema,
 		]),
 	),
 	[],
@@ -24,4 +27,5 @@ export type Modules =
 	| PythLazerModuleConfig
 	| ChainlinkStreamsModuleConfig
 	| DxFeedModuleConfig
-	| HydromancerModuleConfig;
+	| HydromancerModuleConfig
+	| LoTechModuleConfig;

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -106,6 +106,16 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 					);
 				}),
 			),
+			Match.when({ type: "lo-tech" }, (loTechModuleRoute) =>
+				Effect.gen(function* () {
+					yield* Effect.logDebug("Handling LO:TECH request");
+					return yield* moduleService.handleRequest(
+						loTechModuleRoute,
+						params,
+						request,
+					);
+				}),
+			),
 			Match.when({ type: "upstream" }, (upstreamModuleRoute) =>
 				Effect.gen(function* () {
 					yield* Effect.logDebug("Handling upstream request");

--- a/workspace/data-proxy/src/modules/dxfeed/price-cache.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/price-cache.ts
@@ -83,7 +83,7 @@ export const createPriceCache = () =>
 
 				return yield* Deferred.await(waiter.value).pipe(
 					Effect.timeoutFail({
-						duration: Duration.seconds(PRICE_WAIT_TIMEOUT_MS),
+						duration: Duration.millis(PRICE_WAIT_TIMEOUT_MS),
 						onTimeout: () =>
 							new FailedToGetPriceError({
 								error: `Timed out waiting for price of symbol ${symbol}`,

--- a/workspace/data-proxy/src/modules/lo-tech/errors.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/errors.ts
@@ -1,0 +1,19 @@
+import { Data } from "effect";
+
+export class FailedToHandleLoTechRequestError extends Data.TaggedError(
+	"FailedToHandleLoTechRequestError",
+)<{
+	error: string | unknown;
+}> {
+	message = `Failed to handle LO:TECH request: ${this.error}`;
+	status = 400;
+}
+
+export class FailedToGetPriceError extends Data.TaggedError(
+	"FailedToGetPriceError",
+)<{
+	error: string | unknown;
+}> {
+	message = `Failed to get price: ${this.error}`;
+	status = 500;
+}

--- a/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
@@ -1,0 +1,225 @@
+import {
+	Clock,
+	Duration,
+	Effect,
+	Layer,
+	Match,
+	MutableHashMap,
+	Option,
+	Queue,
+	Schedule,
+} from "effect";
+import type { Route } from "../../config/config-parser";
+import {
+	LO_TECH_DATA_TYPE_PRICE,
+	type LoTechModuleConfig,
+} from "../../config/lo-tech-module-config";
+import { createErrorResponse } from "../../controllers/create-error-response";
+import { replaceParams } from "../../utils/replace-params";
+import { FailedToHandleRequest, ModuleService } from "../module";
+import { FailedToHandleLoTechRequestError } from "./errors";
+import { createPriceCache } from "./price-cache";
+import type { LoTechDataPrice, LoTechParsedData } from "./schema";
+import { makeLoTechWebSocketService } from "./ws-client";
+
+export type PriceFeedSymbol = string;
+
+export const LoTechModuleService = (config: LoTechModuleConfig) =>
+	Layer.effect(
+		ModuleService,
+		Effect.gen(function* () {
+			yield* Effect.logInfo("Initializing LO:TECH module");
+
+			const runtime = yield* Effect.runtime();
+			const priceCache = yield* createPriceCache();
+			const priceFeeds = MutableHashMap.empty<PriceFeedSymbol, number>();
+			const newPriceFeedRequests = yield* Queue.unbounded<PriceFeedSymbol>();
+			// The timestamp of the last request to the price feed used for cleanup.
+			const lastRequestToPriceFeed = MutableHashMap.empty<
+				PriceFeedSymbol,
+				number
+			>();
+
+			let priceFeedId = 0;
+
+			const updatePrice = (data: LoTechDataPrice) =>
+				Effect.gen(function* () {
+					yield* Effect.logTrace("Received message from LO:TECH client", data);
+
+					// Set the price if the symbol is subscribed to.
+					const { symbol } = data;
+					if (!MutableHashMap.has(priceFeeds, symbol)) {
+						return;
+					}
+					yield* priceCache.setPrice(symbol, data);
+				});
+
+			const handleDataMessage = (data: LoTechParsedData) =>
+				Match.value(data).pipe(
+					Match.discriminatorsExhaustive("type")({
+						[LO_TECH_DATA_TYPE_PRICE]: (priceData) => updatePrice(priceData),
+					}),
+				);
+
+			const loTechWs = yield* makeLoTechWebSocketService({
+				config,
+				runtime,
+				onConnected: (api) =>
+					Effect.gen(function* () {
+						for (const priceFeed of config.priceFeeds) {
+							yield* Effect.logInfo(
+								`Subscribing to price feed ${priceFeed.symbol}`,
+							);
+
+							const newSubscriptionId = priceFeedId++;
+							MutableHashMap.set(
+								priceFeeds,
+								priceFeed.symbol,
+								newSubscriptionId,
+							);
+
+							const now = yield* Clock.currentTimeMillis;
+							MutableHashMap.set(lastRequestToPriceFeed, priceFeed.symbol, now);
+
+							yield* api.subscribePrice(priceFeed.symbol, newSubscriptionId);
+						}
+					}),
+				handleDataMessage,
+			});
+
+			const start = () =>
+				Effect.gen(function* () {
+					yield* Effect.logInfo("Starting LO:TECH module");
+
+					// Background fiber for handling new price feed subscriptions
+					yield* Effect.forkDaemon(
+						Effect.gen(function* () {
+							const newSymbol = yield* newPriceFeedRequests.take;
+
+							yield* Effect.logInfo(`Subscribing to price feed ${newSymbol}`);
+
+							const newSubscriptionId = priceFeedId++;
+							MutableHashMap.set(priceFeeds, newSymbol, newSubscriptionId);
+
+							const now = yield* Clock.currentTimeMillis;
+							MutableHashMap.set(lastRequestToPriceFeed, newSymbol, now);
+
+							yield* loTechWs.subscribePrice(newSymbol, newSubscriptionId);
+						}).pipe(Effect.forever),
+					);
+
+					// Background fiber for cleaning up price feeds subscriptions
+					yield* Effect.forkDaemon(
+						Effect.gen(function* () {
+							const now = yield* Clock.currentTimeMillis;
+							yield* Effect.logDebug(
+								`Cleaning up price feeds (currently running ${priceCache.size()} price feeds)..`,
+							);
+
+							for (const [
+								symbol,
+								lastRequestTimestamp,
+							] of lastRequestToPriceFeed) {
+								const cleanupInterval = Duration.toMillis(
+									config.priceFeedsCleanupTtl,
+								);
+								const timeSinceLastRequest = now - lastRequestTimestamp;
+
+								yield* Effect.logDebug(
+									`Time since last request for price feed ${symbol}: ${Duration.format(Duration.decode(timeSinceLastRequest))}`,
+								);
+
+								if (timeSinceLastRequest > cleanupInterval) {
+									yield* Effect.logInfo(`Cleaning up price feed ${symbol}`);
+									MutableHashMap.remove(lastRequestToPriceFeed, symbol);
+									yield* priceCache.deletePrice(symbol);
+
+									const priceFeedId = MutableHashMap.get(priceFeeds, symbol);
+
+									if (Option.isSome(priceFeedId)) {
+										yield* loTechWs.unsubscribePrice(symbol);
+										MutableHashMap.remove(priceFeeds, symbol);
+									}
+								}
+							}
+						}).pipe(
+							Effect.schedule(
+								Schedule.spaced(config.priceFeedsCleanupInterval),
+							),
+						),
+					);
+				}).pipe(Effect.annotateLogs("_name", "lo-tech"));
+
+			const handleRequest = (
+				route: Route,
+				params: Record<string, string>,
+				request: Request,
+			) =>
+				Effect.gen(function* () {
+					if (route.type !== "lo-tech") {
+						return yield* Effect.fail(
+							new FailedToHandleRequest({
+								msg: "Route is not a LO:TECH module",
+							}),
+						);
+					}
+
+					yield* Effect.logInfo("Handling LO:TECH request", { route, params });
+
+					const symbols = replaceParams(route.fetchFromModule, params).split(
+						",",
+					);
+
+					if (symbols.length > config.maxFeedsPerRequest) {
+						return yield* Effect.succeed(
+							createErrorResponse(
+								new FailedToHandleLoTechRequestError({
+									error: `Too many symbols requested, max is ${config.maxFeedsPerRequest} but got ${symbols.length}`,
+								}),
+								400,
+							),
+						);
+					}
+
+					const prices: LoTechDataPrice[] = [];
+					const now = yield* Clock.currentTimeMillis;
+
+					for (const symbol of symbols) {
+						// Set the last request timestamp.
+						const lastRequestTimestamp = MutableHashMap.get(
+							lastRequestToPriceFeed,
+							symbol,
+						);
+						if (Option.isNone(lastRequestTimestamp)) {
+							yield* newPriceFeedRequests.offer(symbol);
+						}
+						MutableHashMap.set(lastRequestToPriceFeed, symbol, now);
+
+						// Get the price from the cache.
+						const price = yield* priceCache.getOrWaitPrice(symbol).pipe(
+							Effect.catchTag("FailedToGetPriceError", (error) =>
+								Effect.gen(function* () {
+									yield* priceCache.deletePrice(symbol);
+									return yield* Effect.fail(error);
+								}),
+							),
+						);
+						prices.push(price);
+					}
+
+					return yield* Effect.succeed(
+						new Response(JSON.stringify(prices), { status: 200 }),
+					);
+				}).pipe(
+					Effect.withSpan("handleLoTechRequest"),
+					Effect.catchAll((error) => {
+						return Effect.succeed(createErrorResponse(error, 500));
+					}),
+				);
+
+			return {
+				start,
+				handleRequest,
+			};
+		}),
+	);

--- a/workspace/data-proxy/src/modules/lo-tech/price-cache.test.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/price-cache.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Fiber } from "effect";
+import { createPriceCache } from "./price-cache";
+import type { LoTechDataPrice } from "./schema";
+
+const run = <A, E>(program: Effect.Effect<A, E>) => Effect.runPromise(program);
+
+const price = (
+	symbol: string,
+	overrides: Partial<LoTechDataPrice> = {},
+): LoTechDataPrice => ({
+	type: "PRICE",
+	symbol,
+	ingress_ts: 1000,
+	publish_ts: null,
+	transaction_ts: 1000,
+	price: 100,
+	spread: 1,
+	...overrides,
+});
+
+describe("createPriceCache", () => {
+	it("should set and get a price", async () => {
+		await run(
+			Effect.gen(function* () {
+				const priceCache = yield* createPriceCache();
+				const entry = price("ETH-USDT", { price: 123.45, spread: 0.02 });
+				yield* priceCache.setPrice("ETH-USDT", entry);
+				const got = yield* priceCache.getOrWaitPrice("ETH-USDT");
+				expect(got).toEqual(entry);
+				expect(got.price).toBe(123.45);
+				expect(got.spread).toBe(0.02);
+			}),
+		);
+	});
+
+	it("should wait for price when getOrWaitPrice is called before setPrice", async () => {
+		await run(
+			Effect.gen(function* () {
+				const priceCache = yield* createPriceCache();
+				const entry = price("SOL-USDT", {
+					price: 300,
+					spread: 2,
+					ingress_ts: 3000,
+				});
+				const waiter = yield* Effect.fork(
+					priceCache.getOrWaitPrice("SOL-USDT"),
+				);
+				yield* priceCache.setPrice("SOL-USDT", entry);
+				const result = yield* Fiber.join(waiter);
+				expect(result).toEqual(entry);
+			}),
+		);
+	});
+
+	it("should resolve multiple waiters when setPrice is called", async () => {
+		await run(
+			Effect.gen(function* () {
+				const priceCache = yield* createPriceCache();
+				const sym = "ARB-USDT";
+				const entry = price(sym, { price: 400, spread: 3 });
+				const waiterA = yield* Effect.fork(priceCache.getOrWaitPrice(sym));
+				const waiterB = yield* Effect.fork(priceCache.getOrWaitPrice(sym));
+				yield* priceCache.setPrice(sym, entry);
+				const [a, b] = yield* Effect.all([
+					Fiber.join(waiterA),
+					Fiber.join(waiterB),
+				]);
+				expect(a).toEqual(entry);
+				expect(b).toEqual(entry);
+			}),
+		);
+	});
+
+	it("should always return the latest price when price is updated", async () => {
+		await run(
+			Effect.gen(function* () {
+				const priceCache = yield* createPriceCache();
+				const sym = "BTC-USDT";
+				yield* priceCache.setPrice(sym, price(sym, { price: 100 }));
+				const first = yield* priceCache.getOrWaitPrice(sym);
+				expect(first.price).toBe(100);
+
+				yield* priceCache.setPrice(
+					sym,
+					price(sym, {
+						price: 200,
+						spread: 8,
+						ingress_ts: 2000,
+						transaction_ts: 2000,
+					}),
+				);
+				const latest = yield* priceCache.getOrWaitPrice(sym);
+				expect(latest.price).toBe(200);
+				expect(latest.ingress_ts).toBe(2000);
+				expect(latest.spread).toBe(8);
+			}),
+		);
+	});
+
+	it("should keep different symbols independent", async () => {
+		await run(
+			Effect.gen(function* () {
+				const priceCache = yield* createPriceCache();
+				yield* priceCache.setPrice(
+					"AAA-USDT",
+					price("AAA-USDT", { price: 100 }),
+				);
+				yield* priceCache.setPrice(
+					"BBB-USDT",
+					price("BBB-USDT", { price: 200, spread: 2 }),
+				);
+				const [p1, p2] = yield* Effect.all([
+					priceCache.getOrWaitPrice("AAA-USDT"),
+					priceCache.getOrWaitPrice("BBB-USDT"),
+				]);
+				expect(p1.price).toBe(100);
+				expect(p2.price).toBe(200);
+			}),
+		);
+	});
+});

--- a/workspace/data-proxy/src/modules/lo-tech/price-cache.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/price-cache.ts
@@ -1,0 +1,109 @@
+import {
+	Deferred,
+	Effect,
+	MutableHashMap,
+	Option,
+	SynchronizedRef,
+} from "effect";
+import { FailedToGetPriceError } from "./errors";
+import type { PriceFeedSymbol } from "./lo-tech";
+import type { LoTechDataPrice } from "./schema";
+
+export const createPriceCache = () =>
+	Effect.gen(function* () {
+		const priceCache = MutableHashMap.empty<PriceFeedSymbol, LoTechDataPrice>();
+		const priceWaiters = yield* SynchronizedRef.make(
+			MutableHashMap.empty<
+				PriceFeedSymbol,
+				Deferred.Deferred<LoTechDataPrice, FailedToGetPriceError>
+			>(),
+		);
+
+		const setPrice = (symbol: PriceFeedSymbol, price: LoTechDataPrice) =>
+			Effect.gen(function* () {
+				MutableHashMap.set(priceCache, symbol, price);
+				const waitersMap = yield* SynchronizedRef.get(priceWaiters);
+				const waiter = MutableHashMap.get(waitersMap, symbol);
+
+				if (Option.isSome(waiter)) {
+					yield* Deferred.succeed(waiter.value, price);
+				}
+
+				MutableHashMap.set(priceCache, symbol, price);
+			});
+
+		const setPriceToError = (symbol: PriceFeedSymbol, error: string) =>
+			Effect.gen(function* () {
+				const waitersMap = yield* SynchronizedRef.get(priceWaiters);
+				const waiter = MutableHashMap.get(waitersMap, symbol);
+
+				if (Option.isSome(waiter)) {
+					yield* Deferred.fail(
+						waiter.value,
+						new FailedToGetPriceError({ error }),
+					);
+				}
+			});
+
+		const getOrWaitPrice = (symbol: PriceFeedSymbol) =>
+			Effect.gen(function* () {
+				const price = MutableHashMap.get(priceCache, symbol);
+
+				if (Option.isSome(price)) {
+					return price.value;
+				}
+
+				const newWaitersMap = yield* SynchronizedRef.updateAndGetEffect(
+					priceWaiters,
+					Effect.fnUntraced(function* (waitersMap) {
+						const currentWaiter = MutableHashMap.get(waitersMap, symbol);
+
+						// Don't modify the map if the price feed id already has a waiter
+						if (Option.isSome(currentWaiter)) {
+							return waitersMap;
+						}
+
+						// We can safely create the new waiter
+						const deferred = yield* Deferred.make<
+							LoTechDataPrice,
+							FailedToGetPriceError
+						>();
+						MutableHashMap.set(waitersMap, symbol, deferred);
+						return waitersMap;
+					}),
+				);
+
+				const waiter = MutableHashMap.get(newWaitersMap, symbol);
+
+				if (Option.isNone(waiter)) {
+					return yield* Effect.fail(
+						new FailedToGetPriceError({ error: "Price feed waiter not found" }),
+					);
+				}
+
+				return yield* Deferred.await(waiter.value);
+			});
+
+		const deletePrice = (symbol: PriceFeedSymbol) => {
+			MutableHashMap.remove(priceCache, symbol);
+
+			SynchronizedRef.update(priceWaiters, (waitersMap) => {
+				MutableHashMap.remove(waitersMap, symbol);
+				return waitersMap;
+			});
+
+			return Effect.void;
+		};
+
+		const size = () => {
+			return MutableHashMap.size(priceCache);
+		};
+
+		return {
+			getOrWaitPrice,
+			setPrice,
+			deletePrice,
+			setPriceToError,
+			size,
+		};
+	});

--- a/workspace/data-proxy/src/modules/lo-tech/price-cache.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/price-cache.ts
@@ -1,5 +1,6 @@
 import {
 	Deferred,
+	Duration,
 	Effect,
 	MutableHashMap,
 	Option,
@@ -8,6 +9,8 @@ import {
 import { FailedToGetPriceError } from "./errors";
 import type { PriceFeedSymbol } from "./lo-tech";
 import type { LoTechDataPrice } from "./schema";
+
+const PRICE_WAIT_TIMEOUT_MS = 3_000;
 
 export const createPriceCache = () =>
 	Effect.gen(function* () {
@@ -81,7 +84,15 @@ export const createPriceCache = () =>
 					);
 				}
 
-				return yield* Deferred.await(waiter.value);
+				return yield* Deferred.await(waiter.value).pipe(
+					Effect.timeoutFail({
+						duration: Duration.millis(PRICE_WAIT_TIMEOUT_MS),
+						onTimeout: () =>
+							new FailedToGetPriceError({
+								error: `Timed out waiting for price of symbol ${symbol}`,
+							}),
+					}),
+				);
 			});
 
 		const deletePrice = (symbol: PriceFeedSymbol) => {

--- a/workspace/data-proxy/src/modules/lo-tech/schema.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/schema.ts
@@ -1,0 +1,62 @@
+import * as v from "valibot";
+import {
+	LO_TECH_DATA_TYPE_PRICE,
+	type LoTechDataType,
+} from "../../config/lo-tech-module-config";
+
+export const LoTechDataPriceSchema = v.strictObject({
+	type: v.literal(LO_TECH_DATA_TYPE_PRICE),
+	symbol: v.string(),
+	ingress_ts: v.number(),
+	publish_ts: v.nullable(v.number()),
+	transaction_ts: v.number(),
+	price: v.number(),
+	spread: v.number(),
+});
+
+export type LoTechDataPrice = v.InferOutput<typeof LoTechDataPriceSchema>;
+
+export const LoTechParsedDataSchema = v.variant("type", [
+	LoTechDataPriceSchema,
+]);
+
+export type LoTechParsedData = v.InferOutput<typeof LoTechParsedDataSchema>;
+
+export type LoTechData = LoTechParsedData;
+
+export const LoTechDataMessageSchema = v.object({
+	egress_ts: v.number(),
+	data: LoTechParsedDataSchema,
+});
+
+export type LoTechDataMessage = v.InferOutput<typeof LoTechDataMessageSchema>;
+
+export type LoTechAckMessage = {
+	egress_ts: number;
+	ack: {
+		id: number;
+	};
+};
+
+export type LoTechMessage = LoTechDataMessage | LoTechAckMessage;
+
+/**
+ * Compile-time: keep LoTechDataType (config picklist) and parsed `type`
+ * discriminants in sync — together they imply the same string union.
+ *
+ * - Config ⊆ parsed: every picklist entry has a `v.variant` branch.
+ * - Parsed ⊆ config: every emitted `type` is allowed by the picklist.
+ */
+const _loTechParsedDataExhaustsLoTechDataType: Exclude<
+	LoTechDataType,
+	LoTechParsedData["type"]
+> extends never
+	? true
+	: never = true;
+
+const _loTechParsedVariantsSubsetOfLoTechDataType: Exclude<
+	LoTechParsedData["type"],
+	LoTechDataType
+> extends never
+	? true
+	: never = true;

--- a/workspace/data-proxy/src/modules/lo-tech/ws-client.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/ws-client.ts
@@ -1,0 +1,259 @@
+import { Duration, Effect, Runtime, Schedule } from "effect";
+import * as v from "valibot";
+import WebSocket from "ws";
+import type { LoTechModuleConfig } from "../../config/lo-tech-module-config";
+import { LoTechDataMessageSchema, type LoTechParsedData } from "./schema";
+
+// LO:TECH expects a ping every ~60 seconds to keep the connection alive.
+const LO_TECH_PING_INTERVAL_MS = 30_000;
+
+function subscribePricePayload(symbol: string, priceFeedId: number): string {
+	return JSON.stringify({
+		op: "SUBSCRIBE",
+		topics: [{ symbol, type: "PRICE" }],
+		id: priceFeedId,
+	});
+}
+
+function unsubscribePricePayload(symbol: string): string {
+	return JSON.stringify({
+		op: "UNSUBSCRIBE",
+		topics: [{ symbol, type: "PRICE" }],
+	});
+}
+
+export type LoTechWebSocketServiceApi = {
+	readonly subscribePrice: (
+		symbol: string,
+		priceFeedId: number,
+	) => Effect.Effect<void>;
+	readonly unsubscribePrice: (symbol: string) => Effect.Effect<void>;
+};
+
+export type LoTechWebSocketServiceDeps = {
+	config: LoTechModuleConfig;
+	runtime: Runtime.Runtime<never>;
+	/* Runs immediately after the socket is OPEN */
+	onConnected?: (api: LoTechWebSocketServiceApi) => Effect.Effect<void>;
+	handleDataMessage: (data: LoTechParsedData) => Effect.Effect<void>;
+};
+
+export const makeLoTechWebSocketService = (
+	deps: LoTechWebSocketServiceDeps,
+): Effect.Effect<LoTechWebSocketServiceApi> =>
+	Effect.gen(function* () {
+		const { config, runtime, onConnected, handleDataMessage } = deps;
+
+		let activeSocket: WebSocket | null = null;
+		const pendingOutbound: string[] = [];
+
+		function send(text: string): Effect.Effect<void> {
+			return Effect.gen(function* () {
+				const sock = activeSocket;
+				if (sock !== null && sock.readyState === WebSocket.OPEN) {
+					yield* Effect.logDebug("Sending message to LO:TECH", { text });
+					sock.send(text);
+				} else {
+					pendingOutbound.push(text);
+				}
+			});
+		}
+
+		const subscribePrice = (symbol: string, priceFeedId: number) =>
+			send(subscribePricePayload(symbol, priceFeedId));
+
+		const unsubscribePrice = (symbol: string) =>
+			send(unsubscribePricePayload(symbol));
+
+		const api: LoTechWebSocketServiceApi = {
+			subscribePrice,
+			unsubscribePrice,
+		};
+
+		const flushPendingOutbound = (): void => {
+			const sock = activeSocket;
+			if (sock === null || sock.readyState !== WebSocket.OPEN) {
+				return;
+			}
+			while (pendingOutbound.length > 0) {
+				const text = pendingOutbound.shift();
+				if (text === undefined) {
+					break;
+				}
+				Runtime.runSync(
+					runtime,
+					Effect.gen(function* () {
+						yield* Effect.logDebug(
+							"Flushing pending outbound message to LO:TECH",
+							{ text },
+						);
+						sock.send(text);
+					}),
+				);
+			}
+		};
+
+		const runWebSocketSession = (): Promise<void> =>
+			new Promise((resolve) => {
+				const url = `${config.baseUrl}/${config.exchange}`;
+				let pingTimer: ReturnType<typeof setInterval> | undefined;
+
+				let socket: WebSocket;
+				try {
+					socket = new WebSocket(url, {
+						headers: { "X-API-KEY": config.loTechApiKey },
+					});
+				} catch (error) {
+					Runtime.runSync(
+						runtime,
+						Effect.logError("LO:TECH WebSocket constructor failed", {
+							error,
+						}),
+					);
+					resolve();
+					return;
+				}
+
+				activeSocket = socket;
+
+				socket.on("open", () => {
+					if (onConnected !== undefined) {
+						Runtime.runSync(
+							runtime,
+							onConnected(api).pipe(
+								Effect.catchAll((err) =>
+									Effect.logError("LO:TECH onConnected failed", { err }),
+								),
+							),
+						);
+					}
+
+					flushPendingOutbound();
+
+					if (pingTimer !== undefined) {
+						clearInterval(pingTimer);
+					}
+					pingTimer = setInterval(() => {
+						socket.ping();
+					}, LO_TECH_PING_INTERVAL_MS);
+				});
+
+				socket.on("message", (raw) => {
+					const text = typeof raw === "string" ? raw : raw.toString();
+
+					try {
+						const parsed: unknown = JSON.parse(text);
+
+						Runtime.runSync(
+							runtime,
+							Effect.gen(function* () {
+								if (typeof parsed !== "object" || parsed === null) {
+									yield* Effect.logError(
+										"Unexpected LO:TECH message format",
+										parsed,
+									);
+									return;
+								}
+
+								if ("data" in parsed) {
+									const msgResult = v.safeParse(
+										LoTechDataMessageSchema,
+										parsed,
+									);
+									if (!msgResult.success) {
+										yield* Effect.logError(
+											"Unexpected LO:TECH data message (schema)",
+											{
+												issues: v.flatten(msgResult.issues),
+												raw: parsed,
+											},
+										);
+										return;
+									}
+
+									yield* handleDataMessage(msgResult.output.data).pipe(
+										Effect.catchAll((err) =>
+											Effect.logError(
+												"Failed to handle data message from LO:TECH",
+												{
+													err,
+												},
+											),
+										),
+									);
+								} else if ("ack" in parsed) {
+									yield* Effect.logInfo("Received ack from LO:TECH");
+								} else if ("pong" in parsed) {
+									yield* Effect.logInfo("Received pong from LO:TECH");
+								} else if ("error" in parsed) {
+									yield* Effect.logError(
+										"LO:TECH error message received",
+										parsed,
+									);
+								} else {
+									yield* Effect.logWarning(
+										"Unexpected LO:TECH message received",
+										parsed,
+									);
+								}
+							}),
+						);
+					} catch (error) {
+						Runtime.runSync(
+							runtime,
+							Effect.logWarning("LO:TECH invalid JSON message", {
+								error,
+								text: text.slice(0, 500),
+							}),
+						);
+					}
+				});
+
+				socket.on("close", () => {
+					Runtime.runSync(
+						runtime,
+						Effect.logWarning(
+							"LO:TECH websocket closed; reconnecting after delay",
+						),
+					);
+
+					if (pingTimer !== undefined) {
+						clearInterval(pingTimer);
+						pingTimer = undefined;
+					}
+					if (activeSocket === socket) {
+						activeSocket = null;
+					}
+					resolve();
+				});
+
+				socket.on("error", (error) => {
+					Runtime.runSync(
+						runtime,
+						Effect.logError("LO:TECH websocket error", { error }),
+					);
+				});
+			});
+
+		const reconnectSchedule = Schedule.spaced(
+			Duration.millis(config.reconnectDelayMs ?? 1000),
+		);
+
+		const runSession = Effect.tryPromise({
+			try: () => runWebSocketSession(),
+			catch: (error) =>
+				new Error("Failed to run LO:TECH connection session", {
+					cause: error,
+				}),
+		}).pipe(
+			Effect.catchAll((error) =>
+				Effect.logError("LO:TECH connection session failed", {
+					error,
+				}),
+			),
+		);
+
+		yield* Effect.forkDaemon(Effect.repeat(runSession, reconnectSchedule));
+
+		return api;
+	});

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -19,6 +19,7 @@ import { handleProxyRequest } from "./controllers/proxy/handle-proxy-request";
 import { ChainlinkStreamsModuleService } from "./modules/chainlink-streams/chainlink-streams";
 import { DxFeedModuleService } from "./modules/dxfeed/dxfeed";
 import { HydromancerModuleService } from "./modules/hydromancer/hydromancer";
+import { LoTechModuleService } from "./modules/lo-tech/lo-tech";
 import { EmptyModuleService, ModuleService } from "./modules/module";
 import { PythLazerModuleService } from "./modules/pyth-lazer/pyth-lazer";
 import type { HttpClientService } from "./services/http-client";
@@ -56,6 +57,9 @@ export const startProxyServer = (
 				Match.when({ type: "hydromancer" }, (m) =>
 					Layer.memoize(HydromancerModuleService(m)),
 				),
+				Match.when({ type: "lo-tech" }, (m) =>
+					Layer.memoize(LoTechModuleService(m)),
+				),
 				Match.exhaustive,
 			);
 
@@ -73,7 +77,8 @@ export const startProxyServer = (
 				route.type === "pyth-lazer" ||
 				route.type === "chainlink-streams" ||
 				route.type === "dxfeed" ||
-				route.type === "hydromancer"
+				route.type === "hydromancer" ||
+				route.type === "lo-tech"
 			) {
 				const moduleLayer = MutableHashMap.get(modules, route.moduleName);
 				if (Option.isNone(moduleLayer)) {


### PR DESCRIPTION
## Motivation

Implement LO:TECH module based on WebSocket connection. 
The logic is largely taken from the existing Pyth-Lazer module, but unlike Pyth-Lazer that uses a client library, this module uses the ws WebSocket package directly.

## Explanation of Changes

The API key is available on 1Pass. 
Currently, the API key only gives access to the "PRICE" data type for the following symbols: NVDA, WTIK6, WTIM6, WTIN6, WTIQ6, and WTIU6. The current implementation also only supports the "PRICE" data type, but this can be extended in the future. 

Example configuration:
```json
{
	"modules": [
		{
			"type": "lo-tech",
			"name": "lotech",
			"exchange": "rwa",
			"loTechApiKeyEnvKey": "LOTECH_API_KEY",
			"priceFeeds": [
				{
					"symbol": "NVDA",
					"dataType": "PRICE"
				}
			]
		}
	],
	"routes": [
		{
			"type": "lo-tech",
			"moduleName": "lotech",
			"path": "/lotech/:streams",
			"method": "GET",
			"fetchFromModule": "{:streams}"
		}
	]
}
```

After running the data proxy with the command
```bash
bun start run --disable-proof -c lo-tech.json
```

query the symbols through curl:
```bash
curl http://127.0.0.1:5384/proxy/lotech/NVDA,WTIK6,WTIM6,WTIN6,WTIQ6,WTIU6
```

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

(Write your test plan here)
