### PR TITLE
Make binary available under /app/dataproxy

### DIFF
--- a/.build/docker/Dockerfile
+++ b/.build/docker/Dockerfile
@@ -22,6 +22,8 @@ COPY --from=builder /build/dataproxy.mjs ./dataproxy.mjs
 RUN printf '#!/bin/sh\nexec node /app/dataproxy.mjs "$@"\n' > /usr/local/bin/dataproxy \
     && chmod +x /usr/local/bin/dataproxy
 
+RUN cp /usr/local/bin/dataproxy /app/dataproxy
+
 # Expose the port the app runs on
 EXPOSE 5384
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "workspace/data-proxy": {
       "name": "@seda-protocol/data-proxy",
-      "version": "2.7.1",
+      "version": "2.7.3",
       "dependencies": {
         "@commander-js/extra-typings": "^12.1.0",
         "@cosmjs/crypto": "^0.33.1",


### PR DESCRIPTION
## Motivation

This should make the image fully backwards compatible with the previous one.

## Explanation of Changes

Some deployment config used `/app/dataproxy` directly, so simply adding it to usr/local/bin was not enough.

## Testing

Built the container locally and confirmed `/app/dataproxy` is executable

## Related PRs and Issues

Fixes issue introduced in #115 