### PR TITLE
dxFeed module

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@cosmjs/crypto": "^0.33.1",
         "@cosmjs/encoding": "^0.33.1",
         "@dotenvx/dotenvx": "^1.51.4",
+        "@dxfeed/api": "^1.0.0",
         "@effect/platform": "^0.94.5",
         "@effect/platform-node": "^0.104.1",
         "@elysiajs/openapi": "^1.4.14",
@@ -29,6 +30,7 @@
         "@seda-protocol/data-proxy-sdk": "workspace:*",
         "@seda-protocol/utils": "^2.0.0",
         "big.js": "7.0.1",
+        "cometd-nodejs-client": "^1.0.0",
         "commander": "^12.1.0",
         "confbox": "^0.2.4",
         "date-fns": "^4.1.0",
@@ -120,6 +122,8 @@
     "@dabh/diagnostics": ["@dabh/diagnostics@2.0.3", "", { "dependencies": { "colorspace": "1.1.x", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.51.4", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-AoziS8lRQ3ew/lY5J4JSlzYSN9Fo0oiyMBY37L3Bwq4mOQJT5GSrdZYLFPt6pH1LApDI3ZJceNyx+rHRACZSeQ=="],
+
+    "@dxfeed/api": ["@dxfeed/api@1.6.0", "", { "dependencies": { "@types/cometd": "^4.0.7", "cometd": "^5.0.1" } }, "sha512-3z40Xk4RnmLfe2E0U/mCLIUPCo0ykKETKx0B9QYCO56XXH8QHKizCTT5F68Bkwe/tDWU66yUAImmfaJOPk7S+w=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.4", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-t+iX+Wf5nRKyNzk8dviW3Ikb/280+aEJAnw9YXvCp2tYGPSkMki+NRY+8aNLmVFv3eNtMdvViPNOPxS8SZNP+w=="],
 
@@ -253,6 +257,8 @@
 
     "@types/bun": ["@types/bun@1.2.23", "", { "dependencies": { "bun-types": "1.2.23" } }, "sha512-le8ueOY5b6VKYf19xT3McVbXqLqmxzPXHsQT/q9JHgikJ2X22wyTW3g3ohz2ZMnp7dod6aduIiq8A14Xyimm0A=="],
 
+    "@types/cometd": ["@types/cometd@4.0.15", "", {}, "sha512-z9OiDYijTv0yQNYlXii/FECyEWI1aMVP4w+Yr2AQrG+WNQW4+vPxSIrt/oXc5DFSM4rVu8KyiaqL4/lFCxNThQ=="],
+
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
     "@types/mute-stream": ["@types/mute-stream@0.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow=="],
@@ -269,6 +275,13 @@
 
     "@types/wrap-ansi": ["@types/wrap-ansi@3.0.0", "", {}, "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="],
 
+<<<<<<< HEAD
+=======
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "agent-base": ["agent-base@9.0.0", "", {}, "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA=="],
+
+>>>>>>> 03dfabc (temp)
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -314,6 +327,10 @@
     "colorspace": ["colorspace@1.1.4", "", { "dependencies": { "color": "^3.1.3", "text-hex": "1.0.x" } }, "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "cometd": ["cometd@5.0.23", "", {}, "sha512-ggWywIOSLjdaT7iDI/zzlxW7hmaVuGQhGy8XnMvby/eEhqVdv4m8YK0qO6N7PYtVkxI3XW7Gs5LIlK/tT/xeJw=="],
+
+    "cometd-nodejs-client": ["cometd-nodejs-client@1.5.0", "", { "dependencies": { "cometd": ">=3.1.2", "http-proxy-agent": ">=2.1.0", "https-proxy-agent": ">=2.1.0", "ws": ">=7.2.0" } }, "sha512-q75q5XArn3iqrKrNWQ1e6PdiaBGMwWaoh7xY313G5dK/7nR4So6oBf+N4KYDsOsiONWCtsakqWNElyQ2lILiUw=="],
 
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
@@ -422,6 +439,10 @@
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
     "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@9.0.0", "", { "dependencies": { "agent-base": "9.0.0", "debug": "^4.3.4" } }, "sha512-FcF8VhXYLQcxWCnt/cCpT2apKsRDUGeVEeMqGu4HSTu29U8Yw0TLOjdYIlDsYk3IkUh+taX4IDWpPcCqKDhCjA=="],
+
+    "https-proxy-agent": ["https-proxy-agent@9.0.0", "", { "dependencies": { "agent-base": "9.0.0", "debug": "^4.3.4" } }, "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g=="],
 
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
 
@@ -640,6 +661,8 @@
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "color/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
+
+    "cometd-nodejs-client/cometd": ["cometd@9.0.0", "", {}, "sha512-p+azaf3MRQBoQgmEvMje0MsusfEoAghhlREOyo4CnAthDS0NIg1QTc2kYBXTA75gT2S3kPURS3r6M9CoB1bTIg=="],
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -7,6 +7,8 @@
 		"msw": "2.3.1"
 	},
 	"dependencies": {
+		"@dxfeed/api": "^1.0.0",
+		"cometd-nodejs-client": "^1.0.0",
 		"@commander-js/extra-typings": "^12.1.0",
 		"@cosmjs/crypto": "^0.33.1",
 		"@cosmjs/encoding": "^0.33.1",

--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -20,6 +20,7 @@
 		"@pythnetwork/pyth-lazer-sdk": "^6.2.1",
 		"@seda-protocol/utils": "^2.0.0",
 		"big.js": "7.0.1",
+		"chalk": "^5.3.0",
 		"commander": "^12.1.0",
 		"confbox": "^0.2.4",
 		"date-fns": "^4.1.0",

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -257,15 +257,94 @@ describe("parseConfig", () => {
 			process.env.PYTH_API_KEY = undefined;
 		});
 
+		it("should resolve a dxfeed module without an auth token env key", () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "dxfeed",
+							name: "dxfeed-demo",
+							webSocketUrl: "wss://demo.dxfeed.com/webservice/cometd",
+							subscriptions: [{ symbol: "AEX.IND:TEI" }],
+						},
+					],
+				}),
+			);
+
+			assertIsOkResult(result);
+			const module = result.value.config.modules[0];
+			if (module.type !== "dxfeed") {
+				throw new Error(`expected dxfeed, got ${module.type}`);
+			}
+			expect(module.dxfeedAuthToken).toBeUndefined();
+		});
+
+		it("should reject a dxfeed module when its auth token env var is unset", () => {
+			process.env.DXFEED_TOKEN = undefined;
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "dxfeed",
+							name: "dxfeed-auth",
+							webSocketUrl: "wss://demo.dxfeed.com/webservice/cometd",
+							subscriptions: [{ symbol: "AEX.IND:TEI" }],
+							dxfeedAuthTokenEnvKey: "DXFEED_TOKEN",
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				"Module dxfeed requires DXFEED_TOKEN to be set",
+			);
+		});
+
+		it("should resolve a dxfeed module when its auth token env var is set", () => {
+			process.env.DXFEED_TOKEN = "dxfeed-secret";
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "dxfeed",
+							name: "dxfeed-auth",
+							webSocketUrl: "wss://demo.dxfeed.com/webservice/cometd",
+							subscriptions: [{ symbol: "AEX.IND:TEI" }],
+							dxfeedAuthTokenEnvKey: "DXFEED_TOKEN",
+						},
+					],
+				}),
+			);
+
+			assertIsOkResult(result);
+			const module = result.value.config.modules[0];
+			if (module.type !== "dxfeed") {
+				throw new Error(`expected dxfeed, got ${module.type}`);
+			}
+			expect(module.dxfeedAuthToken).toBe("dxfeed-secret");
+			process.env.DXFEED_TOKEN = undefined;
+		});
+
 		it.each([
 			{
 				missing: "key" as const,
-				env: { CHAINLINK_KEY: undefined, CHAINLINK_SECRET: "secret" },
+				env: {
+					CHAINLINK_KEY: undefined as string | undefined,
+					CHAINLINK_SECRET: "secret",
+				},
 				expected: "Module chainlink-streams requires CHAINLINK_KEY to be set",
 			},
 			{
 				missing: "secret" as const,
-				env: { CHAINLINK_KEY: "key", CHAINLINK_SECRET: undefined },
+				env: {
+					CHAINLINK_KEY: "key",
+					CHAINLINK_SECRET: undefined as string | undefined,
+				},
 				expected:
 					"Module chainlink-streams requires CHAINLINK_SECRET to be set",
 			},

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -17,6 +17,11 @@ import {
 	ChainlinkStreamsModuleRouteSchema,
 	validateChainlinkStreamsModuleRoute,
 } from "./chainlink-streams-module-config";
+import {
+	type DxFeedModuleRoute,
+	DxFeedModuleRouteSchema,
+	validateDxFeedModuleRoute,
+} from "./dxfeed-module-config";
 import { type Modules, ModulesSchema } from "./module-config";
 import {
 	type PythLazerModuleRoute,
@@ -105,6 +110,7 @@ const ConfigSchema = v.strictObject(
 				UpstreamModuleRouteSchema,
 				PythLazerModuleRouteSchema,
 				ChainlinkStreamsModuleRouteSchema,
+				DxFeedModuleRouteSchema,
 			]),
 		),
 		baseURL: maybe(v.string()),
@@ -136,7 +142,9 @@ const ConfigSchema = v.strictObject(
 export type Route =
 	| UpstreamModuleRoute
 	| PythLazerModuleRoute
-	| ChainlinkStreamsModuleRoute;
+	| ChainlinkStreamsModuleRoute
+	| DxFeedModuleRoute;
+
 export interface Config extends v.InferOutput<typeof ConfigSchema> {
 	modules: Modules[];
 }
@@ -229,6 +237,11 @@ export const parseConfig = (
 
 			if (route.type === "chainlink-streams") {
 				yield* validateChainlinkStreamsModuleRoute(route);
+				continue;
+			}
+
+			if (route.type === "dxfeed") {
+				yield* validateDxFeedModuleRoute(route);
 				continue;
 			}
 
@@ -397,6 +410,22 @@ export const parseConfig = (
 							...m,
 							chainlinkKey,
 							chainlinkApiSecret,
+						} satisfies Modules);
+					}),
+					Match.when({ type: "dxfeed" }, (m) => {
+						if (m.dxfeedAuthTokenEnvKey === undefined) {
+							return Effect.succeed({ ...m } satisfies Modules);
+						}
+						const dxfeedAuthToken = process.env[m.dxfeedAuthTokenEnvKey];
+						if (!dxfeedAuthToken) {
+							return Effect.fail(
+								`Module ${m.type} requires ${m.dxfeedAuthTokenEnvKey} to be set`,
+							);
+						}
+						envSecrets.add(dxfeedAuthToken);
+						return Effect.succeed({
+							...m,
+							dxfeedAuthToken,
 						} satisfies Modules);
 					}),
 					Match.exhaustive,

