### PR TITLE
Support more event types for dxfeed

### DIFF
--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -3,7 +3,7 @@ import {
 	assertIsErrorResult,
 	assertIsOkResult,
 } from "@seda-protocol/utils/testing";
-import { Effect } from "effect";
+import { Effect, LogLevel, Logger } from "effect";
 import { parseConfig } from "./config/config-parser";
 
 describe("parseConfig", () => {
@@ -168,7 +168,7 @@ describe("parseConfig", () => {
 						upstreamUrl: "aaaaaa.com/{*}",
 					},
 				],
-			}),
+			}).pipe(Logger.withMinimumLogLevel(LogLevel.None)),
 		);
 
 		expect(result).toBeOkResult();

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -266,9 +266,7 @@ describe("parseConfig", () => {
 							type: "dxfeed",
 							name: "dxfeed-demo",
 							webSocketUrl: "wss://demo.dxfeed.com/webservice/cometd",
-							subscriptions: [
-								{ symbol: "AEX.IND:TEI", type: "Quote" },
-							],
+							subscriptions: [{ symbol: "AEX.IND:TEI", type: "Quote" }],
 						},
 					],
 				}),
@@ -293,9 +291,7 @@ describe("parseConfig", () => {
 							type: "dxfeed",
 							name: "dxfeed-auth",
 							webSocketUrl: "wss://demo.dxfeed.com/webservice/cometd",
-							subscriptions: [
-								{ symbol: "AEX.IND:TEI", type: "Quote" },
-							],
+							subscriptions: [{ symbol: "AEX.IND:TEI", type: "Quote" }],
 							dxfeedAuthTokenEnvKey: "DXFEED_TOKEN",
 						},
 					],
@@ -318,9 +314,7 @@ describe("parseConfig", () => {
 							type: "dxfeed",
 							name: "dxfeed-auth",
 							webSocketUrl: "wss://demo.dxfeed.com/webservice/cometd",
-							subscriptions: [
-								{ symbol: "AEX.IND:TEI", type: "Quote" },
-							],
+							subscriptions: [{ symbol: "AEX.IND:TEI", type: "Quote" }],
 							dxfeedAuthTokenEnvKey: "DXFEED_TOKEN",
 						},
 					],

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -266,7 +266,9 @@ describe("parseConfig", () => {
 							type: "dxfeed",
 							name: "dxfeed-demo",
 							webSocketUrl: "wss://demo.dxfeed.com/webservice/cometd",
-							subscriptions: ["AEX.IND:TEI"],
+							subscriptions: [
+								{ symbol: "AEX.IND:TEI", type: "Quote" },
+							],
 						},
 					],
 				}),
@@ -291,7 +293,9 @@ describe("parseConfig", () => {
 							type: "dxfeed",
 							name: "dxfeed-auth",
 							webSocketUrl: "wss://demo.dxfeed.com/webservice/cometd",
-							subscriptions: ["AEX.IND:TEI"],
+							subscriptions: [
+								{ symbol: "AEX.IND:TEI", type: "Quote" },
+							],
 							dxfeedAuthTokenEnvKey: "DXFEED_TOKEN",
 						},
 					],
@@ -314,7 +318,9 @@ describe("parseConfig", () => {
 							type: "dxfeed",
 							name: "dxfeed-auth",
 							webSocketUrl: "wss://demo.dxfeed.com/webservice/cometd",
-							subscriptions: ["AEX.IND:TEI"],
+							subscriptions: [
+								{ symbol: "AEX.IND:TEI", type: "Quote" },
+							],
 							dxfeedAuthTokenEnvKey: "DXFEED_TOKEN",
 						},
 					],

