### PR TITLE
chore: always give back prices even when one symbol fails

### DIFF
--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "2.7.4",
+	"version": "2.7.5",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",

--- a/workspace/data-proxy/src/config/dxfeed-module-config.ts
+++ b/workspace/data-proxy/src/config/dxfeed-module-config.ts
@@ -40,7 +40,7 @@ export const DxFeedModuleConfigSchema = v.strictObject({
 	subscriptions: v.optional(v.array(DxFeedSubscriptionSchema), []),
 	maxFeedsPerRequest: v.optional(v.number(), 100),
 	subscriptionsCleanupTtl: v.pipe(
-		v.optional(v.union([v.number(), v.string()]), "2 minutes"),
+		v.optional(v.union([v.number(), v.string()]), "1 hour"),
 		v.transform((ttl) =>
 			Option.getOrThrowWith(
 				Duration.decodeUnknown(ttl),

--- a/workspace/data-proxy/src/config/hydromancer-module-config.ts
+++ b/workspace/data-proxy/src/config/hydromancer-module-config.ts
@@ -39,7 +39,7 @@ export const HydromancerModuleConfigSchema = v.strictObject({
 		),
 	),
 	coinsCleanupTtl: v.pipe(
-		v.optional(v.union([v.number(), v.string()]), "2 minutes"),
+		v.optional(v.union([v.number(), v.string()]), "1 hour"),
 		v.transform((ttl) =>
 			Option.getOrThrowWith(
 				Duration.decodeUnknown(ttl),

--- a/workspace/data-proxy/src/config/pyth-lazer-module-config.ts
+++ b/workspace/data-proxy/src/config/pyth-lazer-module-config.ts
@@ -22,7 +22,7 @@ export const PythLazerModuleConfigSchema = v.strictObject({
 	maxFeedsPerRequest: v.optional(v.number(), 100),
 	pythLazerApiKeyEnvKey: v.string(),
 	priceFeedsCleanupTtl: v.pipe(
-		v.optional(v.union([v.number(), v.string()]), "2 minutes"),
+		v.optional(v.union([v.number(), v.string()]), "1 hour"),
 		v.transform((ttl) =>
 			Option.getOrThrowWith(
 				Duration.decodeUnknown(ttl),

--- a/workspace/data-proxy/src/constants.ts
+++ b/workspace/data-proxy/src/constants.ts
@@ -19,6 +19,7 @@ export const DEFAULT_VERIFICATION_MAX_RETRIES = 2;
 export const DEFAULT_VERIFICATION_RETRY_DELAY = 1000;
 
 export const PRIVATE_KEY_ENV_KEY = "SEDA_DATA_PROXY_PRIVATE_KEY";
+export const HAS_PRICE_KEY = "__sedaHasPrice";
 
 // Use a getter function instead of a constant to ensure we read the decrypted value at runtime
 export function getPrivateKey(): string | undefined {

--- a/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
@@ -9,6 +9,7 @@ import {
 	Clock,
 	Duration,
 	Effect,
+	Either,
 	Layer,
 	MutableHashMap,
 	Option,
@@ -23,6 +24,7 @@ import {
 	type DxFeedModuleConfig,
 	dxfeedKey,
 } from "../../config/dxfeed-module-config";
+import { HAS_PRICE_KEY } from "../../constants";
 import { createErrorResponse } from "../../controllers/create-error-response";
 import { replaceParams } from "../../utils/replace-params";
 import { FailedToHandleRequest, ModuleService } from "../module";
@@ -253,26 +255,39 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 					const prices: DxFeedFullEventData[] = [];
 					const now = yield* Clock.currentTimeMillis;
 
+					// First subscribe to all the symbols that we have not subscribed to yet
+					// We do this separately from the price fetching to avoid waiting extra time
+					// for each symbol.
 					for (const symbol of symbols) {
 						const key = dxfeedKey(symbol, eventType);
-						const lastRequestTimestamp = MutableHashMap.get(
-							lastRequestByKey,
-							key,
-						);
-						if (Option.isNone(lastRequestTimestamp)) {
-							yield* newSubscriptionRequests.offer({ symbol, eventType });
+
+						if (MutableHashMap.has(lastRequestByKey, key)) {
+							continue;
 						}
+
+						yield* newSubscriptionRequests.offer({ symbol, eventType });
+					}
+
+					// Now since the subscriptions are in-flight, we can fetch the prices.
+					for (const symbol of symbols) {
+						const key = dxfeedKey(symbol, eventType);
 						MutableHashMap.set(lastRequestByKey, key, now);
 
-						const price = yield* priceCache.getOrWaitPrice(key).pipe(
-							Effect.catchTag("FailedToGetPriceError", (error) =>
-								Effect.gen(function* () {
-									yield* priceCache.deletePrice(key);
-									return yield* Effect.fail(error);
-								}),
-							),
-						);
-						prices.push(price);
+						const price = yield* Effect.either(priceCache.getOrWaitPrice(key));
+
+						if (Either.isLeft(price)) {
+							yield* priceCache.deletePrice(key);
+							prices.push({
+								symbol,
+								[HAS_PRICE_KEY]: false,
+								type: eventType,
+							});
+						} else {
+							prices.push({
+								...price.right,
+								[HAS_PRICE_KEY]: true,
+							});
+						}
 					}
 
 					return yield* Effect.succeed(

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -7,6 +7,7 @@ import {
 	Clock,
 	Data,
 	Effect,
+	Either,
 	Layer,
 	MutableHashMap,
 	Option,
@@ -15,6 +16,7 @@ import {
 } from "effect";
 import type { Route } from "../../config/config-parser";
 import type { PythLazerModuleConfig } from "../../config/pyth-lazer-module-config";
+import { HAS_PRICE_KEY } from "../../constants";
 import { createErrorResponse } from "../../controllers/create-error-response";
 import { forkIdleCleanup } from "../../utils/idle-cleanup";
 import { replaceParams } from "../../utils/replace-params";
@@ -37,6 +39,7 @@ type PriceFeedSymbol = string;
 
 interface PriceFeedWithSymbol extends ParsedFeedPayload {
 	symbol?: string;
+	[HAS_PRICE_KEY]: boolean;
 }
 
 export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
@@ -322,29 +325,39 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 					const prices: PriceFeedWithSymbol[] = [];
 					const now = yield* Clock.currentTimeMillis;
 
-					for (const [index, priceFeedId] of priceFeedIds.entries()) {
-						const lastRequestTimestamp = MutableHashMap.get(
-							lastRequestToPriceFeed,
-							priceFeedId,
-						);
-						if (Option.isNone(lastRequestTimestamp)) {
-							yield* newPriceFeedRequests.offer(priceFeedId);
+					// First subscribe to all the symbols that we have not subscribed to yet
+					// We do this separately from the price fetching to avoid waiting extra time
+					// for each symbol.
+					for (const priceFeedId of priceFeedIds) {
+						if (MutableHashMap.has(lastRequestToPriceFeed, priceFeedId)) {
+							continue;
 						}
 
+						yield* newPriceFeedRequests.offer(priceFeedId);
+					}
+
+					// Now since the subscriptions are in-flight, we can fetch the prices.
+					for (const [index, priceFeedId] of priceFeedIds.entries()) {
 						MutableHashMap.set(lastRequestToPriceFeed, priceFeedId, now);
-						const price = yield* priceCache.getOrWaitPrice(priceFeedId).pipe(
-							Effect.catchTag("FailedToGetPriceError", (error) =>
-								Effect.gen(function* () {
-									yield* priceCache.deletePrice(priceFeedId);
-									return yield* Effect.fail(error);
-								}),
-							),
+
+						const price = yield* Effect.either(
+							priceCache.getOrWaitPrice(priceFeedId),
 						);
 
-						prices.push({
-							symbol: priceFeedIdsRaw.at(index),
-							...price,
-						});
+						if (Either.isLeft(price)) {
+							yield* priceCache.deletePrice(priceFeedId);
+							prices.push({
+								priceFeedId,
+								symbol: priceFeedIdsRaw.at(index),
+								[HAS_PRICE_KEY]: false,
+							});
+						} else {
+							prices.push({
+								...price.right,
+								symbol: priceFeedIdsRaw.at(index),
+								[HAS_PRICE_KEY]: true,
+							});
+						}
 					}
 
 					return yield* Effect.succeed(


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Sometimes a price could not be fetched and the whole request would fail. Now we flag the failing price and give back the other prices. This way one bad price doesn't stall the rest of the prices.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Add `__sedaHasPrice: boolean` to the response so the OP can detect if there is a price available.