--- a/workspace/data-proxy/src/config/dxfeed-module-config.ts
+++ b/workspace/data-proxy/src/config/dxfeed-module-config.ts
@@ -1,0 +1,66 @@
+import { EventType } from "@dxfeed/api";
+import { Duration, Effect, Option } from "effect";
+import * as v from "valibot";
+import { RouteSchema } from "./route-config";
+
+type EventTypeKeys = `${EventType}`;
+export type DxFeedEventTypeName = EventTypeKeys[number];
+
+export const DxFeedEventTypeSchema = v.picklist(Object.values(EventType));
+
+export const DxFeedSubscriptionSchema = v.object({
+	symbol: v.string(),
+	eventTypes: v.optional(v.array(DxFeedEventTypeSchema)),
+});
+
+export type DxFeedSubscription = v.InferOutput<typeof DxFeedSubscriptionSchema>;
+
+export const DxFeedModuleConfigSchema = v.strictObject({
+	name: v.string(),
+	webSocketUrl: v.string(),
+	subscriptions: v.array(DxFeedSubscriptionSchema),
+	defaultEventTypes: v.optional(v.array(DxFeedEventTypeSchema), [
+		EventType.Summary,
+		EventType.Trade,
+	]),
+	maxFeedsPerRequest: v.optional(v.number(), 100),
+	dxfeedAuthTokenEnvKey: v.optional(v.string()),
+	subscriptionsCleanupTtl: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "2 minutes"),
+		v.transform((ttl) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(ttl),
+				() => new Error("Invalid subscription cleanup TTL"),
+			),
+		),
+	),
+	subscriptionsCleanupInterval: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((interval) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(interval),
+				() => new Error("Invalid subscription cleanup interval"),
+			),
+		),
+	),
+	type: v.literal("dxfeed"),
+});
+
+export interface DxFeedModuleConfig
+	extends v.InferOutput<typeof DxFeedModuleConfigSchema> {
+	dxfeedAuthToken?: string;
+}
+
+export const DxFeedModuleRouteSchema = v.strictObject({
+	...RouteSchema.entries,
+	moduleName: v.string(),
+	fetchFromModule: v.string(),
+	type: v.literal("dxfeed"),
+});
+
+export type DxFeedModuleRoute = v.InferOutput<typeof DxFeedModuleRouteSchema>;
+
+export const validateDxFeedModuleRoute = (_route: DxFeedModuleRoute) =>
+	Effect.gen(function* () {
+		return yield* Effect.void;
+	});

