### PR TITLE
LO:TECH response involving failed symbols

### DIFF
--- a/workspace/data-proxy/src/config/lo-tech-module-config.ts
+++ b/workspace/data-proxy/src/config/lo-tech-module-config.ts
@@ -27,7 +27,7 @@ export const LoTechModuleConfigSchema = v.strictObject({
 	maxFeedsPerRequest: v.optional(v.number(), 100),
 	loTechApiKeyEnvKey: v.string(),
 	priceFeedsCleanupTtl: v.pipe(
-		v.optional(v.union([v.number(), v.string()]), "2 minutes"),
+		v.optional(v.union([v.number(), v.string()]), "1 hour"),
 		v.transform((ttl) =>
 			Option.getOrThrowWith(
 				Duration.decodeUnknown(ttl),

--- a/workspace/data-proxy/src/config/lo-tech-module-config.ts
+++ b/workspace/data-proxy/src/config/lo-tech-module-config.ts
@@ -3,7 +3,6 @@ import * as v from "valibot";
 import { RouteSchema } from "./route-config";
 
 export const LO_TECH_DATA_TYPE_PRICE = "PRICE" as const;
-
 export const LoTechDataTypeSchema = v.picklist([LO_TECH_DATA_TYPE_PRICE]);
 
 export type LoTechDataType = v.InferOutput<typeof LoTechDataTypeSchema>;

--- a/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
@@ -276,7 +276,6 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 						const price = yield* Effect.either(priceCache.getOrWaitPrice(key));
 
 						if (Either.isLeft(price)) {
-							yield* priceCache.deletePrice(key);
 							prices.push({
 								symbol,
 								[HAS_PRICE_KEY]: false,

--- a/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
+++ b/workspace/data-proxy/src/modules/dxfeed/dxfeed.ts
@@ -256,24 +256,29 @@ export const DxFeedModuleService = (config: DxFeedModuleConfig) =>
 					const now = yield* Clock.currentTimeMillis;
 
 					// First subscribe to all the symbols that we have not subscribed to yet
-					// We do this separately from the price fetching to avoid waiting extra time
-					// for each symbol.
+					const keys: DxFeedKey[] = [];
 					for (const symbol of symbols) {
 						const key = dxfeedKey(symbol, eventType);
 
-						if (MutableHashMap.has(lastRequestByKey, key)) {
-							continue;
+						if (!MutableHashMap.has(lastRequestByKey, key)) {
+							yield* newSubscriptionRequests.offer({ symbol, eventType });
 						}
 
-						yield* newSubscriptionRequests.offer({ symbol, eventType });
-					}
-
-					// Now since the subscriptions are in-flight, we can fetch the prices.
-					for (const symbol of symbols) {
-						const key = dxfeedKey(symbol, eventType);
 						MutableHashMap.set(lastRequestByKey, key, now);
 
-						const price = yield* Effect.either(priceCache.getOrWaitPrice(key));
+						keys.push(key);
+					}
+
+					// Now since the subscriptions are in-flight, we can fetch the prices concurrently.
+					const results = yield* Effect.forEach(
+						keys,
+						(key) => Effect.either(priceCache.getOrWaitPrice(key)),
+						{ concurrency: "unbounded" },
+					);
+
+					for (let i = 0; i < symbols.length; i++) {
+						const symbol = symbols[i];
+						const price = results[i];
 
 						if (Either.isLeft(price)) {
 							prices.push({

--- a/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
@@ -24,9 +24,11 @@ import { FailedToHandleLoTechRequestError } from "./errors";
 import type {
 	LoTechAck,
 	LoTechDataPrice,
+	LoTechErrorMessage,
 	LoTechParsedData,
 	LoTechResponse,
 } from "./schema";
+import { LoTechSubscriptionFailureCode } from "./schema";
 import { makeLoTechWebSocketService } from "./ws-client";
 
 export type PriceFeedSymbol = string;
@@ -94,6 +96,19 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 					MutableHashMap.set(lastRequestToPriceFeed, symbol.value, now);
 				});
 
+			const handleErrorMessage = (msg: LoTechErrorMessage) =>
+				Effect.gen(function* () {
+					if (msg.error.code === LoTechSubscriptionFailureCode) {
+						yield* Effect.logInfo("Subscription request failed", {
+							id: msg.error.id,
+						});
+						MutableHashMap.remove(priceFeedIds, msg.error.id);
+						return;
+					}
+
+					yield* Effect.logWarning("Unexpected LO:TECH error message", { msg });
+				});
+
 			const loTechWs = yield* makeLoTechWebSocketService({
 				config,
 				runtime,
@@ -116,6 +131,7 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 					}),
 				handleDataMessage,
 				handleAckMessage,
+				handleErrorMessage,
 			});
 
 			const start = () =>

--- a/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
@@ -220,24 +220,26 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 					const responses: LoTechResponse[] = [];
 					const now = yield* Clock.currentTimeMillis;
 
-					// First subscribe to all the symbols that we have not subscribed to yet
-					// We do this separately from the price fetching to avoid waiting extra time
-					// for each symbol.
+					// Subscribe to the symbols that we have not subscribed to yet.
 					for (const symbol of symbols) {
 						if (!MutableHashMap.has(priceFeeds, symbol)) {
 							yield* newPriceFeedQueue.offer(symbol);
 						}
-					}
 
-					// Now since the subscriptions are in-flight, we can fetch the prices.
-					for (const symbol of symbols) {
 						if (MutableHashMap.has(lastRequestToPriceFeed, symbol)) {
 							MutableHashMap.set(lastRequestToPriceFeed, symbol, now);
 						}
+					}
 
-						const price = yield* Effect.either(
-							priceCache.getOrWaitPrice(symbol),
-						);
+					const prices = yield* Effect.forEach(
+						symbols,
+						(symbol) => Effect.either(priceCache.getOrWaitPrice(symbol)),
+						{ concurrency: "unbounded" },
+					);
+
+					for (let i = 0; i < symbols.length; i++) {
+						const symbol = symbols[i];
+						const price = prices[i];
 
 						if (Either.isLeft(price)) {
 							responses.push({

--- a/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
@@ -22,6 +22,7 @@ import { FailedToHandleRequest, ModuleService } from "../module";
 import { createPriceCache } from "../shared/price-cache";
 import { FailedToHandleLoTechRequestError } from "./errors";
 import type {
+	LoTechAck,
 	LoTechDataPrice,
 	LoTechParsedData,
 	LoTechResponse,
@@ -37,9 +38,16 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 			yield* Effect.logInfo("Initializing LO:TECH module");
 
 			const runtime = yield* Effect.runtime();
+
+			// Monotonically increasing counter for price feed IDs.
+			let latestPriceFeedId = 0;
+			// Map from price feed IDs to symbols. (Used to process acks)
+			const priceFeedIds = MutableHashMap.empty<number, PriceFeedSymbol>();
+			// Map from subscribed symbols to price feed IDs.
 			const priceFeeds = MutableHashMap.empty<PriceFeedSymbol, number>();
-			const newPriceFeedRequests = yield* Queue.unbounded<PriceFeedSymbol>();
-			// The timestamp of the last request to the price feed used for cleanup.
+			// Queue of new symbols to subscribe to.
+			const newPriceFeedQueue = yield* Queue.unbounded<PriceFeedSymbol>();
+			// Timestamp of the last request to the price feed. (Used for cleanup)
 			const lastRequestToPriceFeed = MutableHashMap.empty<
 				PriceFeedSymbol,
 				number
@@ -49,11 +57,9 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 				LoTechDataPrice
 			>();
 
-			let priceFeedId = 0;
-
 			const updatePrice = (data: LoTechDataPrice) =>
 				Effect.gen(function* () {
-					yield* Effect.logTrace("Received message from LO:TECH client", data);
+					yield* Effect.logDebug("Received message from LO:TECH client", data);
 
 					// Set the price if the symbol is subscribed to.
 					const { symbol } = data;
@@ -70,6 +76,24 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 					}),
 				);
 
+			const handleAckMessage = (msg: LoTechAck) =>
+				Effect.gen(function* () {
+					yield* Effect.logDebug("handling ack", { msg });
+
+					const symbol = MutableHashMap.get(priceFeedIds, msg.ack.id);
+					if (Option.isNone(symbol)) {
+						yield* Effect.logWarning("Received ack for unknown price feed ID", {
+							msg,
+						});
+						return;
+					}
+
+					MutableHashMap.set(priceFeeds, symbol.value, msg.ack.id);
+
+					const now = yield* Clock.currentTimeMillis;
+					MutableHashMap.set(lastRequestToPriceFeed, symbol.value, now);
+				});
+
 			const loTechWs = yield* makeLoTechWebSocketService({
 				config,
 				runtime,
@@ -80,20 +104,18 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 								`Subscribing to price feed ${priceFeed.symbol}`,
 							);
 
-							const newSubscriptionId = priceFeedId++;
+							const newSubscriptionId = latestPriceFeedId++;
 							MutableHashMap.set(
-								priceFeeds,
-								priceFeed.symbol,
+								priceFeedIds,
 								newSubscriptionId,
+								priceFeed.symbol,
 							);
-
-							const now = yield* Clock.currentTimeMillis;
-							MutableHashMap.set(lastRequestToPriceFeed, priceFeed.symbol, now);
 
 							yield* api.subscribePrice(priceFeed.symbol, newSubscriptionId);
 						}
 					}),
 				handleDataMessage,
+				handleAckMessage,
 			});
 
 			const start = () =>
@@ -103,15 +125,12 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 					// Background fiber for handling new price feed subscriptions
 					yield* Effect.forkDaemon(
 						Effect.gen(function* () {
-							const newSymbol = yield* newPriceFeedRequests.take;
+							const newSymbol = yield* newPriceFeedQueue.take;
 
 							yield* Effect.logInfo(`Subscribing to price feed ${newSymbol}`);
 
-							const newSubscriptionId = priceFeedId++;
-							MutableHashMap.set(priceFeeds, newSymbol, newSubscriptionId);
-
-							const now = yield* Clock.currentTimeMillis;
-							MutableHashMap.set(lastRequestToPriceFeed, newSymbol, now);
+							const newSubscriptionId = latestPriceFeedId++;
+							MutableHashMap.set(priceFeedIds, newSubscriptionId, newSymbol);
 
 							yield* loTechWs.subscribePrice(newSymbol, newSubscriptionId);
 						}).pipe(Effect.forever),
@@ -148,6 +167,14 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 									if (Option.isSome(priceFeedId)) {
 										yield* loTechWs.unsubscribePrice(symbol);
 										MutableHashMap.remove(priceFeeds, symbol);
+										MutableHashMap.remove(priceFeedIds, priceFeedId.value);
+									} else {
+										yield* Effect.logError(
+											"Failed to find price feed ID for symbol",
+											{
+												symbol,
+											},
+										);
 									}
 								}
 							}
@@ -173,7 +200,7 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 						);
 					}
 
-					yield* Effect.logInfo("Handling LO:TECH request", { route, params });
+					yield* Effect.logDebug("Handling LO:TECH request", { route, params });
 
 					const symbols = replaceParams(route.fetchFromModule, params).split(
 						",",
@@ -197,15 +224,16 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 					// We do this separately from the price fetching to avoid waiting extra time
 					// for each symbol.
 					for (const symbol of symbols) {
-						if (MutableHashMap.has(lastRequestToPriceFeed, symbol)) {
-							continue;
+						if (!MutableHashMap.has(priceFeeds, symbol)) {
+							yield* newPriceFeedQueue.offer(symbol);
 						}
-						yield* newPriceFeedRequests.offer(symbol);
 					}
 
 					// Now since the subscriptions are in-flight, we can fetch the prices.
 					for (const symbol of symbols) {
-						MutableHashMap.set(lastRequestToPriceFeed, symbol, now);
+						if (MutableHashMap.has(lastRequestToPriceFeed, symbol)) {
+							MutableHashMap.set(lastRequestToPriceFeed, symbol, now);
+						}
 
 						const price = yield* Effect.either(
 							priceCache.getOrWaitPrice(symbol),

--- a/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
@@ -2,6 +2,7 @@ import {
 	Clock,
 	Duration,
 	Effect,
+	Either,
 	Layer,
 	Match,
 	MutableHashMap,
@@ -14,12 +15,17 @@ import {
 	LO_TECH_DATA_TYPE_PRICE,
 	type LoTechModuleConfig,
 } from "../../config/lo-tech-module-config";
+import { HAS_PRICE_KEY } from "../../constants";
 import { createErrorResponse } from "../../controllers/create-error-response";
 import { replaceParams } from "../../utils/replace-params";
 import { FailedToHandleRequest, ModuleService } from "../module";
 import { createPriceCache } from "../shared/price-cache";
 import { FailedToHandleLoTechRequestError } from "./errors";
-import type { LoTechDataPrice, LoTechParsedData } from "./schema";
+import type {
+	LoTechDataPrice,
+	LoTechParsedData,
+	LoTechResponse,
+} from "./schema";
 import { makeLoTechWebSocketService } from "./ws-client";
 
 export type PriceFeedSymbol = string;
@@ -184,34 +190,42 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 						);
 					}
 
-					const prices: LoTechDataPrice[] = [];
+					const responses: LoTechResponse[] = [];
 					const now = yield* Clock.currentTimeMillis;
 
+					// First subscribe to all the symbols that we have not subscribed to yet
+					// We do this separately from the price fetching to avoid waiting extra time
+					// for each symbol.
 					for (const symbol of symbols) {
-						// Set the last request timestamp.
-						const lastRequestTimestamp = MutableHashMap.get(
-							lastRequestToPriceFeed,
-							symbol,
-						);
-						if (Option.isNone(lastRequestTimestamp)) {
-							yield* newPriceFeedRequests.offer(symbol);
+						if (MutableHashMap.has(lastRequestToPriceFeed, symbol)) {
+							continue;
 						}
+						yield* newPriceFeedRequests.offer(symbol);
+					}
+
+					// Now since the subscriptions are in-flight, we can fetch the prices.
+					for (const symbol of symbols) {
 						MutableHashMap.set(lastRequestToPriceFeed, symbol, now);
 
-						// Get the price from the cache.
-						const price = yield* priceCache.getOrWaitPrice(symbol).pipe(
-							Effect.catchTag("FailedToGetPriceError", (error) =>
-								Effect.gen(function* () {
-									yield* priceCache.deletePrice(symbol);
-									return yield* Effect.fail(error);
-								}),
-							),
+						const price = yield* Effect.either(
+							priceCache.getOrWaitPrice(symbol),
 						);
-						prices.push(price);
+
+						if (Either.isLeft(price)) {
+							responses.push({
+								symbol,
+								[HAS_PRICE_KEY]: false,
+							});
+						} else {
+							responses.push({
+								...price.right,
+								[HAS_PRICE_KEY]: true,
+							});
+						}
 					}
 
 					return yield* Effect.succeed(
-						new Response(JSON.stringify(prices), { status: 200 }),
+						new Response(JSON.stringify(responses), { status: 200 }),
 					);
 				}).pipe(
 					Effect.withSpan("handleLoTechRequest"),

--- a/workspace/data-proxy/src/modules/lo-tech/schema.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/schema.ts
@@ -3,6 +3,7 @@ import {
 	LO_TECH_DATA_TYPE_PRICE,
 	type LoTechDataType,
 } from "../../config/lo-tech-module-config";
+import { HAS_PRICE_KEY } from "../../constants";
 
 export const LoTechDataPriceSchema = v.strictObject({
 	type: v.literal(LO_TECH_DATA_TYPE_PRICE),
@@ -15,6 +16,15 @@ export const LoTechDataPriceSchema = v.strictObject({
 });
 
 export type LoTechDataPrice = v.InferOutput<typeof LoTechDataPriceSchema>;
+
+export type LoTechResponse =
+	| (LoTechDataPrice & {
+			[HAS_PRICE_KEY]: true;
+	  })
+	| {
+			symbol: string;
+			[HAS_PRICE_KEY]: false;
+	  };
 
 export const LoTechParsedDataSchema = v.variant("type", [
 	LoTechDataPriceSchema,

--- a/workspace/data-proxy/src/modules/lo-tech/schema.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/schema.ts
@@ -5,6 +5,18 @@ import {
 } from "../../config/lo-tech-module-config";
 import { HAS_PRICE_KEY } from "../../constants";
 
+export type LoTechResponse =
+	| (LoTechDataPrice & {
+			[HAS_PRICE_KEY]: true;
+	  })
+	| {
+			symbol: string;
+			[HAS_PRICE_KEY]: false;
+	  };
+
+/*
+ * Data messages
+ */
 export const LoTechDataPriceSchema = v.strictObject({
 	type: v.literal(LO_TECH_DATA_TYPE_PRICE),
 	symbol: v.string(),
@@ -16,24 +28,6 @@ export const LoTechDataPriceSchema = v.strictObject({
 });
 
 export type LoTechDataPrice = v.InferOutput<typeof LoTechDataPriceSchema>;
-
-export type LoTechResponse =
-	| (LoTechDataPrice & {
-			[HAS_PRICE_KEY]: true;
-	  })
-	| {
-			symbol: string;
-			[HAS_PRICE_KEY]: false;
-	  };
-
-export const LoTechAckSchema = v.strictObject({
-	egress_ts: v.number(),
-	ack: v.object({
-		id: v.number(),
-	}),
-});
-
-export type LoTechAck = v.InferOutput<typeof LoTechAckSchema>;
 
 export const LoTechParsedDataSchema = v.variant("type", [
 	LoTechDataPriceSchema,
@@ -50,14 +44,57 @@ export const LoTechDataMessageSchema = v.object({
 
 export type LoTechDataMessage = v.InferOutput<typeof LoTechDataMessageSchema>;
 
-export type LoTechAckMessage = {
-	egress_ts: number;
-	ack: {
-		id: number;
-	};
-};
+/*
+ * Ack messages
+ */
+export const LoTechAckSchema = v.strictObject({
+	egress_ts: v.number(),
+	ack: v.object({
+		id: v.number(),
+	}),
+});
 
-export type LoTechMessage = LoTechDataMessage | LoTechAckMessage;
+export type LoTechAck = v.InferOutput<typeof LoTechAckSchema>;
+
+/*
+ * Error messages
+ */
+export const LoTechSubscriptionFailureCode = 14;
+export const LoTechSubscriptionFailureSchema = v.object({
+	error: v.string(),
+	code: v.literal(LoTechSubscriptionFailureCode),
+	id: v.number(),
+	info: v.object({
+		type: v.literal("subscription_failure"),
+		failures: v.array(
+			v.object({
+				type: v.literal("topic_parse_error"),
+				raw: v.object({
+					symbol: v.string(),
+					type: v.literal(LO_TECH_DATA_TYPE_PRICE),
+				}),
+				message: v.string(),
+			}),
+		),
+		succeeded: v.array(
+			v.object({
+				symbol: v.string(),
+				type: v.literal(LO_TECH_DATA_TYPE_PRICE),
+			}),
+		),
+	}),
+});
+
+export const LoTechParsedErrorSchema = v.variant("code", [
+	LoTechSubscriptionFailureSchema,
+]);
+
+export const LoTechErrorMessageSchema = v.object({
+	egress_ts: v.number(),
+	error: LoTechParsedErrorSchema,
+});
+
+export type LoTechErrorMessage = v.InferOutput<typeof LoTechErrorMessageSchema>;
 
 /**
  * Compile-time: keep LoTechDataType (config picklist) and parsed `type`

--- a/workspace/data-proxy/src/modules/lo-tech/schema.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/schema.ts
@@ -26,6 +26,15 @@ export type LoTechResponse =
 			[HAS_PRICE_KEY]: false;
 	  };
 
+export const LoTechAckSchema = v.strictObject({
+	egress_ts: v.number(),
+	ack: v.object({
+		id: v.number(),
+	}),
+});
+
+export type LoTechAck = v.InferOutput<typeof LoTechAckSchema>;
+
 export const LoTechParsedDataSchema = v.variant("type", [
 	LoTechDataPriceSchema,
 ]);

--- a/workspace/data-proxy/src/modules/lo-tech/ws-client.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/ws-client.ts
@@ -2,7 +2,12 @@ import { Duration, Effect, Runtime, Schedule } from "effect";
 import * as v from "valibot";
 import WebSocket from "ws";
 import type { LoTechModuleConfig } from "../../config/lo-tech-module-config";
-import { LoTechDataMessageSchema, type LoTechParsedData } from "./schema";
+import {
+	type LoTechAck,
+	LoTechAckSchema,
+	LoTechDataMessageSchema,
+	type LoTechParsedData,
+} from "./schema";
 
 // LO:TECH expects a ping every ~60 seconds to keep the connection alive.
 const LO_TECH_PING_INTERVAL_MS = 30_000;
@@ -36,13 +41,20 @@ export type LoTechWebSocketServiceDeps = {
 	/* Runs immediately after the socket is OPEN */
 	onConnected?: (api: LoTechWebSocketServiceApi) => Effect.Effect<void>;
 	handleDataMessage: (data: LoTechParsedData) => Effect.Effect<void>;
+	handleAckMessage: (data: LoTechAck) => Effect.Effect<void>;
 };
 
 export const makeLoTechWebSocketService = (
 	deps: LoTechWebSocketServiceDeps,
 ): Effect.Effect<LoTechWebSocketServiceApi> =>
 	Effect.gen(function* () {
-		const { config, runtime, onConnected, handleDataMessage } = deps;
+		const {
+			config,
+			runtime,
+			onConnected,
+			handleDataMessage,
+			handleAckMessage,
+		} = deps;
 
 		let activeSocket: WebSocket | null = null;
 		const pendingOutbound: string[] = [];
@@ -182,7 +194,27 @@ export const makeLoTechWebSocketService = (
 										),
 									);
 								} else if ("ack" in parsed) {
-									yield* Effect.logInfo("Received ack from LO:TECH");
+									const ackResult = v.safeParse(LoTechAckSchema, parsed);
+									if (!ackResult.success) {
+										yield* Effect.logError(
+											"Unexpected LO:TECH ack message (schema)",
+											{
+												issues: v.flatten(ackResult.issues),
+												raw: parsed,
+											},
+										);
+										return;
+									}
+									yield* handleAckMessage(ackResult.output).pipe(
+										Effect.catchAll((err) =>
+											Effect.logError(
+												"Failed to handle ack message from LO:TECH",
+												{
+													err,
+												},
+											),
+										),
+									);
 								} else if ("pong" in parsed) {
 									yield* Effect.logInfo("Received pong from LO:TECH");
 								} else if ("error" in parsed) {

--- a/workspace/data-proxy/src/modules/lo-tech/ws-client.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/ws-client.ts
@@ -6,6 +6,8 @@ import {
 	type LoTechAck,
 	LoTechAckSchema,
 	LoTechDataMessageSchema,
+	type LoTechErrorMessage,
+	LoTechErrorMessageSchema,
 	type LoTechParsedData,
 } from "./schema";
 
@@ -42,6 +44,7 @@ export type LoTechWebSocketServiceDeps = {
 	onConnected?: (api: LoTechWebSocketServiceApi) => Effect.Effect<void>;
 	handleDataMessage: (data: LoTechParsedData) => Effect.Effect<void>;
 	handleAckMessage: (data: LoTechAck) => Effect.Effect<void>;
+	handleErrorMessage: (data: LoTechErrorMessage) => Effect.Effect<void>;
 };
 
 export const makeLoTechWebSocketService = (
@@ -54,6 +57,7 @@ export const makeLoTechWebSocketService = (
 			onConnected,
 			handleDataMessage,
 			handleAckMessage,
+			handleErrorMessage,
 		} = deps;
 
 		let activeSocket: WebSocket | null = null;
@@ -168,60 +172,28 @@ export const makeLoTechWebSocketService = (
 								}
 
 								if ("data" in parsed) {
-									const msgResult = v.safeParse(
+									yield* parseAndHandle(
 										LoTechDataMessageSchema,
+										"data",
 										parsed,
-									);
-									if (!msgResult.success) {
-										yield* Effect.logError(
-											"Unexpected LO:TECH data message (schema)",
-											{
-												issues: v.flatten(msgResult.issues),
-												raw: parsed,
-											},
-										);
-										return;
-									}
-
-									yield* handleDataMessage(msgResult.output.data).pipe(
-										Effect.catchAll((err) =>
-											Effect.logError(
-												"Failed to handle data message from LO:TECH",
-												{
-													err,
-												},
-											),
-										),
+										(msg) => handleDataMessage(msg.data),
 									);
 								} else if ("ack" in parsed) {
-									const ackResult = v.safeParse(LoTechAckSchema, parsed);
-									if (!ackResult.success) {
-										yield* Effect.logError(
-											"Unexpected LO:TECH ack message (schema)",
-											{
-												issues: v.flatten(ackResult.issues),
-												raw: parsed,
-											},
-										);
-										return;
-									}
-									yield* handleAckMessage(ackResult.output).pipe(
-										Effect.catchAll((err) =>
-											Effect.logError(
-												"Failed to handle ack message from LO:TECH",
-												{
-													err,
-												},
-											),
-										),
+									yield* parseAndHandle(
+										LoTechAckSchema,
+										"ack",
+										parsed,
+										handleAckMessage,
+									);
+								} else if ("error" in parsed) {
+									yield* parseAndHandle(
+										LoTechErrorMessageSchema,
+										"error",
+										parsed,
+										handleErrorMessage,
 									);
 								} else if ("pong" in parsed) {
 									yield* Effect.logInfo("Received pong from LO:TECH");
-								} else if ("error" in parsed) {
-									yield* Effect.logError(
-										"LO:TECH error message received",
-										parsed,
-									);
 								} else {
 									yield* Effect.logWarning(
 										"Unexpected LO:TECH message received",
@@ -288,4 +260,28 @@ export const makeLoTechWebSocketService = (
 		yield* Effect.forkDaemon(Effect.repeat(runSession, reconnectSchedule));
 
 		return api;
+	});
+
+const parseAndHandle = <T>(
+	schema: v.GenericSchema<unknown, T>,
+	label: string,
+	raw: unknown,
+	handler: (value: T) => Effect.Effect<void>,
+) =>
+	Effect.gen(function* () {
+		const result = v.safeParse(schema, raw);
+		if (!result.success) {
+			yield* Effect.logError(`Unexpected LO:TECH ${label} message (schema)`, {
+				issues: v.flatten(result.issues),
+				raw,
+			});
+			return;
+		}
+		yield* handler(result.output).pipe(
+			Effect.catchAll((err) =>
+				Effect.logError(`Failed to handle ${label} message from LO:TECH`, {
+					err,
+				}),
+			),
+		);
 	});

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -345,7 +345,6 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 						);
 
 						if (Either.isLeft(price)) {
-							yield* priceCache.deletePrice(priceFeedId);
 							prices.push({
 								priceFeedId,
 								symbol: priceFeedIdsRaw.at(index),

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -326,34 +326,36 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 					const now = yield* Clock.currentTimeMillis;
 
 					// First subscribe to all the symbols that we have not subscribed to yet
-					// We do this separately from the price fetching to avoid waiting extra time
-					// for each symbol.
 					for (const priceFeedId of priceFeedIds) {
-						if (MutableHashMap.has(lastRequestToPriceFeed, priceFeedId)) {
-							continue;
+						if (!MutableHashMap.has(lastRequestToPriceFeed, priceFeedId)) {
+							yield* newPriceFeedRequests.offer(priceFeedId);
 						}
 
-						yield* newPriceFeedRequests.offer(priceFeedId);
+						MutableHashMap.set(lastRequestToPriceFeed, priceFeedId, now);
 					}
 
-					// Now since the subscriptions are in-flight, we can fetch the prices.
-					for (const [index, priceFeedId] of priceFeedIds.entries()) {
-						MutableHashMap.set(lastRequestToPriceFeed, priceFeedId, now);
+					// Now since the subscriptions are in-flight, we can fetch the prices concurrently.
+					const results = yield* Effect.forEach(
+						priceFeedIds,
+						(priceFeedId) =>
+							Effect.either(priceCache.getOrWaitPrice(priceFeedId)),
+						{ concurrency: "unbounded" },
+					);
 
-						const price = yield* Effect.either(
-							priceCache.getOrWaitPrice(priceFeedId),
-						);
+					for (let i = 0; i < priceFeedIds.length; i++) {
+						const priceFeedId = priceFeedIds[i];
+						const price = results[i];
 
 						if (Either.isLeft(price)) {
 							prices.push({
 								priceFeedId,
-								symbol: priceFeedIdsRaw.at(index),
+								symbol: priceFeedIdsRaw.at(i),
 								[HAS_PRICE_KEY]: false,
 							});
 						} else {
 							prices.push({
 								...price.right,
-								symbol: priceFeedIdsRaw.at(index),
+								symbol: priceFeedIdsRaw.at(i),
 								[HAS_PRICE_KEY]: true,
 							});
 						}

--- a/workspace/data-proxy/src/modules/shared/price-cache.ts
+++ b/workspace/data-proxy/src/modules/shared/price-cache.ts
@@ -87,6 +87,7 @@ export const createPriceCache = <K, V>() =>
 					}),
 				);
 			}).pipe(
+				Effect.tapError(() => deletePrice(key)),
 				Effect.withSpan("priceCache.getOrWaitPrice", { attributes: { key } }),
 			);
 


### PR DESCRIPTION
## Explanation of Changes

Explanation of the three commits in order:
1. Apply changes from #130 to the lo-tech module. Also, move cleanup upon timeout error from the call sites to the shared cache.
2. Lo-tech module now handles acknowledgement messages. The price feed map is now updated only after receiving ack messages, preventing updates when a subscription request fails.
3. Lo-tech module also handles subscription failure errors. This helps us clean up the price feed IDs we add for every subscription request.
4. Price fetch is now done concurrently so that timeouts do not accumulate across multiple invalid symbols.

## Testing

```bash
$ curl http://localhost:5384/proxy/lotech/NVDA,WTIN6 | jq

[
  {
    "type": "PRICE",
    "symbol": "NVDA",
    "ingress_ts": 1779818875945310,
    "publish_ts": null,
    "transaction_ts": 1779818875860000,
    "price": 213.496,
    "spread": 0.01,
    "__sedaHasPrice": true
  },
  {
    "symbol": "WTIN6",
    "__sedaHasPrice": false
  }
]
```

