### PR TITLE
feat(data-proxy): add hydromancer module

### DIFF
--- a/workspace/data-proxy/src/config/hydromancer-module-config.ts
+++ b/workspace/data-proxy/src/config/hydromancer-module-config.ts
@@ -1,3 +1,4 @@
+import { tryParseSync } from "@seda-protocol/utils";
 import { Duration, Effect, Option } from "effect";
 import * as v from "valibot";
 import { RouteSchema } from "./route-config";
@@ -75,14 +76,15 @@ export const HydromancerModuleRouteSchema = v.strictObject({
 	...RouteSchema.entries,
 	type: v.literal("hydromancer"),
 	moduleName: v.string(),
-	fetchFromModule: v.string(),
 });
 
 export type HydromancerModuleRoute = v.InferOutput<
 	typeof HydromancerModuleRouteSchema
 >;
 
-export const validateHydromancerModuleRoute = (route: HydromancerModuleRoute) =>
+export const validateHydromancerModuleRoute = (
+	_route: HydromancerModuleRoute,
+) =>
 	Effect.gen(function* () {
 		return yield* Effect.void;
 	});
@@ -96,3 +98,26 @@ export const AssetCtxSchema = v.object({
 });
 
 export type AssetCtx = v.InferOutput<typeof AssetCtxSchema>;
+
+// Request body the module accepts. Anything else is rejected with 400.
+export const AssetContextRequestBodySchema = v.object({
+	type: v.literal("assetContext"),
+	coins: v.array(v.string()),
+});
+
+export type AssetContextRequestBody = v.InferOutput<
+	typeof AssetContextRequestBodySchema
+>;
+
+export const parseAssetContextRequestBody = (
+	raw: string,
+): Option.Option<AssetContextRequestBody> => {
+	let json: unknown;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		return Option.none();
+	}
+	const parsed = tryParseSync(AssetContextRequestBodySchema, json);
+	return parsed.isErr ? Option.none() : Option.some(parsed.value);
+};

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -148,7 +148,9 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 
 					// Inject all configured headers by the data proxy node configuration
 					// Important: configured headers take precedence over headers sent in the request
-					for (const [key, value] of Object.entries(route.headers)) {
+					for (const [key, value] of Object.entries(
+						upstreamModuleRoute.headers,
+					)) {
 						upstreamHeaders.set(key, replaceParams(value, params));
 					}
 

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -73,7 +73,6 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 						pythLazerModuleRoute,
 						params,
 						request,
-						Option.getOrElse(body, () => ""),
 					);
 				}),
 			),
@@ -84,7 +83,6 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 						chainlinkStreamsModuleRoute,
 						params,
 						request,
-						Option.getOrElse(body, () => ""),
 					);
 				}),
 			),
@@ -95,7 +93,6 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 						dxFeedModuleRoute,
 						params,
 						request,
-						Option.getOrElse(body, () => ""),
 					);
 				}),
 			),

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -73,6 +73,7 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 						pythLazerModuleRoute,
 						params,
 						request,
+						Option.getOrElse(body, () => ""),
 					);
 				}),
 			),
@@ -83,6 +84,7 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 						chainlinkStreamsModuleRoute,
 						params,
 						request,
+						Option.getOrElse(body, () => ""),
 					);
 				}),
 			),
@@ -93,6 +95,7 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 						dxFeedModuleRoute,
 						params,
 						request,
+						Option.getOrElse(body, () => ""),
 					);
 				}),
 			),
@@ -103,6 +106,7 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 						hydromancerModuleRoute,
 						params,
 						request,
+						Option.getOrElse(body, () => ""),
 					);
 				}),
 			),

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
@@ -42,26 +42,43 @@ const ethCtx = {
 	openInterest: "192841.521",
 };
 
-const buildRoute = (fetchFromModule: string) =>
+const buildRoute = () =>
 	v.parse(HydromancerModuleRouteSchema, {
 		type: "hydromancer",
 		moduleName: "hydromancer",
-		path: "/hydromancer/:coin",
-		fetchFromModule,
+		path: "/info",
+		method: ["POST"],
 	});
 