--- a/workspace/data-proxy/src/config/module-config.ts
+++ b/workspace/data-proxy/src/config/module-config.ts
@@ -1,6 +1,8 @@
 import * as v from "valibot";
 import type { ChainlinkStreamsModuleConfig } from "./chainlink-streams-module-config";
 import { ChainlinkStreamsModuleConfigSchema } from "./chainlink-streams-module-config";
+import type { DxFeedModuleConfig } from "./dxfeed-module-config";
+import { DxFeedModuleConfigSchema } from "./dxfeed-module-config";
 import type { PythLazerModuleConfig } from "./pyth-lazer-module-config";
 import { PythLazerModuleConfigSchema } from "./pyth-lazer-module-config";
 
@@ -9,9 +11,13 @@ export const ModulesSchema = v.optional(
 		v.variant("type", [
 			PythLazerModuleConfigSchema,
 			ChainlinkStreamsModuleConfigSchema,
+			DxFeedModuleConfigSchema,
 		]),
 	),
 	[],
 );
 
-export type Modules = PythLazerModuleConfig | ChainlinkStreamsModuleConfig;
+export type Modules =
+	| PythLazerModuleConfig
+	| ChainlinkStreamsModuleConfig
+	| DxFeedModuleConfig;

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -86,6 +86,16 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 					);
 				}),
 			),
