### PR TITLE
Recude DxFeed logs

### DIFF
--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -372,6 +372,15 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 		Effect.withSpan("handleProxyRequest"),
 		Effect.tapError((error) =>
 			Effect.gen(function* () {
+				// We don't want to log errors for 4xx status codes
+				if (
+					error._tag === "NotOkUpstreamResponseError" &&
+					error.status >= 400 &&
+					error.status < 500
+				) {
+					return;
+				}
+
 				const { message, ...errorRest } = error as unknown as {
 					message: string;
 				} & Record<string, unknown>;

--- a/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
@@ -281,7 +281,7 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 				}).pipe(
 					Effect.withSpan("handleDxFeedRequest"),
 					Effect.catchAll((error) => {
-						return Effect.succeed(createErrorResponse(error, 500));
+						return Effect.succeed(createErrorResponse(error, error.status));
 					}),
 				);
 

--- a/workspace/data-proxy/src/modules/dxfeed/errors.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/errors.ts
@@ -9,11 +9,12 @@ export class FailedToHandleDxFeedRequestError extends Data.TaggedError(
 	status = 400;
 }
 
+// We can't distinguish between a price not found and a price error, so we use a 404 status code to reduce the noise in the logs
 export class FailedToGetPriceError extends Data.TaggedError(
 	"FailedToGetPriceError",
 )<{
 	error: string | unknown;
 }> {
 	message = `Failed to get price: ${this.error}`;
-	status = 500;
+	status = 404;
 }


### PR DESCRIPTION
## Motivation

Since DxFeed doesn't tell us whether a requested symbol is invalid or stale we default to returning a 404 to the client. This reduces error log spam on our end.

## Explanation of Changes

N.A.

## Testing

N.A.

## Related PRs and Issues

N.A.