### PR TITLE
Hydro single coin + REST fallback for unsupported

### DIFF
--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",

--- a/workspace/data-proxy/src/config/hydromancer-module-config.ts
+++ b/workspace/data-proxy/src/config/hydromancer-module-config.ts
@@ -99,11 +99,20 @@ export const AssetCtxSchema = v.object({
 
 export type AssetCtx = v.InferOutput<typeof AssetCtxSchema>;
 
-// Request body the module accepts. Anything else is rejected with 400.
-export const AssetContextRequestBodySchema = v.object({
-	type: v.literal("assetContext"),
+const AssetContextType = v.literal("assetContext");
+const SingleAssetContextType = v.object({
+	type: AssetContextType,
+	coin: v.string(),
+});
+const BatchAssetContextType = v.object({
+	type: AssetContextType,
 	coins: v.array(v.string()),
 });
+// Request body the module accepts. Anything else is forwarded to the upstream
+export const AssetContextRequestBodySchema = v.union([
+	SingleAssetContextType,
+	BatchAssetContextType,
+]);
 
 export type AssetContextRequestBody = v.InferOutput<
 	typeof AssetContextRequestBodySchema

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
@@ -50,25 +50,29 @@ const buildRoute = () =>
 		method: ["POST"],
 	});
 
-const buildAssetContextRequest = (coins: string[]) =>
+const buildAssetContextRequest = (body: string) =>
 	new Request("http://proxy.local/info", {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ type: "assetContext", coins }),
+		body,
 	});
 
-const assetContextBody = (coins: string[]) =>
+const buildRequestBody = (coins: string[]) =>
 	JSON.stringify({ type: "assetContext", coins });
 
-const callHandle = (config: HydromancerModuleConfig, coins: string[]) => {
+const callHandle = (
+	config: HydromancerModuleConfig,
+	coins: string[],
+	buildBody = buildRequestBody,
+) => {
 	const route = buildRoute();
-	const body = assetContextBody(coins);
+	const body = buildBody(coins);
 	const program = Effect.gen(function* () {
 		const svc = yield* ModuleService;
 		return yield* svc.handleRequest(
 			route,
 			{},
-			buildAssetContextRequest(coins),
+			buildAssetContextRequest(body),
 			body,
 		);
 	});
@@ -95,7 +99,10 @@ const callHandleRaw = (config: HydromancerModuleConfig, rawBody: string) => {
 		);
 	});
 	return Effect.runPromise(
-		program.pipe(Effect.provide(HydromancerModuleService(config))),
+		program.pipe(
+			Effect.provide(HydromancerModuleService(config)),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		),
 	);
 };
 