-const callHandle = (
-	config: HydromancerModuleConfig,
-	fetchFromModule: string,
-	params: Record<string, string>,
-) => {
-	const route = buildRoute(fetchFromModule);
+const buildAssetContextRequest = (coins: string[]) =>
+	new Request("http://proxy.local/info", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ type: "assetContext", coins }),
+	});
+
+const callHandle = (config: HydromancerModuleConfig, coins: string[]) => {
+	const route = buildRoute();
+	const program = Effect.gen(function* () {
+		const svc = yield* ModuleService;
+		return yield* svc.handleRequest(route, {}, buildAssetContextRequest(coins));
+	});
+	return Effect.runPromise(
+		program.pipe(Effect.provide(HydromancerModuleService(config))),
+	);
+};
+
+const callHandleRaw = (config: HydromancerModuleConfig, rawBody: string) => {
+	const route = buildRoute();
 	const program = Effect.gen(function* () {
 		const svc = yield* ModuleService;
 		return yield* svc.handleRequest(
 			route,
-			params,
-			new Request("http://proxy.local/hydromancer/BTC"),
+			{},
+			new Request("http://proxy.local/info", {
+				method: "POST",
+				body: rawBody,
+			}),
 		);
 	});
 	return Effect.runPromise(
@@ -69,24 +86,22 @@ const callHandle = (
 	);
 };
 
-type CallSpec = { fetchFromModule: string; params: Record<string, string> };
-
 // Runs multiple handleRequest invocations against the SAME module instance,
 // so cache state carries across calls. Returns responses in order.
 const callHandleSequence = (
 	config: HydromancerModuleConfig,
-	calls: CallSpec[],
+	calls: string[][],
 	between?: () => Promise<void>,
 ) => {
+	const route = buildRoute();
 	const program = Effect.gen(function* () {
 		const svc = yield* ModuleService;
 		const responses: Response[] = [];
-		for (const call of calls) {
-			const route = buildRoute(call.fetchFromModule);
+		for (const coins of calls) {
 			const response = yield* svc.handleRequest(
 				route,
-				call.params,
-				new Request("http://proxy.local/hydromancer"),
+				{},
+				buildAssetContextRequest(coins),
 			);
 			responses.push(response);
 			if (between) {
@@ -130,14 +145,14 @@ describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
 		);
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-		const response = await callHandle(baseConfig, "BTC,ETH", {});
+		const response = await callHandle(baseConfig, ["BTC", "ETH"]);
 		expect(response.status).toBe(200);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const body = await response.json();
 		expect(body).toEqual({ BTC: btcCtx, ETH: ethCtx });
 	});
 
-	it("filters out coins that come back null", async () => {
+	it("keeps null entries for coins that come back null", async () => {
 		globalThis.fetch = mock(
 			async () =>
 				new Response(JSON.stringify({ BTC: btcCtx, ZZZ: null }), {
@@ -145,35 +160,21 @@ describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
 				}),
 		) as unknown as typeof fetch;
 
-		const response = await callHandle(baseConfig, "BTC,ZZZ", {});
+		const response = await callHandle(baseConfig, ["BTC", "ZZZ"]);
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body).toEqual({ BTC: btcCtx });
+		expect(body).toEqual({ BTC: btcCtx, ZZZ: null });
 	});
 
-	it("returns an empty object when every coin is unknown", async () => {
+	it("returns null for every requested coin when none resolve", async () => {
 		globalThis.fetch = mock(
 			async () => new Response(JSON.stringify({ ZZZ: null }), { status: 200 }),
 		) as unknown as typeof fetch;
 
-		const response = await callHandle(baseConfig, "ZZZ", {});
+		const response = await callHandle(baseConfig, ["ZZZ"]);
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body).toEqual({});
-	});
-
-	it("substitutes path params into fetchFromModule", async () => {
-		const captured: { body?: unknown } = {};
-		globalThis.fetch = mock(
-			async (_input: URL | RequestInfo, init?: RequestInit) => {
-				captured.body = JSON.parse(init?.body as string);
-				return new Response(JSON.stringify({ BTC: btcCtx }), { status: 200 });
-			},
-		) as unknown as typeof fetch;
-
-		const response = await callHandle(baseConfig, "{:coin}", { coin: "BTC" });
-		expect(response.status).toBe(200);
-		expect(captured.body).toEqual({ type: "assetContext", coins: ["BTC"] });
+		expect(body).toEqual({ ZZZ: null });
 	});
 
 	it("passes through a 4xx upstream status", async () => {
@@ -181,7 +182,7 @@ describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
 			async () => new Response("Bad request", { status: 400 }),
 		) as unknown as typeof fetch;
 
-		const response = await callHandle(baseConfig, "BTC", {});
+		const response = await callHandle(baseConfig, ["BTC"]);
 		expect(response.status).toBe(400);
 	});
 
@@ -190,7 +191,7 @@ describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
 			async () => new Response("internal", { status: 500 }),
 		) as unknown as typeof fetch;
 
-		const response = await callHandle(baseConfig, "BTC", {});
+		const response = await callHandle(baseConfig, ["BTC"]);
 		expect(response.status).toBe(502);
 	});
 
@@ -201,7 +202,7 @@ describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
 			throw error;
 		}) as unknown as typeof fetch;
 