--- a/workspace/data-proxy/src/config/dxfeed-module-config.ts
+++ b/workspace/data-proxy/src/config/dxfeed-module-config.ts
@@ -26,10 +26,19 @@ const DxFeedSubscriptionSchema = v.union([
 
 export const DxFeedModuleConfigSchema = v.strictObject({
 	name: v.string(),
+	dxfeedAuthTokenEnvKey: v.optional(v.string()),
 	webSocketUrl: v.string(),
+	/**
+	 * Aggregation period in seconds.
+	 * If not specified, the channel will use the default value.
+	 * If specified as 0, the channel will try not aggregate events.
+	 */
+	acceptAggregationPeriod: v.optional(v.number()),
+	/**
+	 * Default subscriptions to be added to the feed.
+	 */
 	subscriptions: v.optional(v.array(DxFeedSubscriptionSchema), []),
 	maxFeedsPerRequest: v.optional(v.number(), 100),
-	dxfeedAuthTokenEnvKey: v.optional(v.string()),
 	subscriptionsCleanupTtl: v.pipe(
 		v.optional(v.union([v.number(), v.string()]), "2 minutes"),
 		v.transform((ttl) =>
@@ -53,7 +62,7 @@ export const DxFeedModuleConfigSchema = v.strictObject({
 
 // DxFeedKey is a eventType-symbol composite key used to identify subscriptions.
 // Event type prefix is separated from symbol by a dash.
-export type DxFeedKey = string;
+export type DxFeedKey = `${DxFeedEventType}-${string}`;
 
 export function dxfeedKey(
 	symbol: string,
@@ -71,7 +80,7 @@ export const DxFeedModuleRouteSchema = v.strictObject({
 	...RouteSchema.entries,
 	moduleName: v.string(),
 	fetchFromModule: v.string(),
-	eventType: v.optional(v.picklist(dxfeedEventTypes), "Quote"),
+	eventType: v.picklist(dxfeedEventTypes),
 	type: v.literal("dxfeed"),
 });
 

--- a/workspace/data-proxy/src/config/dxfeed-module-config.ts
+++ b/workspace/data-proxy/src/config/dxfeed-module-config.ts
@@ -2,18 +2,32 @@ import { Duration, Effect, Option } from "effect";
 import * as v from "valibot";
 import { RouteSchema } from "./route-config";
 
-export const eventFields = [
-	"askPrice",
-	"bidPrice",
-	"bidTime",
-	"askTime",
+export const dxfeedEventTypes = [
+	// Events on orders:
+	"Quote",
+	"Order",
+	"SpreadOrder",
+	// Events on transactions:
+	"Trade",
+	"TradeETH",
+	"TimeAndSale",
+	"Summary",
+	// Information about the security instrument:
+	"Profile",
 ] as const;
+export type DxFeedEventType = (typeof dxfeedEventTypes)[number];
+
+const DxFeedSubscriptionSchema = v.union([
+	v.strictObject({
+		symbol: v.string(),
+		type: v.picklist(dxfeedEventTypes),
+	}),
+]);
 
 export const DxFeedModuleConfigSchema = v.strictObject({
 	name: v.string(),
 	webSocketUrl: v.string(),
-	subscriptions: v.optional(v.array(v.string()), []),
-	eventFields: v.optional(v.array(v.picklist(eventFields)), eventFields),
+	subscriptions: v.optional(v.array(DxFeedSubscriptionSchema), []),
 	maxFeedsPerRequest: v.optional(v.number(), 100),
 	dxfeedAuthTokenEnvKey: v.optional(v.string()),
 	subscriptionsCleanupTtl: v.pipe(
@@ -37,11 +51,16 @@ export const DxFeedModuleConfigSchema = v.strictObject({
 	type: v.literal("dxfeed"),
 });
 
-export type DxFeedModuleEventField = v.InferOutput<
-	typeof DxFeedModuleConfigSchema
->["eventFields"];
+// DxFeedKey is a eventType-symbol composite key used to identify subscriptions.
+// Event type prefix is separated from symbol by a dash.
+export type DxFeedKey = string;
 
-export type DxFeedEventField = DxFeedModuleEventField[number];
+export function dxfeedKey(
+	symbol: string,
+	eventType: DxFeedEventType,
+): DxFeedKey {
+	return `${eventType}-${symbol}`;
+}
 
 export interface DxFeedModuleConfig
 	extends v.InferOutput<typeof DxFeedModuleConfigSchema> {
@@ -52,6 +71,7 @@ export const DxFeedModuleRouteSchema = v.strictObject({
 	...RouteSchema.entries,
 	moduleName: v.string(),
 	fetchFromModule: v.string(),
+	eventType: v.optional(v.picklist(dxfeedEventTypes), "Quote"),
 	type: v.literal("dxfeed"),
 });
 

--- a/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
@@ -17,13 +17,21 @@ import {
 	Schedule,
 } from "effect";
 import type { Route } from "../../config/config-parser";
-import type { DxFeedModuleConfig } from "../../config/dxfeed-module-config";
+import {
+	type DxFeedEventType,
+	type DxFeedKey,
+	type DxFeedModuleConfig,
+	dxfeedKey,
+} from "../../config/dxfeed-module-config";
 import { createErrorResponse } from "../../controllers/create-error-response";
 import { replaceParams } from "../../utils/replace-params";
 import { FailedToHandleRequest, ModuleService } from "../module";
 import { createPriceCache } from "../shared/price-cache";
 import { FailedToHandleDxFeedRequestError } from "./errors";
-import { type DxFeedDataPrice, extractPriceDataFromEvent } from "./schema";
+import {
+	type DxFeedFullEventData,
+	extractFullEventDataFromEvent,
+} from "./schema";
 
 export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 	Layer.effect(
@@ -35,11 +43,17 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 			});
 
 			const runtime = yield* Effect.runtime();
-			const priceCache = yield* createPriceCache<string, DxFeedDataPrice>();
-			const subscriptions = MutableHashMap.empty<string, number>();
-			const unsubscribeBySymbol = MutableHashMap.empty<string, () => void>();
-			const newSubscriptionRequests = yield* Queue.unbounded<string>();
-			const lastRequestToSubscription = MutableHashMap.empty<string, number>();
+			const priceCache = yield* createPriceCache<
+				DxFeedKey,
+				DxFeedFullEventData
+			>();
+			const subscriptions = MutableHashMap.empty<DxFeedKey, number>();
+			const unsubscribeByKey = MutableHashMap.empty<DxFeedKey, () => void>();
+			const newSubscriptionRequests = yield* Queue.unbounded<{
+				symbol: string;
+				eventType: DxFeedEventType;
+			}>();
+			const lastRequestByKey = MutableHashMap.empty<DxFeedKey, number>();
 
 			let subscriptionId = 0;
 
@@ -56,10 +70,6 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 			feed.configure({
 				acceptAggregationPeriod: 10,
 				acceptDataFormat: FeedDataFormat.FULL,
-				acceptEventFields: {
-					// We always want the eventSymbol
-					Quote: ["eventSymbol", ...config.eventFields],
-				},
 			});
 
 			feed.addEventListener((events) => {
@@ -69,10 +79,7 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 						for (const event of events) {
 							yield* Effect.logDebug("dxFeed event", event);
 
-							const priceData = extractPriceDataFromEvent(
-								event,
-								config.eventFields,
-							);
+							const priceData = extractFullEventDataFromEvent(event);
 							if (priceData === undefined) {
 								yield* Effect.logError(
 									"Failed to extract price data from event",
@@ -83,15 +90,20 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 								continue;
 							}
 
-							if (MutableHashMap.has(subscriptions, priceData.symbol)) {
-								yield* priceCache.setPrice(priceData.symbol, priceData);
+							const eventType =
+								((event as Record<string, unknown>).eventType as string) ??
+								"Quote";
+							const key = dxfeedKey(
+								priceData.symbol,
+								eventType as DxFeedEventType,
+							);
+
+							if (MutableHashMap.has(subscriptions, key)) {
+								yield* priceCache.setPrice(key, priceData);
 							} else {
-								yield* Effect.logError(
-									"Received event for unsubscribed symbol",
-									{
-										symbol: priceData.symbol,
-									},
-								);
+								yield* Effect.logError("Received event for unsubscribed key", {
+									key,
+								});
 							}
 						}
 					}),
@@ -102,40 +114,50 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 				Runtime.runSync(runtime, Effect.logError("dxFeed error", error));
 			});
 
-			const subscribeSymbol = (symbol: string) =>
+			const subscribeSymbol = (
+				symbol: string,
+				eventType: DxFeedEventType = "Quote",
+			) =>
 				Effect.gen(function* () {
-					if (MutableHashMap.has(unsubscribeBySymbol, symbol)) {
+					const key = dxfeedKey(symbol, eventType);
+					if (MutableHashMap.has(unsubscribeByKey, key)) {
 						return;
 					}
 
-					yield* Effect.logInfo(`Subscribing to dxFeed symbol ${symbol}`);
+					yield* Effect.logInfo(
+						`Subscribing to dxFeed symbol ${symbol} (${eventType})`,
+					);
 
 					const subscription = {
-						type: "Quote",
+						type: eventType,
 						symbol,
 					};
 
 					feed.addSubscriptions([subscription]);
 
-					MutableHashMap.set(unsubscribeBySymbol, symbol, () =>
+					MutableHashMap.set(unsubscribeByKey, key, () =>
 						feed.removeSubscriptions(subscription),
 					);
 				});
 
-			const unsubscribeSymbol = (symbol: string) => {
-				const unsub = MutableHashMap.get(unsubscribeBySymbol, symbol);
+			const unsubscribeByCompositeKey = (key: string) => {
+				const unsub = MutableHashMap.get(unsubscribeByKey, key);
 
 				if (Option.isSome(unsub)) {
 					unsub.value();
-					MutableHashMap.remove(unsubscribeBySymbol, symbol);
-					MutableHashMap.remove(subscriptions, symbol);
+					MutableHashMap.remove(unsubscribeByKey, key);
+					MutableHashMap.remove(subscriptions, key);
 				}
 			};
 
-			for (const symbol of config.subscriptions) {
+			for (const sub of config.subscriptions) {
+				const symbol = sub.symbol;
+				const eventType = sub.type;
+
+				const key = dxfeedKey(symbol, eventType);
 				const newSubscriptionId = subscriptionId++;
-				MutableHashMap.set(subscriptions, symbol, newSubscriptionId);
-				yield* subscribeSymbol(symbol);
+				MutableHashMap.set(subscriptions, key, newSubscriptionId);
+				yield* subscribeSymbol(symbol, eventType);
 			}
 
 			const start = () =>
@@ -145,19 +167,20 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 					// Subscribe to new symbols as they are requested
 					yield* Effect.forkDaemon(
 						Effect.gen(function* () {
-							const newSymbol = yield* newSubscriptionRequests.take;
+							const { symbol, eventType } = yield* newSubscriptionRequests.take;
+							const key = dxfeedKey(symbol, eventType);
 
 							yield* Effect.logInfo(
-								`Subscribing to dxFeed symbol ${newSymbol}`,
+								`Subscribing to dxFeed symbol ${symbol} (${eventType})`,
 							);
 
 							const newSubscriptionId = subscriptionId++;
-							MutableHashMap.set(subscriptions, newSymbol, newSubscriptionId);
+							MutableHashMap.set(subscriptions, key, newSubscriptionId);
 
 							const now = yield* Clock.currentTimeMillis;
-							MutableHashMap.set(lastRequestToSubscription, newSymbol, now);
+							MutableHashMap.set(lastRequestByKey, key, now);
 
-							yield* subscribeSymbol(newSymbol);
+							yield* subscribeSymbol(symbol, eventType);
 						}).pipe(Effect.forever),
 					);
 
@@ -169,29 +192,26 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 								`Cleaning up dxFeed subscriptions (running ${priceCache.size()})`,
 							);
 
-							for (const [
-								symbol,
-								lastRequestTimestamp,
-							] of lastRequestToSubscription) {
+							for (const [key, lastRequestTimestamp] of lastRequestByKey) {
 								const cleanupInterval = Duration.toMillis(
 									config.subscriptionsCleanupTtl,
 								);
 								const timeSinceLastRequest = now - lastRequestTimestamp;
 
 								yield* Effect.logDebug(
-									`Time since last request for dxFeed ${symbol}: ${Duration.format(Duration.decode(timeSinceLastRequest))}`,
+									`Time since last request for dxFeed ${key}: ${Duration.format(Duration.decode(timeSinceLastRequest))}`,
 								);
 
 								if (timeSinceLastRequest > cleanupInterval) {
 									yield* Effect.logInfo(
-										`Cleaning up dxFeed subscription ${symbol}`,
+										`Cleaning up dxFeed subscription ${key}`,
 									);
-									MutableHashMap.remove(lastRequestToSubscription, symbol);
-									yield* priceCache.deletePrice(symbol);
+									MutableHashMap.remove(lastRequestByKey, key);
+									yield* priceCache.deletePrice(key);
 
-									const id = MutableHashMap.get(subscriptions, symbol);
+									const id = MutableHashMap.get(subscriptions, key);
 									if (Option.isSome(id)) {
-										unsubscribeSymbol(symbol);
+										unsubscribeByCompositeKey(key);
 									}
 								}
 							}
@@ -219,6 +239,9 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 
 					yield* Effect.logDebug("Handling dxFeed request", { route, params });
 
+					const eventType: DxFeedEventType =
+						route.type === "dxfeed" ? (route.eventType ?? "Quote") : "Quote";
+
 					const symbols = replaceParams(route.fetchFromModule, params)
 						.split(",")
 						.map((s) => s.trim())
@@ -235,23 +258,24 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 						);
 					}
 
-					const prices: DxFeedDataPrice[] = [];
+					const prices: DxFeedFullEventData[] = [];
 					const now = yield* Clock.currentTimeMillis;
 
 					for (const symbol of symbols) {
+						const key = dxfeedKey(symbol, eventType);
 						const lastRequestTimestamp = MutableHashMap.get(
-							lastRequestToSubscription,
-							symbol,
+							lastRequestByKey,
+							key,
 						);
 						if (Option.isNone(lastRequestTimestamp)) {
-							yield* newSubscriptionRequests.offer(symbol);
+							yield* newSubscriptionRequests.offer({ symbol, eventType });
 						}
-						MutableHashMap.set(lastRequestToSubscription, symbol, now);
+						MutableHashMap.set(lastRequestByKey, key, now);
 
-						const price = yield* priceCache.getOrWaitPrice(symbol).pipe(
+						const price = yield* priceCache.getOrWaitPrice(key).pipe(
 							Effect.catchTag("FailedToGetPriceError", (error) =>
 								Effect.gen(function* () {
-									yield* priceCache.deletePrice(symbol);
+									yield* priceCache.deletePrice(key);
 									return yield* Effect.fail(error);
 								}),
 							),

--- a/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
@@ -68,7 +68,7 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 			const feed = new DXLinkFeed(client, FeedContract.AUTO);
 
 			feed.configure({
-				acceptAggregationPeriod: 10,
+				acceptAggregationPeriod: config.acceptAggregationPeriod,
 				acceptDataFormat: FeedDataFormat.FULL,
 			});
 
@@ -79,27 +79,19 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 						for (const event of events) {
 							yield* Effect.logDebug("dxFeed event", event);
 
-							const priceData = extractFullEventDataFromEvent(event);
-							if (priceData === undefined) {
+							const eventData = extractFullEventDataFromEvent(event);
+							if (eventData === undefined) {
 								yield* Effect.logError(
-									"Failed to extract price data from event",
-									{
-										event,
-									},
+									"Failed to extract symbol and type from event",
+									event,
 								);
 								continue;
 							}
 
-							const eventType =
-								((event as Record<string, unknown>).eventType as string) ??
-								"Quote";
-							const key = dxfeedKey(
-								priceData.symbol,
-								eventType as DxFeedEventType,
-							);
+							const key = dxfeedKey(eventData.symbol, eventData.type);
 
 							if (MutableHashMap.has(subscriptions, key)) {
-								yield* priceCache.setPrice(key, priceData);
+								yield* priceCache.setPrice(key, eventData);
 							} else {
 								yield* Effect.logError("Received event for unsubscribed key", {
 									key,

--- a/workspace/data-proxy/src/modules/dxfeed/schema.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/schema.ts
@@ -1,22 +1,37 @@
+import {
+	type DxFeedEventType,
+	dxfeedEventTypes,
+} from "../../config/dxfeed-module-config";
+
 export type DxFeedFullEventData = Record<string, unknown> & {
 	symbol: string;
+	type: DxFeedEventType;
 };
 
 export const extractFullEventDataFromEvent = (
 	event: unknown,
 ): DxFeedFullEventData | undefined => {
-	const record = event as Record<string, unknown>;
-	const symbol = readString(record, "eventSymbol");
-	if (symbol === undefined) {
+	if (
+		typeof event !== "object" ||
+		event === null ||
+		!("eventSymbol" in event) ||
+		!("eventType" in event)
+	) {
 		return undefined;
 	}
-	return { ...record, symbol };
+
+	const symbol = event.eventSymbol;
+	if (typeof symbol !== "string") {
+		return undefined;
+	}
+
+	const type = event.eventType;
+	if (!isDxFeedEventType(type)) {
+		return undefined;
+	}
+
+	return { ...event, symbol, type };
 };
 
-const readString = (
-	record: Record<string, unknown>,
-	key: string,
-): string | undefined => {
-	const value = record[key];
-	return typeof value === "string" ? value : undefined;
-};
+const isDxFeedEventType = (type: unknown): type is DxFeedEventType =>
+	dxfeedEventTypes.includes(type as DxFeedEventType);

--- a/workspace/data-proxy/src/modules/dxfeed/schema.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/schema.ts
@@ -1,10 +1,17 @@
-import type { DxFeedEventField } from "../../config/dxfeed-module-config";
-
-export type DxFeedSymbol = string;
-
-export type DxFeedDataPrice = {
+export type DxFeedFullEventData = Record<string, unknown> & {
 	symbol: string;
-} & Partial<Record<DxFeedEventField, unknown>>;
+};
+
+export const extractFullEventDataFromEvent = (
+	event: unknown,
+): DxFeedFullEventData | undefined => {
+	const record = event as Record<string, unknown>;
+	const symbol = readString(record, "eventSymbol");
+	if (symbol === undefined) {
+		return undefined;
+	}
+	return { ...record, symbol };
+};
 
 const readString = (
 	record: Record<string, unknown>,
@@ -12,29 +19,4 @@ const readString = (
 ): string | undefined => {
 	const value = record[key];
 	return typeof value === "string" ? value : undefined;
-};
-
-export const extractPriceDataFromEvent = (
-	event: unknown,
-	eventFields: readonly DxFeedEventField[],
-): DxFeedDataPrice | undefined => {
-	const record = event as Record<string, unknown>;
-
-	const symbol = readString(record, "eventSymbol");
-	if (symbol === undefined) {
-		return undefined;
-	}
-
-	const fields = {} as Partial<Record<DxFeedEventField, unknown>>;
-
-	for (const key of eventFields) {
-		if (Object.hasOwn(record, key)) {
-			fields[key] = record[key];
-		}
-	}
-
-	return {
-		symbol,
-		...fields,
-	};
 };

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { Duration, Effect } from "effect";
+import { Duration, Effect, LogLevel, Logger } from "effect";
 import * as v from "valibot";
 import {
 	type HydromancerModuleConfig,
@@ -65,7 +65,10 @@ const callHandle = (
 		);
 	});
 	return Effect.runPromise(
-		program.pipe(Effect.provide(HydromancerModuleService(config))),
+		program.pipe(
+			Effect.provide(HydromancerModuleService(config)),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		),
 	);
 };
 
@@ -96,7 +99,10 @@ const callHandleSequence = (
 		return responses;
 	});
 	return Effect.runPromise(
-		program.pipe(Effect.provide(HydromancerModuleService(config))),
+		program.pipe(
+			Effect.provide(HydromancerModuleService(config)),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		),
 	);
 };
 
@@ -371,7 +377,10 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 		});
 
 		const response = await Effect.runPromise(
-			program.pipe(Effect.provide(HydromancerModuleService(config))),
+			program.pipe(
+				Effect.provide(HydromancerModuleService(config)),
+				Logger.withMinimumLogLevel(LogLevel.None),
+			),
 		);
 		expect(response.status).toBe(200);
 
@@ -414,7 +423,10 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 		});
 
 		await Effect.runPromise(
-			program.pipe(Effect.provide(HydromancerModuleService(config))),
+			program.pipe(
+				Effect.provide(HydromancerModuleService(config)),
+				Logger.withMinimumLogLevel(LogLevel.None),
+			),
 		);
 
 		await flush();
@@ -454,7 +466,10 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 		});
 
 		await Effect.runPromise(
-			program.pipe(Effect.provide(HydromancerModuleService(config))),
+			program.pipe(
+				Effect.provide(HydromancerModuleService(config)),
+				Logger.withMinimumLogLevel(LogLevel.None),
+			),
 		);
 
 		await flush();
@@ -535,7 +550,10 @@ describe("HydromancerModuleService REST fallback when WS is errored", () => {
 		});
 
 		await Effect.runPromise(
-			program.pipe(Effect.provide(HydromancerModuleService(config))),
+			program.pipe(
+				Effect.provide(HydromancerModuleService(config)),
+				Logger.withMinimumLogLevel(LogLevel.None),
+			),
 		);
 
 		expect(restCalls).toEqual([["BTC"], ["BTC"]]);

--- a/workspace/data-proxy/src/modules/hydromancer/ws-client.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/ws-client.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { Duration, Effect, Fiber, Option, Schedule } from "effect";
+import {
+	Duration,
+	Effect,
+	Fiber,
+	LogLevel,
+	Logger,
+	Option,
+	Schedule,
+} from "effect";
 import type { HydromancerModuleConfig } from "../../config/hydromancer-module-config";
 import { createAssetCache } from "./asset-cache";
 import {
@@ -193,7 +201,7 @@ const startService = (
 		}
 		const fiber = yield* ws.start();
 		return { cache, ws, fiber };
-	});
+	}).pipe(Logger.withMinimumLogLevel(LogLevel.None));
 
 describe("createHydromancerWS", () => {
 	it("opens the WS with the token query and sends subscribe frames on open", async () => {

--- a/workspace/data-proxy/src/testutils/mock-upstream.ts
+++ b/workspace/data-proxy/src/testutils/mock-upstream.ts
@@ -16,6 +16,11 @@ const handlers = [
 	http.all(`${TEST_LOCAL_PROXY_BASE}*`, () => {
 		return passthrough();
 	}),
+	http.all("https://rpc.devnet.seda.xyz/status", () => {
+		return Response.json({
+			result: { node_info: { network: "seda-1-devnet" } },
+		});
+	}),
 ];
 
 export const server = setupServer(...handlers);

--- a/workspace/data-proxy/src/utils/idle-cleanup.test.ts
+++ b/workspace/data-proxy/src/utils/idle-cleanup.test.ts
@@ -4,6 +4,8 @@ import {
 	Duration,
 	Effect,
 	Fiber,
+	LogLevel,
+	Logger,
 	MutableHashMap,
 	Option,
 	TestClock,
@@ -12,7 +14,12 @@ import {
 import { forkIdleCleanup } from "./idle-cleanup";
 
 const provideTestClock = <A, E>(effect: Effect.Effect<A, E, never>) =>
-	Effect.runPromise(effect.pipe(Effect.provide(TestContext.TestContext)));
+	Effect.runPromise(
+		effect.pipe(
+			Effect.provide(TestContext.TestContext),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		),
+	);
 
 describe("forkIdleCleanup", () => {
 	it("removes an entry that has been idle past the TTL and calls onExpire once", async () => {


### PR DESCRIPTION
## Explanation of Changes

Add support for all event types on orders and transactions (see [here](https://kb.dxfeed.com/en/data-model/market-events/dxfeed-api-market-events.html#summary-125811)) for the dxfeed module. 

The response fields are no longer configurable, and we return the full data that we accept from the upstream (Just thought it was the easiest way to add support for all types at least for now. But please correct me if this is a bad approach)

## Testing

I had some trouble trying out many of the endpoints probably because the trading hours have ended.

Requests (Other symbols we use include `BRN%2FUSD:BFX`, `SPX%2FUSD:BFX`, `BTC%2FUSD:CXDXF`:
```
curl http://localhost:5384/dxfeed/quote/AAPL:BFX
curl http://localhost:5384/dxfeed/order/AAPL:BFX
curl http://localhost:5384/dxfeed/spreadorder/AAPL:BFX
curl http://localhost:5384/dxfeed/trade/AAPL:BFX
curl http://localhost:5384/dxfeed/tradeeth/AAPL:BFX
curl http://localhost:5384/dxfeed/timeandsale/AAPL:BFX
curl http://localhost:5384/dxfeed/summary/AAPL:BFX
curl http://localhost:5384/dxfeed/profile/AAPL:BFX
```

Example config (must set env var `DXFEED_AUTH_TOKEN`):
```
{
	"modules": [
		{
			"type": "dxfeed",
			"name": "dxfeed",
			"webSocketUrl": "wss://tools.dxfeed.com/dxlink-tradearcade",
			"dxfeedAuthTokenEnvKey": "DXFEED_AUTH_TOKEN"
		}
	],
	"routeGroup": "dxfeed",
	"routes": [
		{
			"type": "dxfeed",
			"moduleName": "dxfeed",
			"path": "quote/:symbols",
			"fetchFromModule": "{:symbols}",
			"eventType": "Quote"
		},
		{
			"type": "dxfeed",
			"moduleName": "dxfeed",
			"path": "order/:symbols",
			"fetchFromModule": "{:symbols}",
			"eventType": "Order"
		},
		{
			"type": "dxfeed",
			"moduleName": "dxfeed",
			"path": "spreadorder/:symbols",
			"fetchFromModule": "{:symbols}",
			"eventType": "SpreadOrder"
		},
		{
			"type": "dxfeed",
			"moduleName": "dxfeed",
			"path": "trade/:symbols",
			"fetchFromModule": "{:symbols}",
			"eventType": "Trade"
		},
		{
			"type": "dxfeed",
			"moduleName": "dxfeed",
			"path": "tradeeth/:symbols",
			"fetchFromModule": "{:symbols}",
			"eventType": "TradeETH"
		},
		{
			"type": "dxfeed",
			"moduleName": "dxfeed",
			"path": "timeandsale/:symbols",
			"fetchFromModule": "{:symbols}",
			"eventType": "TimeAndSale"
		},
		{
			"type": "dxfeed",
			"moduleName": "dxfeed",
			"path": "summary/:symbols",
			"fetchFromModule": "{:symbols}",
			"eventType": "Summary"
		},
		{
			"type": "dxfeed",
			"moduleName": "dxfeed",
			"path": "profile/:symbols",
			"fetchFromModule": "{:symbols}",
			"eventType": "Profile"
		}
	]
}

```