+			Match.when({ type: "dxfeed" }, (dxFeedModuleRoute) =>
+				Effect.gen(function* () {
+					yield* Effect.logDebug("Handling dxFeed request");
+					return yield* moduleService.handleRequest(
+						dxFeedModuleRoute,
+						params,
+						request,
+					);
+				}),
+			),
 			Match.when({ type: "upstream" }, (upstreamModuleRoute) =>
 				Effect.gen(function* () {
 					yield* Effect.logDebug("Handling upstream request");

--- a/workspace/data-proxy/src/modules/dxfeed/cometd-bootstrap.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/cometd-bootstrap.ts
@@ -1,0 +1,3 @@
+import * as CometdNodejsClient from "cometd-nodejs-client";
+
+CometdNodejsClient.adapt();

--- a/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
@@ -19,7 +19,10 @@ import type {
 import { createErrorResponse } from "../../controllers/create-error-response";
 import { replaceParams } from "../../utils/replace-params";
 import { FailedToHandleRequest, ModuleService } from "../module";
-import { FailedToHandleDxFeedRequestError } from "./errors";
+import {
+	FailedToConnectDxFeedError,
+	FailedToHandleDxFeedRequestError,
+} from "./errors";
 import {
 	extractNumericPrice,
 	parseDxFeedEventTypes,
@@ -27,7 +30,30 @@ import {
 import { createPriceCache } from "./price-cache";
 import type { DxFeedDataPrice } from "./schema";
 
-// export type { DxFeedSymbol } from "./schema";
+const DXFEED_CONNECTION_TIMEOUT = Duration.seconds(10);
+
+const waitForDxFeedConnected = (
+	feed: Feed,
+	webSocketUrl: string,
+	timeout: Duration.Duration,
+) =>
+	Effect.gen(function* () {
+		const timeoutMs = Duration.toMillis(timeout);
+		const deadline = (yield* Clock.currentTimeMillis) + timeoutMs;
+		while (!feed.subscriptions.state.connected) {
+			const now = yield* Clock.currentTimeMillis;
+			if (now >= deadline) {
+				const err = new FailedToConnectDxFeedError({
+					webSocketUrl,
+					timeoutMs,
+				});
+				yield* Effect.logError(err.message);
+				return yield* Effect.fail(err);
+			}
+			yield* Effect.sleep(Duration.millis(100));
+		}
+		yield* Effect.logInfo("dxFeed connected");
+	});
 
 export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 	Layer.effect(
@@ -72,6 +98,12 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 			yield* Effect.sync(() => {
 				feed.connect(config.webSocketUrl);
 			}).pipe(Effect.orDie);
+
+			yield* waitForDxFeedConnected(
+				feed,
+				config.webSocketUrl,
+				DXFEED_CONNECTION_TIMEOUT,
+			).pipe(Effect.orDie);
 
 			const handleIncomingEvent = (subscribedSymbol: string, event: IEvent) =>
 				Effect.gen(function* () {

--- a/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
@@ -1,0 +1,292 @@
+import "./cometd-bootstrap";
+import { Feed, type IEvent } from "@dxfeed/api";
+import {
+	Clock,
+	Duration,
+	Effect,
+	Layer,
+	MutableHashMap,
+	Option,
+	Queue,
+	Runtime,
+	Schedule,
+} from "effect";
+import type { Route } from "../../config/config-parser";
+import type {
+	DxFeedEventTypeName,
+	DxFeedModuleConfig,
+} from "../../config/dxfeed-module-config";
+import { createErrorResponse } from "../../controllers/create-error-response";
+import { replaceParams } from "../../utils/replace-params";
+import { FailedToHandleRequest, ModuleService } from "../module";
+import { FailedToHandleDxFeedRequestError } from "./errors";
+import {
+	extractNumericPrice,
+	parseDxFeedEventTypes,
+} from "./parse-event-types";
+import { createPriceCache } from "./price-cache";
+import type { DxFeedDataPrice } from "./schema";
+
+// export type { DxFeedSymbol } from "./schema";
+
+export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
+	Layer.effect(
+		ModuleService,
+		Effect.gen(function* () {
+			yield* Effect.logInfo("Initializing dxFeed module", {
+				name: config.name,
+				webSocketUrl: config.webSocketUrl,
+			});
+
+			const runtime = yield* Effect.runtime();
+			const priceCache = yield* createPriceCache();
+			const subscriptions = MutableHashMap.empty<string, number>();
+			const unsubscribeBySymbol = MutableHashMap.empty<string, () => void>();
+			const newSubscriptionRequests = yield* Queue.unbounded<string>();
+			const lastRequestToSubscription = MutableHashMap.empty<string, number>();
+
+			let subscriptionId = 0;
+
+			const defaultEventTypeNames = config.defaultEventTypes;
+
+			const eventTypesByConfiguredSymbol = new Map(
+				config.subscriptions.map((sub) => [
+					sub.symbol,
+					sub.eventTypes ?? defaultEventTypeNames,
+				]),
+			);
+
+			const resolveEventTypeNamesForSymbol = (
+				symbol: string,
+			): readonly DxFeedEventTypeName[] => {
+				const fromConfig = eventTypesByConfiguredSymbol.get(symbol);
+				return fromConfig ?? defaultEventTypeNames;
+			};
+
+			const feed = new Feed();
+
+			if (config.dxfeedAuthToken !== undefined) {
+				feed.setAuthToken(config.dxfeedAuthToken);
+			}
+
+			yield* Effect.sync(() => {
+				feed.connect(config.webSocketUrl);
+			}).pipe(Effect.orDie);
+
+			const handleIncomingEvent = (subscribedSymbol: string, event: IEvent) =>
+				Effect.gen(function* () {
+					yield* Effect.logDebug("dxFeed event", {
+						subscribedSymbol,
+						event,
+					});
+
+					if (
+						event.eventSymbol !== subscribedSymbol &&
+						!event.eventSymbol.startsWith(`${subscribedSymbol}#`)
+					) {
+						return;
+					}
+
+					const price = extractNumericPrice(event);
+					if (price === undefined) {
+						return;
+					}
+
+					const payload: DxFeedDataPrice = {
+						symbol: subscribedSymbol,
+						price,
+						eventType: event.eventType,
+						eventSymbol: event.eventSymbol,
+					};
+					yield* priceCache.setPrice(subscribedSymbol, payload);
+				});
+
+			const subscribeMarketData = (symbol: string) =>
+				Effect.gen(function* () {
+					if (MutableHashMap.has(unsubscribeBySymbol, symbol)) {
+						return;
+					}
+
+					const eventTypeNames = resolveEventTypeNamesForSymbol(symbol);
+					const eventTypes = parseDxFeedEventTypes(eventTypeNames);
+
+					yield* Effect.logInfo(`Subscribing to dxFeed symbol ${symbol}`, {
+						eventTypes: eventTypeNames,
+					});
+
+					const unsub = feed.subscribe<IEvent>(
+						eventTypes,
+						[symbol],
+						(event) => {
+							Runtime.runFork(
+								runtime,
+								handleIncomingEvent(symbol, event).pipe(
+									Effect.catchAll((error) =>
+										Effect.logError(`dxFeed handler error: ${String(error)}`),
+									),
+								),
+							);
+						},
+					);
+
+					MutableHashMap.set(unsubscribeBySymbol, symbol, unsub);
+				});
+
+			const unsubscribeSymbol = (symbol: string) =>
+				Effect.sync(() => {
+					const unsub = MutableHashMap.get(unsubscribeBySymbol, symbol);
+					if (Option.isSome(unsub)) {
+						unsub.value();
+						MutableHashMap.remove(unsubscribeBySymbol, symbol);
+						MutableHashMap.remove(subscriptions, symbol);
+					}
+				});
+
+			for (const sub of config.subscriptions) {
+				const newSubscriptionId = subscriptionId++;
+				MutableHashMap.set(subscriptions, sub.symbol, newSubscriptionId);
+				yield* subscribeMarketData(sub.symbol);
+			}
+
+			const start = () =>
+				Effect.gen(function* () {
+					yield* Effect.logInfo("Starting dxFeed module");
+
+					// Subscribe to new symbols as they are requested
+					yield* Effect.forkDaemon(
+						Effect.gen(function* () {
+							const newSymbol = yield* newSubscriptionRequests.take;
+
+							yield* Effect.logInfo(
+								`Subscribing to dxFeed symbol ${newSymbol}`,
+							);
+
+							const newSubscriptionId = subscriptionId++;
+							MutableHashMap.set(subscriptions, newSymbol, newSubscriptionId);
+
+							const now = yield* Clock.currentTimeMillis;
+							MutableHashMap.set(lastRequestToSubscription, newSymbol, now);
+
+							yield* subscribeMarketData(newSymbol);
+						}).pipe(Effect.forever),
+					);
+
+					// Clean up subscriptions that haven't been requested in a while
+					yield* Effect.forkDaemon(
+						Effect.gen(function* () {
+							const now = yield* Clock.currentTimeMillis;
+							yield* Effect.logDebug(
+								`Cleaning up dxFeed subscriptions (running ${priceCache.size()})`,
+							);
+
+							for (const [
+								symbol,
+								lastRequestTimestamp,
+							] of lastRequestToSubscription) {
+								const cleanupInterval = Duration.toMillis(
+									config.subscriptionsCleanupTtl,
+								);
+								const timeSinceLastRequest = now - lastRequestTimestamp;
+
+								yield* Effect.logDebug(
+									`Time since last request for dxFeed ${symbol}: ${Duration.format(Duration.decode(timeSinceLastRequest))}`,
+								);
+
+								if (timeSinceLastRequest > cleanupInterval) {
+									const configured = eventTypesByConfiguredSymbol.has(symbol);
+									if (configured) {
+										continue;
+									}
+
+									yield* Effect.logInfo(
+										`Cleaning up dxFeed subscription ${symbol}`,
+									);
+									MutableHashMap.remove(lastRequestToSubscription, symbol);
+									yield* priceCache.deletePrice(symbol);
+
+									const id = MutableHashMap.get(subscriptions, symbol);
+									if (Option.isSome(id)) {
+										yield* unsubscribeSymbol(symbol);
+									}
+								}
+							}
+						}).pipe(
+							Effect.schedule(
+								Schedule.spaced(config.subscriptionsCleanupInterval),
+							),
+						),
+					);
+				}).pipe(Effect.annotateLogs("_name", "dxfeed"));
+
+			const handleRequest = (
+				route: Route,
+				params: Record<string, string>,
+				request: Request,
+			) =>
+				Effect.gen(function* () {
+					if (route.type !== "dxfeed") {
+						return yield* Effect.fail(
+							new FailedToHandleRequest({
+								msg: "Route is not a dxFeed module",
+							}),
+						);
+					}
+
+					yield* Effect.logInfo("Handling dxFeed request", { route, params });
+
+					const symbols = replaceParams(route.fetchFromModule, params)
+						.split(",")
+						.map((s) => s.trim())
+						.filter(Boolean);
+
+					if (symbols.length > config.maxFeedsPerRequest) {
+						return yield* Effect.succeed(
+							createErrorResponse(
+								new FailedToHandleDxFeedRequestError({
+									error: `Too many symbols requested, max is ${config.maxFeedsPerRequest} but got ${symbols.length}`,
+								}),
+								400,
+							),
+						);
+					}
+
+					const prices: DxFeedDataPrice[] = [];
+					const now = yield* Clock.currentTimeMillis;
+
+					for (const symbol of symbols) {
+						const lastRequestTimestamp = MutableHashMap.get(
+							lastRequestToSubscription,
+							symbol,
+						);
+						if (Option.isNone(lastRequestTimestamp)) {
+							yield* newSubscriptionRequests.offer(symbol);
+						}
+						MutableHashMap.set(lastRequestToSubscription, symbol, now);
+
+						const price = yield* priceCache.getOrWaitPrice(symbol).pipe(
+							Effect.catchTag("FailedToGetPriceError", (error) =>
+								Effect.gen(function* () {
+									yield* priceCache.deletePrice(symbol);
+									return yield* Effect.fail(error);
+								}),
+							),
+						);
+						prices.push(price);
+					}
+
+					return yield* Effect.succeed(
+						new Response(JSON.stringify(prices), { status: 200 }),
+					);
+				}).pipe(
+					Effect.withSpan("handleDxFeedRequest"),
+					Effect.catchAll((error) => {
+						return Effect.succeed(createErrorResponse(error, 500));
+					}),
+				);
+
+			return {
+				start,
+				handleRequest,
+			};
+		}),
+	);

--- a/workspace/data-proxy/src/modules/dxfeed/errors.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/errors.ts
@@ -1,0 +1,19 @@
+import { Data } from "effect";
+
+export class FailedToHandleDxFeedRequestError extends Data.TaggedError(
+	"FailedToHandleDxFeedRequestError",
+)<{
+	error: string | unknown;
+}> {
+	message = `Failed to handle dxFeed request: ${this.error}`;
+	status = 400;
+}
+
+export class FailedToGetPriceError extends Data.TaggedError(
+	"FailedToGetPriceError",
+)<{
+	error: string | unknown;
+}> {
+	message = `Failed to get price: ${this.error}`;
+	status = 500;
+}

--- a/workspace/data-proxy/src/modules/dxfeed/errors.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/errors.ts
@@ -17,3 +17,12 @@ export class FailedToGetPriceError extends Data.TaggedError(
 	message = `Failed to get price: ${this.error}`;
 	status = 500;
 }
+
+export class FailedToConnectDxFeedError extends Data.TaggedError(
+	"FailedToConnectDxFeedError",
+)<{
+	webSocketUrl: string;
+	timeoutMs: number;
+}> {
+	message = `dxFeed did not reach connected state within ${this.timeoutMs}ms (url: ${this.webSocketUrl})`;
+}

--- a/workspace/data-proxy/src/modules/dxfeed/parse-event-types.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/parse-event-types.ts
@@ -1,0 +1,36 @@
+import { EventType, type IEvent } from "@dxfeed/api";
+import type { DxFeedEventTypeName } from "../../config/dxfeed-module-config";
+
+const allowed = new Set<string>(Object.values(EventType));
+
+export const parseDxFeedEventTypes = (
+	names: readonly DxFeedEventTypeName[],
+): EventType[] =>
+	names.map((name) => {
+		if (!allowed.has(name)) {
+			throw new Error(`Invalid dxFeed EventType: ${name}`);
+		}
+		return name as EventType;
+	});
+
+/** Pull a numeric quote from common dxFeed event fields */
+export const extractNumericPrice = (event: IEvent): number | undefined => {
+	const record = event as Record<string, unknown>;
+	const keys = [
+		"value",
+		"price",
+		"dayClosePrice",
+		"dayOpenPrice",
+		"vwap",
+		"prevDayClosePrice",
+		"bidPrice",
+		"askPrice",
+	] as const;
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "number" && Number.isFinite(value)) {
+			return value;
+		}
+	}
+	return undefined;
+};

--- a/workspace/data-proxy/src/modules/dxfeed/price-cache.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/price-cache.ts
@@ -1,0 +1,115 @@
+import {
+	Deferred,
+	Duration,
+	Effect,
+	MutableHashMap,
+	Option,
+	SynchronizedRef,
+} from "effect";
+import { FailedToGetPriceError } from "./errors";
+import type { DxFeedDataPrice, DxFeedSymbol } from "./schema";
+
+const PRICE_WAIT_TIMEOUT_MS = 3_000;
+
+export const createPriceCache = () =>
+	Effect.gen(function* () {
+		const priceCache = MutableHashMap.empty<DxFeedSymbol, DxFeedDataPrice>();
+		const priceWaiters = yield* SynchronizedRef.make(
+			MutableHashMap.empty<
+				DxFeedSymbol,
+				Deferred.Deferred<DxFeedDataPrice, FailedToGetPriceError>
+			>(),
+		);
+
+		const setPrice = (symbol: DxFeedSymbol, price: DxFeedDataPrice) =>
+			Effect.gen(function* () {
+				MutableHashMap.set(priceCache, symbol, price);
+				const waitersMap = yield* SynchronizedRef.get(priceWaiters);
+				const waiter = MutableHashMap.get(waitersMap, symbol);
+
+				if (Option.isSome(waiter)) {
+					yield* Deferred.succeed(waiter.value, price);
+				}
+
+				MutableHashMap.set(priceCache, symbol, price);
+			});
+
+		const setPriceToError = (symbol: DxFeedSymbol, error: string) =>
+			Effect.gen(function* () {
+				const waitersMap = yield* SynchronizedRef.get(priceWaiters);
+				const waiter = MutableHashMap.get(waitersMap, symbol);
+
+				if (Option.isSome(waiter)) {
+					yield* Deferred.fail(
+						waiter.value,
+						new FailedToGetPriceError({ error }),
+					);
+				}
+			});
+
+		const getOrWaitPrice = (symbol: DxFeedSymbol) =>
+			Effect.gen(function* () {
+				const price = MutableHashMap.get(priceCache, symbol);
+
+				if (Option.isSome(price)) {
+					return price.value;
+				}
+
+				const newWaitersMap = yield* SynchronizedRef.updateAndGetEffect(
+					priceWaiters,
+					Effect.fnUntraced(function* (waitersMap) {
+						const currentWaiter = MutableHashMap.get(waitersMap, symbol);
+
+						if (Option.isSome(currentWaiter)) {
+							return waitersMap;
+						}
+
+						const deferred = yield* Deferred.make<
+							DxFeedDataPrice,
+							FailedToGetPriceError
+						>();
+						MutableHashMap.set(waitersMap, symbol, deferred);
+						return waitersMap;
+					}),
+				);
+
+				const waiter = MutableHashMap.get(newWaitersMap, symbol);
+
+				if (Option.isNone(waiter)) {
+					return yield* Effect.fail(
+						new FailedToGetPriceError({ error: "Price feed waiter not found" }),
+					);
+				}
+
+				return yield* Deferred.await(waiter.value).pipe(
+					Effect.timeoutFail({
+						duration: Duration.seconds(PRICE_WAIT_TIMEOUT_MS),
+						onTimeout: () =>
+							new FailedToGetPriceError({
+								error: `Timed out waiting for price of symbol ${symbol}`,
+							}),
+					}),
+				);
+			});
+
+		const deletePrice = (symbol: DxFeedSymbol) => {
+			MutableHashMap.remove(priceCache, symbol);
+
+			SynchronizedRef.update(priceWaiters, (waitersMap) => {
+				MutableHashMap.remove(waitersMap, symbol);
+				return waitersMap;
+			});
+
+			return Effect.void;
+		};
+
+		const size = () => MutableHashMap.size(priceCache);
+
+		return {
+			getOrWaitPrice,
+			setPrice,
+			deletePrice,
+			setPriceToError,
+			size,
+		};
+	});

--- a/workspace/data-proxy/src/modules/dxfeed/schema.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/schema.ts
@@ -1,0 +1,8 @@
+export type DxFeedSymbol = string;
+
+export type DxFeedDataPrice = {
+	symbol: string;
+	price: number;
+	eventType: string;
+	eventSymbol: string;
+};

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -17,6 +17,7 @@ import { type Config, getHttpMethods } from "./config/config-parser";
 import { DEFAULT_PROXY_ROUTE_GROUP } from "./constants";
 import { handleProxyRequest } from "./controllers/proxy/handle-proxy-request";
 import { ChainlinkStreamsModuleService } from "./modules/chainlink-streams/chainlink-streams";
+import { DxFeedModuleService } from "./modules/dxfeed/dxfeed";
 import { EmptyModuleService, ModuleService } from "./modules/module";
 import { PythLazerModuleService } from "./modules/pyth-lazer/pyth-lazer";
 import type { HttpClientService } from "./services/http-client";
@@ -54,6 +55,9 @@ export const startProxyServer = (
 				Match.when({ type: "chainlink-streams" }, (m) =>
 					Layer.memoize(ChainlinkStreamsModuleService(m)),
 				),
+				Match.when({ type: "dxfeed" }, (m) =>
+					Layer.memoize(DxFeedModuleService(m)),
+				),
 				Match.exhaustive,
 			);
 
@@ -67,7 +71,11 @@ export const startProxyServer = (
 
 		// Make sure that all routes are correctly configured with their respective module
 		for (const route of config.routes) {
-			if (route.type === "pyth-lazer" || route.type === "chainlink-streams") {
+			if (
+				route.type === "pyth-lazer" ||
+				route.type === "chainlink-streams" ||
+				route.type === "dxfeed"
+			) {
 				const moduleLayer = MutableHashMap.get(modules, route.moduleName);
 				if (Option.isNone(moduleLayer)) {
 					return yield* Effect.die(`Module ${route.moduleName} not found`);


### PR DESCRIPTION
## Explanation of Changes

Run `bun start run --disable-proof -c dxfeed.json`
Sample config `dxfeed.json`:
```json
{
	"modules": [
		{
			"type": "dxfeed",
			"name": "dx-demo",
			"webSocketUrl": "wss://demo.dxfeed.com/webservice/cometd",
			"subscriptions": [{ "symbol": "ETH/USD" }],
			"defaultEventTypes": ["Summary", "Trade", "Quote"]
		}
	],
	"routes": [
		{
			"type": "dxfeed",
			"moduleName": "dx-demo",
			"path": "/prices/:symbols",
			"fetchFromModule": "{:symbols}"
		}
	]
}
```