-		const response = await callHandle(baseConfig, "BTC", {});
+		const response = await callHandle(baseConfig, ["BTC"]);
 		expect(response.status).toBe(504);
 	});
 
@@ -213,7 +214,7 @@ describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
 				}),
 		) as unknown as typeof fetch;
 
-		const response = await callHandle(baseConfig, "BTC", {});
+		const response = await callHandle(baseConfig, ["BTC"]);
 		expect(response.status).toBe(502);
 	});
 
@@ -226,8 +227,22 @@ describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
 			async () => new Response("{}", { status: 200 }),
 		) as unknown as typeof fetch;
 
-		const response = await callHandle(tightConfig, "BTC,ETH,SOL", {});
+		const response = await callHandle(tightConfig, ["BTC", "ETH", "SOL"]);
 		expect(response.status).toBe(400);
+	});
+});
+
+describe("HydromancerModuleService.handleRequest (non-assetContext)", () => {
+	it("returns 400 for a body shape other than assetContext", async () => {
+		const fetchMock = mock(async () => new Response("{}", { status: 200 }));
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const response = await callHandleRaw(
+			baseConfig,
+			JSON.stringify({ type: "userState" }),
+		);
+		expect(response.status).toBe(400);
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });
 
@@ -239,10 +254,7 @@ describe("HydromancerModuleService cache behavior", () => {
 		);
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-		const [r1, r2] = await callHandleSequence(baseConfig, [
-			{ fetchFromModule: "BTC", params: {} },
-			{ fetchFromModule: "BTC", params: {} },
-		]);
+		const [r1, r2] = await callHandleSequence(baseConfig, [["BTC"], ["BTC"]]);
 
 		expect(r1.status).toBe(200);
 		expect(r2.status).toBe(200);
@@ -264,10 +276,7 @@ describe("HydromancerModuleService cache behavior", () => {
 
 		await callHandleSequence(
 			tightConfig,
-			[
-				{ fetchFromModule: "BTC", params: {} },
-				{ fetchFromModule: "BTC", params: {} },
-			],
+			[["BTC"], ["BTC"]],
 			() => new Promise((r) => setTimeout(r, 60)),
 		);
 
@@ -291,8 +300,8 @@ describe("HydromancerModuleService cache behavior", () => {
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 
 		const [r1, r2] = await callHandleSequence(baseConfig, [
-			{ fetchFromModule: "BTC", params: {} },
-			{ fetchFromModule: "BTC,ETH", params: {} },
+			["BTC"],
+			["BTC", "ETH"],
 		]);
 
 		expect(r1.status).toBe(200);
@@ -362,11 +371,11 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 		const program = Effect.gen(function* () {
 			const svc = yield* ModuleService;
 			yield* svc.start();
-			const route = buildRoute("BTC");
+			const route = buildRoute();
 			return yield* svc.handleRequest(
 				route,
 				{},
-				new Request("http://proxy.local/hydromancer"),
+				buildAssetContextRequest(["BTC"]),
 			);
 		});
 
@@ -400,17 +409,9 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 		const program = Effect.gen(function* () {
 			const svc = yield* ModuleService;
 			yield* svc.start();
-			const route = buildRoute("BTC");
-			yield* svc.handleRequest(
-				route,
-				{},
-				new Request("http://proxy.local/hydromancer"),
-			);
-			yield* svc.handleRequest(
-				route,
-				{},
-				new Request("http://proxy.local/hydromancer"),
-			);
+			const route = buildRoute();
+			yield* svc.handleRequest(route, {}, buildAssetContextRequest(["BTC"]));
+			yield* svc.handleRequest(route, {}, buildAssetContextRequest(["BTC"]));
 		});
 
 		await Effect.runPromise(
@@ -445,12 +446,8 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 		const program = Effect.gen(function* () {
 			const svc = yield* ModuleService;
 			yield* svc.start();
-			const route = buildRoute("BTC");
-			yield* svc.handleRequest(
-				route,
-				{},
-				new Request("http://proxy.local/hydromancer"),
-			);
+			const route = buildRoute();
+			yield* svc.handleRequest(route, {}, buildAssetContextRequest(["BTC"]));
 		});
 
 		await Effect.runPromise(
@@ -513,25 +510,17 @@ describe("HydromancerModuleService REST fallback when WS is errored", () => {
 			ws.triggerOpen();
 			yield* Effect.sleep(Duration.millis(0));
 
-			const route = buildRoute("BTC");
+			const route = buildRoute();
 
 			// Request 1: cache miss, REST populates BTC.
-			yield* svc.handleRequest(
-				route,
-				{},
-				new Request("http://proxy.local/hydromancer"),
-			);
+			yield* svc.handleRequest(route, {}, buildAssetContextRequest(["BTC"]));
 
 			// Drop the socket: cache.markSocketError fires, currentWS clears.
 			ws.close();
 			yield* Effect.sleep(Duration.millis(0));
 
 			// Request 2: BTC is fresh in cache but socketError forces another REST.
-			yield* svc.handleRequest(
-				route,
-				{},
-				new Request("http://proxy.local/hydromancer"),
-			);
+			yield* svc.handleRequest(route, {}, buildAssetContextRequest(["BTC"]));
 		});
 
 		await Effect.runPromise(

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
@@ -57,11 +57,20 @@ const buildAssetContextRequest = (coins: string[]) =>
 		body: JSON.stringify({ type: "assetContext", coins }),
 	});
 
+const assetContextBody = (coins: string[]) =>
+	JSON.stringify({ type: "assetContext", coins });
+
 const callHandle = (config: HydromancerModuleConfig, coins: string[]) => {
 	const route = buildRoute();
+	const body = assetContextBody(coins);
 	const program = Effect.gen(function* () {
 		const svc = yield* ModuleService;
-		return yield* svc.handleRequest(route, {}, buildAssetContextRequest(coins));
+		return yield* svc.handleRequest(
+			route,
+			{},
+			buildAssetContextRequest(coins),
+			body,
+		);
 	});
 	return Effect.runPromise(
 		program.pipe(Effect.provide(HydromancerModuleService(config))),
@@ -79,6 +88,7 @@ const callHandleRaw = (config: HydromancerModuleConfig, rawBody: string) => {
 				method: "POST",
 				body: rawBody,
 			}),
+			rawBody,
 		);
 	});
 	return Effect.runPromise(
@@ -102,6 +112,7 @@ const callHandleSequence = (
 				route,
 				{},
 				buildAssetContextRequest(coins),
+				assetContextBody(coins),
 			);
 			responses.push(response);
 			if (between) {
@@ -376,6 +387,7 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 				route,
 				{},
 				buildAssetContextRequest(["BTC"]),
+				assetContextBody(["BTC"]),
 			);
 		});
 
@@ -410,8 +422,18 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 			const svc = yield* ModuleService;
 			yield* svc.start();
 			const route = buildRoute();
-			yield* svc.handleRequest(route, {}, buildAssetContextRequest(["BTC"]));
-			yield* svc.handleRequest(route, {}, buildAssetContextRequest(["BTC"]));
+			yield* svc.handleRequest(
+				route,
+				{},
+				buildAssetContextRequest(["BTC"]),
+				assetContextBody(["BTC"]),
+			);
+			yield* svc.handleRequest(
+				route,
+				{},
+				buildAssetContextRequest(["BTC"]),
+				assetContextBody(["BTC"]),
+			);
 		});
 
 		await Effect.runPromise(
@@ -447,7 +469,12 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 			const svc = yield* ModuleService;
 			yield* svc.start();
 			const route = buildRoute();
-			yield* svc.handleRequest(route, {}, buildAssetContextRequest(["BTC"]));
+			yield* svc.handleRequest(
+				route,
+				{},
+				buildAssetContextRequest(["BTC"]),
+				assetContextBody(["BTC"]),
+			);
 		});
 
 		await Effect.runPromise(
@@ -513,14 +540,24 @@ describe("HydromancerModuleService REST fallback when WS is errored", () => {
 			const route = buildRoute();
 
 			// Request 1: cache miss, REST populates BTC.
-			yield* svc.handleRequest(route, {}, buildAssetContextRequest(["BTC"]));
+			yield* svc.handleRequest(
+				route,
+				{},
+				buildAssetContextRequest(["BTC"]),
+				assetContextBody(["BTC"]),
+			);
 
 			// Drop the socket: cache.markSocketError fires, currentWS clears.
 			ws.close();
 			yield* Effect.sleep(Duration.millis(0));
 
 			// Request 2: BTC is fresh in cache but socketError forces another REST.
-			yield* svc.handleRequest(route, {}, buildAssetContextRequest(["BTC"]));
+			yield* svc.handleRequest(
+				route,
+				{},
+				buildAssetContextRequest(["BTC"]),
+				assetContextBody(["BTC"]),
+			);
 		});
 
 		await Effect.runPromise(

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
@@ -57,7 +57,7 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 				route: Route,
 				_params: Record<string, string>,
 				_request: Request,
-				body: string,
+				body?: string,
 			) =>
 				Effect.gen(function* () {
 					if (route.type !== "hydromancer") {
@@ -68,12 +68,11 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 						);
 					}
 
-					const parsedBody = parseAssetContextRequestBody(body);
+					const parsedBody = parseAssetContextRequestBody(body ?? "");
 					if (Option.isNone(parsedBody)) {
 						return yield* Effect.fail(
 							new FailedToHandleHydromancerRequestError({
-								error:
-									"Hydromancer module only handles assetContext bodies",
+								error: "Hydromancer module only handles assetContext bodies",
 								status: 400,
 							}),
 						);

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
@@ -56,7 +56,8 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 			const handleRequest = (
 				route: Route,
 				_params: Record<string, string>,
-				request: Request,
+				_request: Request,
+				body: string,
 			) =>
 				Effect.gen(function* () {
 					if (route.type !== "hydromancer") {
@@ -67,15 +68,7 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 						);
 					}
 
-					const bodyText = yield* Effect.tryPromise({
-						try: () => request.clone().text(),
-						catch: () =>
-							new FailedToHandleHydromancerRequestError({
-								error: "Failed to read request body",
-								status: 400,
-							}),
-					});
-					const parsedBody = parseAssetContextRequestBody(bodyText);
+					const parsedBody = parseAssetContextRequestBody(body);
 					if (Option.isNone(parsedBody)) {
 						return yield* Effect.fail(
 							new FailedToHandleHydromancerRequestError({

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
@@ -1,12 +1,12 @@
 import { Clock, Duration, Effect, Layer, MutableHashMap, Option } from "effect";
 import type { Route } from "../../config/config-parser";
-import type {
-	AssetCtx,
-	HydromancerModuleConfig,
+import {
+	type AssetCtx,
+	type HydromancerModuleConfig,
+	parseAssetContextRequestBody,
 } from "../../config/hydromancer-module-config";
 import { createErrorResponse } from "../../controllers/create-error-response";
 import { forkIdleCleanup } from "../../utils/idle-cleanup";
-import { replaceParams } from "../../utils/replace-params";
 import { FailedToHandleRequest, ModuleService } from "../module";
 import { createAssetCache } from "./asset-cache";
 import { FailedToHandleHydromancerRequestError } from "./errors";
@@ -55,8 +55,8 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 
 			const handleRequest = (
 				route: Route,
-				params: Record<string, string>,
-				_request: Request,
+				_params: Record<string, string>,
+				request: Request,
 			) =>
 				Effect.gen(function* () {
 					if (route.type !== "hydromancer") {
@@ -67,7 +67,25 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 						);
 					}
 
-					const coins = replaceParams(route.fetchFromModule, params).split(",");
+					const bodyText = yield* Effect.tryPromise({
+						try: () => request.clone().text(),
+						catch: () =>
+							new FailedToHandleHydromancerRequestError({
+								error: "Failed to read request body",
+								status: 400,
+							}),
+					});
+					const parsedBody = parseAssetContextRequestBody(bodyText);
+					if (Option.isNone(parsedBody)) {
+						return yield* Effect.fail(
+							new FailedToHandleHydromancerRequestError({
+								error:
+									"Hydromancer module only handles assetContext bodies",
+								status: 400,
+							}),
+						);
+					}
+					const coins = parsedBody.value.coins;
 
 					if (coins.length > config.maxCoinsPerRequest) {
 						return yield* Effect.fail(
@@ -86,7 +104,11 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 						MutableHashMap.set(lastRequestToCoin, coin, now);
 					}
 
-					const resolved: Record<string, AssetCtx> = {};
+					// Pre-seed every requested coin to null so the response shape matches
+					// Hydromancer's native /info: a key per coin, unresolved ones stay null.
+					const resolved: Record<string, AssetCtx | null> = {};
+					for (const coin of coins) resolved[coin] = null;
+
 					const toFetch: string[] = [];
 
 					for (const coin of coins) {

--- a/workspace/data-proxy/src/modules/module.ts
+++ b/workspace/data-proxy/src/modules/module.ts
@@ -16,7 +16,7 @@ export class ModuleService extends Context.Tag("ModuleService")<
 			route: Route,
 			params: Record<string, string>,
 			request: Request,
-			body: string,
+			body?: string,
 		) => Effect.Effect<Response, FailedToHandleRequest>;
 	}
 >() {}
@@ -30,7 +30,7 @@ export const EmptyModuleService = Layer.effect(
 				route: Route,
 				params: Record<string, string>,
 				request: Request,
-				body: string,
+				body?: string,
 			) => Effect.succeed(new Response("Not implemented", { status: 500 })),
 		});
 	}),

--- a/workspace/data-proxy/src/modules/module.ts
+++ b/workspace/data-proxy/src/modules/module.ts
@@ -16,6 +16,7 @@ export class ModuleService extends Context.Tag("ModuleService")<
 			route: Route,
 			params: Record<string, string>,
 			request: Request,
+			body: string,
 		) => Effect.Effect<Response, FailedToHandleRequest>;
 	}
 >() {}
@@ -29,6 +30,7 @@ export const EmptyModuleService = Layer.effect(
 				route: Route,
 				params: Record<string, string>,
 				request: Request,
+				body: string,
 			) => Effect.succeed(new Response("Not implemented", { status: 500 })),
 		});
 	}),


### PR DESCRIPTION
Adds a Hydromancer module with WS subscriptions for `activeAssetCtx` and a REST batch fallback when the cache is stale or the socket is errored. Requests to `POST /info` go through the module: assetContext bodies are served from cache or batch-fetched, anything else returns 400. The branch also lands the Bun-to-Node runtime migration (with a follow-up fix that threads the already-parsed request body through `ModuleService.handleRequest`, since elysia's parse step now consumes the request stream), dxfeed event handling, and a shared idle-cleanup utility used by hydromancer and pyth-lazer.