### PR TITLE
chore(dxfeed): add script to generate token

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"start": "bun run check-ts && bun run ./workspace/data-proxy",
 		"fmt": "bunx biome check --write .",
 		"check-fmt": "bunx biome check .",
-		"check-ts": "bunx tsc --noEmit"
+		"check-ts": "bunx tsc --noEmit",
+		"gen:dxfeed-token": "bun run ./workspace/data-proxy/src/scripts/generate-dxfeed-token.ts"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",

--- a/workspace/data-proxy/src/scripts/generate-dxfeed-token.ts
+++ b/workspace/data-proxy/src/scripts/generate-dxfeed-token.ts
@@ -1,0 +1,57 @@
+import { createHmac } from "node:crypto";
+
+function ask(label: string, defaultValue?: string): string {
+	const suffix = defaultValue ? ` [${defaultValue}]` : "";
+	const answer = prompt(`${label}${suffix}:`)?.trim();
+	const value = answer || defaultValue;
+
+	if (!value) {
+		console.error(`A value for "${label}" is required.`);
+		process.exit(1);
+	}
+
+	return value;
+}
+
+const issuer = ask("Issuer (provided by dxFeed)");
+const secret = ask("Secret (signing key provided by dxFeed)");
+const session = ask("Session / sessionType (provided by dxFeed)");
+const message = ask("Message (<userID> or <userID>,<filter_1>;...;<filter_n>)");
+const days = Number(ask("Validity in days", "30"));
+
+if (!Number.isInteger(days) || days <= 0) {
+	console.error("Validity in days must be a positive integer.");
+	process.exit(1);
+}
+
+const notBeforeTime = "";
+const issuedAtTime = Math.floor(Date.now() / 1000);
+const expirationTime = issuedAtTime + days * 86400;
+
+const payload = [
+	issuer,
+	session,
+	notBeforeTime,
+	expirationTime,
+	issuedAtTime,
+	message,
+].join(",");
+
+const encodedPayload = Buffer.from(encodeURI(payload))
+	.toString("base64")
+	.split("=")[0];
+
+const signature = createHmac("sha256", encodeURI(secret))
+	.update(encodedPayload)
+	.digest("base64")
+	.split("=")[0]
+	.replace(/\+/g, "-")
+	.replace(/\//g, "_");
+
+const token = `${encodedPayload}.${signature}`;
+
+console.log(`\nPayload: ${payload}`);
+console.log(
+	`Expires: ${new Date(expirationTime * 1000).toISOString()} (in ${days} ${days === 1 ? "day" : "days"})`,
+);
+console.log(`\nToken: ${token}`);


### PR DESCRIPTION
## Motivation

We occasionally need to manually generate dxFeed self-signed auth tokens (e.g. for the dxFeed module's `dxfeedAuthToken`), but had no convenient way to do so.

## Explanation of Changes

Added a small interactive script (`workspace/data-proxy/src/scripts/generate-dxfeed-token.ts`) that prompts for the issuer, secret, session, message and validity (days), then builds an HMAC-SHA256 self-signed token per the [dxFeed token spec](https://kb.dxfeed.com/en/data-services/real-time-and-delayed-services/token-based-authorization/token.html). It uses Bun's built-in `prompt()` and native `node:crypto`, so no new dependencies. Wired up as the `gen:dxfeed-token` script in the root `package.json`.

## Testing

```bash
bun run gen:dxfeed-token
```

Follow the prompts; the script prints the payload, expiry, and final token.