@@ -105,17 +112,19 @@ const callHandleSequence = (
 	config: HydromancerModuleConfig,
 	calls: string[][],
 	between?: () => Promise<void>,
+	buildBody = buildRequestBody,
 ) => {
 	const route = buildRoute();
 	const program = Effect.gen(function* () {
 		const svc = yield* ModuleService;
 		const responses: Response[] = [];
 		for (const coins of calls) {
+			const body = buildBody(coins);
 			const response = yield* svc.handleRequest(
 				route,
 				{},
-				buildAssetContextRequest(coins),
-				assetContextBody(coins),
+				buildAssetContextRequest(body),
+				body,
 			);
 			responses.push(response);
 			if (between) {
@@ -167,6 +176,38 @@ describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const body = await response.json();
 		expect(body).toEqual({ BTC: btcCtx, ETH: ethCtx });
+	});
+
+	it("supports single-coin assetContext requests", async () => {
+		const fetchMock = mock(
+			async (input: URL | RequestInfo, init?: RequestInit) => {
+				const url =
+					input instanceof URL
+						? input.toString()
+						: ((input as Request).url ?? input);
+				expect(String(url)).toContain("/info");
+				expect(init?.method).toBe("POST");
+				expect(JSON.parse(init?.body as string)).toEqual({
+					type: "assetContext",
+					coins: ["BTC"],
+				});
+				expect((init?.headers as Record<string, string>).Authorization).toBe(
+					"Bearer test-api-key",
+				);
+				return new Response(JSON.stringify({ BTC: btcCtx }), {
+					status: 200,
+				});
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, ["BTC"], (coins) =>
+			JSON.stringify({ type: "assetContext", coin: coins[0] }),
+		);
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const body = await response.json();
+		expect(body).toEqual({ BTC: btcCtx });
 	});
 
 	it("keeps null entries for coins that come back null", async () => {
@@ -250,16 +291,27 @@ describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
 });
 
 describe("HydromancerModuleService.handleRequest (non-assetContext)", () => {
-	it("returns 400 for a body shape other than assetContext", async () => {
+	it("forwards the body to the upstream REST endpoint", async () => {
 		const fetchMock = mock(async () => new Response("{}", { status: 200 }));
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 
 		const response = await callHandleRaw(
 			baseConfig,
-			JSON.stringify({ type: "userState" }),
+			JSON.stringify({ type: "fundingHistory", coin: "BTC" }),
 		);
-		expect(response.status).toBe(400);
-		expect(fetchMock).not.toHaveBeenCalled();
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledWith(
+			new URL("/info", baseConfig.restBaseUrl),
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer test-api-key",
+				},
+				body: JSON.stringify({ type: "fundingHistory", coin: "BTC" }),
+				signal: expect.anything(),
+			},
+		);
 	});
 });
 
@@ -389,11 +441,12 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 			const svc = yield* ModuleService;
 			yield* svc.start();
 			const route = buildRoute();
+			const body = buildRequestBody(["BTC"]);
 			return yield* svc.handleRequest(
 				route,
 				{},
-				buildAssetContextRequest(["BTC"]),
-				assetContextBody(["BTC"]),
+				buildAssetContextRequest(body),
+				body,
 			);
 		});
 
@@ -431,18 +484,9 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 			const svc = yield* ModuleService;
 			yield* svc.start();
 			const route = buildRoute();
-			yield* svc.handleRequest(
-				route,
-				{},
-				buildAssetContextRequest(["BTC"]),
-				assetContextBody(["BTC"]),
-			);
-			yield* svc.handleRequest(
-				route,
-				{},
-				buildAssetContextRequest(["BTC"]),
-				assetContextBody(["BTC"]),
-			);
+			const body = buildRequestBody(["BTC"]);
+			yield* svc.handleRequest(route, {}, buildAssetContextRequest(body), body);
+			yield* svc.handleRequest(route, {}, buildAssetContextRequest(body), body);
 		});
 
 		await Effect.runPromise(
@@ -481,12 +525,8 @@ describe("HydromancerModuleService demand-driven subscriptions", () => {
 			const svc = yield* ModuleService;
 			yield* svc.start();
 			const route = buildRoute();
-			yield* svc.handleRequest(
-				route,
-				{},
-				buildAssetContextRequest(["BTC"]),
-				assetContextBody(["BTC"]),
-			);
+			const body = buildRequestBody(["BTC"]);
+			yield* svc.handleRequest(route, {}, buildAssetContextRequest(body), body);
 		});
 
 		await Effect.runPromise(
@@ -555,24 +595,15 @@ describe("HydromancerModuleService REST fallback when WS is errored", () => {
 			const route = buildRoute();
 
 			// Request 1: cache miss, REST populates BTC.
-			yield* svc.handleRequest(
-				route,
-				{},
-				buildAssetContextRequest(["BTC"]),
-				assetContextBody(["BTC"]),
-			);
+			const body = buildRequestBody(["BTC"]);
+			yield* svc.handleRequest(route, {}, buildAssetContextRequest(body), body);
 
 			// Drop the socket: cache.markSocketError fires, currentWS clears.
 			ws.close();
 			yield* Effect.sleep(Duration.millis(0));
 
 			// Request 2: BTC is fresh in cache but socketError forces another REST.
-			yield* svc.handleRequest(
-				route,
-				{},
-				buildAssetContextRequest(["BTC"]),
-				assetContextBody(["BTC"]),
-			);
+			yield* svc.handleRequest(route, {}, buildAssetContextRequest(body), body);
 		});
 
 		await Effect.runPromise(

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
@@ -1,4 +1,12 @@
-import { Clock, Duration, Effect, Layer, MutableHashMap, Option } from "effect";
+import {
+	Clock,
+	Duration,
+	Effect,
+	Layer,
+	Match,
+	MutableHashMap,
+	Option,
+} from "effect";
 import type { Route } from "../../config/config-parser";
 import {
 	type AssetCtx,
@@ -10,7 +18,10 @@ import { forkIdleCleanup } from "../../utils/idle-cleanup";
 import { FailedToHandleRequest, ModuleService } from "../module";
 import { createAssetCache } from "./asset-cache";
 import { FailedToHandleHydromancerRequestError } from "./errors";
-import { fetchAssetContextsFromRest } from "./rest-fallback";
+import {
+	executeHydromancerRestRequest,
+	fetchAssetContextsFromRest,
+} from "./rest-fallback";
 import { createHydromancerWS } from "./ws-client";
 
 export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
@@ -70,14 +81,22 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 
 					const parsedBody = parseAssetContextRequestBody(body ?? "");
 					if (Option.isNone(parsedBody)) {
-						return yield* Effect.fail(
-							new FailedToHandleHydromancerRequestError({
-								error: "Hydromancer module only handles assetContext bodies",
-								status: 400,
-							}),
+						yield* Effect.logDebug(
+							"Hydromancer module received unsupported body, forwarding to REST",
 						);
+						return yield* executeHydromancerRestRequest(config, body);
 					}
-					const coins = parsedBody.value.coins;
+
+					const coins = Match.value(parsedBody.value).pipe(
+						Match.when(
+							{ type: "assetContext", coins: Match.any },
+							(body) => body.coins,
+						),
+						Match.when({ type: "assetContext", coin: Match.any }, (body) => [
+							body.coin,
+						]),
+						Match.exhaustive,
+					);
 
 					if (coins.length > config.maxCoinsPerRequest) {
 						return yield* Effect.fail(

--- a/workspace/data-proxy/src/modules/hydromancer/rest-fallback.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/rest-fallback.ts
@@ -11,13 +11,16 @@ const BatchResponseSchema = v.record(v.string(), v.nullable(AssetCtxSchema));
 
 export type BatchAssetContexts = v.InferOutput<typeof BatchResponseSchema>;
 
-export const fetchAssetContextsFromRest = (
+export const executeHydromancerRestRequest = (
 	config: HydromancerModuleConfig,
-	coins: string[],
-): Effect.Effect<BatchAssetContexts, FailedToHandleHydromancerRequestError> =>
+	rawBody: unknown,
+): Effect.Effect<Response, FailedToHandleHydromancerRequestError> =>
 	Effect.gen(function* () {
 		const url = new URL("/info", config.restBaseUrl);
 		const timeoutMs = Duration.toMillis(config.restFetchTimeout);
+
+		const body =
+			typeof rawBody === "string" ? rawBody : JSON.stringify(rawBody);
 
 		const response = yield* Effect.tryPromise({
 			try: () =>
@@ -27,7 +30,7 @@ export const fetchAssetContextsFromRest = (
 						"Content-Type": "application/json",
 						Authorization: `Bearer ${config.hydromancerApiKey}`,
 					},
-					body: JSON.stringify({ type: "assetContext", coins }),
+					body,
 					signal: AbortSignal.timeout(timeoutMs),
 				}),
 			catch: (error) => {
@@ -40,6 +43,19 @@ export const fetchAssetContextsFromRest = (
 					status: isTimeout ? 504 : 502,
 				});
 			},
+		});
+
+		return response;
+	}).pipe(Effect.withSpan("executeHydromancerRestRequest"));
+
+export const fetchAssetContextsFromRest = (
+	config: HydromancerModuleConfig,
+	coins: string[],
+): Effect.Effect<BatchAssetContexts, FailedToHandleHydromancerRequestError> =>
+	Effect.gen(function* () {
+		const response = yield* executeHydromancerRestRequest(config, {
+			type: "assetContext",
+			coins,
 		});
 
 		const responseText = yield* Effect.tryPromise({


### PR DESCRIPTION
## Motivation

The REST fallback for any requests that the module can't handle allows this module to serve as a drop-in replacement of Hydromancer data-proxies that use the standard request forwarding.

## Explanation of Changes

In addition to falling back to REST for unknown request bodies, we now also support the singular `coin`.

## Testing

Added and updated unit tests to match the new behaviour.

## Related PRs and Issues

N.A.