### PR TITLE
Add pyth lazer latest price surface

### DIFF
--- a/workspace/data-proxy/src/config/pyth-lazer-module-config.ts
+++ b/workspace/data-proxy/src/config/pyth-lazer-module-config.ts
@@ -50,7 +50,10 @@ export interface PythLazerModuleConfig
 export const PythLazerModuleRouteSchema = v.strictObject({
 	...RouteSchema.entries,
 	moduleName: v.string(),
-	fetchFromModule: v.string(),
+	// Present: the symbols/ids come from the path (e.g. GET /price/:symbols),
+	// returning a per-feed array. Absent: use the legacy-compatible
+	// POST /v1/latest_price body surface.
+	fetchFromModule: v.optional(v.string()),
 	type: v.literal("pyth-lazer"),
 });
 

--- a/workspace/data-proxy/src/config/pyth-lazer-module-config.ts
+++ b/workspace/data-proxy/src/config/pyth-lazer-module-config.ts
@@ -2,6 +2,15 @@ import { Duration, Effect, Option } from "effect";
 import * as v from "valibot";
 import { RouteSchema } from "./route-config";
 
+export const PythLazerChannelSchema = v.picklist([
+	"real_time",
+	"fixed_rate@50ms",
+	"fixed_rate@1000ms",
+	"fixed_rate@200ms",
+]);
+
+export type PythLazerChannel = v.InferOutput<typeof PythLazerChannelSchema>;
+
 export const PythLazerModuleConfigSchema = v.strictObject({
 	name: v.string(),
 	priceFeedIds: v.array(
@@ -10,15 +19,7 @@ export const PythLazerModuleConfigSchema = v.strictObject({
 			id: v.number(),
 		}),
 	),
-	channel: v.optional(
-		v.picklist([
-			"real_time",
-			"fixed_rate@50ms",
-			"fixed_rate@1000ms",
-			"fixed_rate@200ms",
-		]),
-		"fixed_rate@200ms",
-	),
+	channel: v.optional(PythLazerChannelSchema, "fixed_rate@200ms"),
 	maxFeedsPerRequest: v.optional(v.number(), 100),
 	pythLazerApiKeyEnvKey: v.string(),
 	priceFeedsCleanupTtl: v.pipe(

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -73,6 +73,7 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 						pythLazerModuleRoute,
 						params,
 						request,
+						Option.getOrElse(body, () => ""),
 					);
 				}),
 			),

--- a/workspace/data-proxy/src/modules/pyth-lazer/legacy-latest-price/latest-price.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/legacy-latest-price/latest-price.ts
@@ -1,0 +1,121 @@
+import { tryParseSync } from "@seda-protocol/utils";
+import { Clock, Effect } from "effect";
+import * as v from "valibot";
+import type { PythLazerModuleConfig } from "../../../config/pyth-lazer-module-config";
+import { FailedToHandlePythLazerRequestError } from "../errors";
+import type { CachedPriceFeed, PythLazerHandlerError } from "../types";
+
+type LegacyLatestPriceHandlerDeps = {
+	config: Pick<PythLazerModuleConfig, "maxFeedsPerRequest">;
+	ensureSubscribedAndTrack: (
+		priceFeedIds: number[],
+		now: number,
+	) => Effect.Effect<void, PythLazerHandlerError>;
+	getOrWaitPrice: (
+		priceFeedId: number,
+	) => Effect.Effect<CachedPriceFeed, PythLazerHandlerError>;
+	resolvePriceFeedIds: (
+		rawTokens: string[],
+	) => Effect.Effect<number[], PythLazerHandlerError>;
+};
+
+const maxTimestampUs = (timestamps: string[]) =>
+	timestamps.reduce((latest, timestamp) =>
+		BigInt(timestamp) > BigInt(latest) ? timestamp : latest,
+	);
+
+const LatestPriceRequestBodySchema = v.pipe(
+	v.looseObject({
+		priceFeedIds: v.optional(v.array(v.number())),
+		priceFeedSymbols: v.optional(v.array(v.string())),
+	}),
+	v.check(
+		(body) =>
+			(body.priceFeedIds?.length ?? 0) > 0 ||
+			(body.priceFeedSymbols?.length ?? 0) > 0,
+		"Request body must include a non-empty priceFeedIds or priceFeedSymbols array",
+	),
+);
+
+type LatestPriceRequestBody = v.InferOutput<
+	typeof LatestPriceRequestBodySchema
+>;
+
+const getRequestedFeedIdentifiers = (body: LatestPriceRequestBody) => {
+	if (body.priceFeedIds !== undefined && body.priceFeedIds.length > 0) {
+		return body.priceFeedIds.map(String);
+	}
+
+	return body.priceFeedSymbols ?? [];
+};
+
+const parseJsonBody = (body: string | undefined) =>
+	Effect.try({
+		try: () => JSON.parse(body && body.length > 0 ? body : "{}") as unknown,
+		catch: () =>
+			new FailedToHandlePythLazerRequestError({
+				error: "Request body must be valid JSON",
+			}),
+	});
+
+const parseRequestedFeeds = (body: string | undefined) =>
+	Effect.gen(function* () {
+		const parsedBody = yield* parseJsonBody(body);
+		const parsedRequest = tryParseSync(
+			LatestPriceRequestBodySchema,
+			parsedBody,
+		);
+
+		if (parsedRequest.isErr) {
+			return yield* Effect.fail(
+				new FailedToHandlePythLazerRequestError({
+					error: parsedRequest.error.map((issue) => issue.message).join(", "),
+				}),
+			);
+		}
+
+		return getRequestedFeedIdentifiers(parsedRequest.value);
+	});
+
+// Legacy compatibility surface for POST /v1/latest_price. It returns the native
+// Pyth Lazer { parsed: { timestampUs, priceFeeds } } shape from the live cache.
+export const createLegacyLatestPriceHandler =
+	({
+		config,
+		ensureSubscribedAndTrack,
+		getOrWaitPrice,
+		resolvePriceFeedIds,
+	}: LegacyLatestPriceHandlerDeps) =>
+	(body: string | undefined) =>
+		Effect.gen(function* () {
+			const requestedFeeds = yield* parseRequestedFeeds(body);
+
+			if (requestedFeeds.length > config.maxFeedsPerRequest) {
+				return yield* Effect.fail(
+					new FailedToHandlePythLazerRequestError({
+						error: `Too many price feeds, max is ${config.maxFeedsPerRequest} but got ${requestedFeeds.length}`,
+					}),
+				);
+			}
+
+			const priceFeedIds = yield* resolvePriceFeedIds(requestedFeeds);
+			const now = yield* Clock.currentTimeMillis;
+			yield* ensureSubscribedAndTrack(priceFeedIds, now);
+
+			const cachedFeeds: CachedPriceFeed[] = [];
+			for (const priceFeedId of priceFeedIds) {
+				cachedFeeds.push(yield* getOrWaitPrice(priceFeedId));
+			}
+
+			return new Response(
+				JSON.stringify({
+					parsed: {
+						timestampUs: maxTimestampUs(
+							cachedFeeds.map((feed) => feed.timestampUs),
+						),
+						priceFeeds: cachedFeeds.map((feed) => feed.priceFeed),
+					},
+				}),
+				{ status: 200 },
+			);
+		});

--- a/workspace/data-proxy/src/modules/pyth-lazer/legacy-latest-price/latest-price.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/legacy-latest-price/latest-price.ts
@@ -41,6 +41,37 @@ type LatestPriceRequestBody = v.InferOutput<
 	typeof LatestPriceRequestBodySchema
 >;
 
+const PYTH_PRO_COMPAT_PRICE_FEED_FIELDS = [
+	"bestAskPrice",
+	"bestBidPrice",
+	"confidence",
+	"emaConfidence",
+	"emaPrice",
+	"fundingRate",
+	"fundingRateInterval",
+	"fundingTimestamp",
+	"marketSession",
+	"price",
+	"publisherCount",
+] as const;
+
+const toPythProPriceFeed = ({ priceFeed, timestampUs }: CachedPriceFeed) => {
+	const rawFeed = priceFeed as Record<string, unknown>;
+	const out: Record<string, unknown> = {
+		priceFeedId: priceFeed.priceFeedId,
+		exponent: priceFeed.exponent,
+		feedUpdateTimestamp:
+			priceFeed.feedUpdateTimestamp ?? Number.parseInt(timestampUs, 10),
+	};
+
+	for (const field of PYTH_PRO_COMPAT_PRICE_FEED_FIELDS) {
+		const value = rawFeed[field];
+		out[field] = value ?? null;
+	}
+
+	return out;
+};
+
 const getRequestedFeedIdentifiers = (body: LatestPriceRequestBody) => {
 	if (body.priceFeedIds !== undefined && body.priceFeedIds.length > 0) {
 		return body.priceFeedIds.map(String);
@@ -113,7 +144,7 @@ export const createLegacyLatestPriceHandler =
 						timestampUs: maxTimestampUs(
 							cachedFeeds.map((feed) => feed.timestampUs),
 						),
-						priceFeeds: cachedFeeds.map((feed) => feed.priceFeed),
+						priceFeeds: cachedFeeds.map(toPythProPriceFeed),
 					},
 				}),
 				{ status: 200 },

--- a/workspace/data-proxy/src/modules/pyth-lazer/legacy-latest-price/latest-price.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/legacy-latest-price/latest-price.ts
@@ -1,18 +1,24 @@
 import { tryParseSync } from "@seda-protocol/utils";
 import { Clock, Effect } from "effect";
 import * as v from "valibot";
-import type { PythLazerModuleConfig } from "../../../config/pyth-lazer-module-config";
+import {
+	type PythLazerChannel,
+	PythLazerChannelSchema,
+	type PythLazerModuleConfig,
+} from "../../../config/pyth-lazer-module-config";
 import { FailedToHandlePythLazerRequestError } from "../errors";
 import type { CachedPriceFeed, PythLazerHandlerError } from "../types";
 
 type LegacyLatestPriceHandlerDeps = {
-	config: Pick<PythLazerModuleConfig, "maxFeedsPerRequest">;
+	config: Pick<PythLazerModuleConfig, "maxFeedsPerRequest" | "channel">;
 	ensureSubscribedAndTrack: (
 		priceFeedIds: number[],
+		channel: PythLazerChannel,
 		now: number,
 	) => Effect.Effect<void, PythLazerHandlerError>;
 	getOrWaitPrice: (
 		priceFeedId: number,
+		channel: PythLazerChannel,
 	) => Effect.Effect<CachedPriceFeed, PythLazerHandlerError>;
 	resolvePriceFeedIds: (
 		rawTokens: string[],
@@ -28,6 +34,7 @@ const LatestPriceRequestBodySchema = v.pipe(
 	v.looseObject({
 		priceFeedIds: v.optional(v.array(v.number())),
 		priceFeedSymbols: v.optional(v.array(v.string())),
+		channel: v.optional(PythLazerChannelSchema),
 	}),
 	v.check(
 		(body) =>
@@ -89,7 +96,7 @@ const parseJsonBody = (body: string | undefined) =>
 			}),
 	});
 
-const parseRequestedFeeds = (body: string | undefined) =>
+const parseRequest = (body: string | undefined) =>
 	Effect.gen(function* () {
 		const parsedBody = yield* parseJsonBody(body);
 		const parsedRequest = tryParseSync(
@@ -105,7 +112,10 @@ const parseRequestedFeeds = (body: string | undefined) =>
 			);
 		}
 
-		return getRequestedFeedIdentifiers(parsedRequest.value);
+		return {
+			requestedFeeds: getRequestedFeedIdentifiers(parsedRequest.value),
+			channel: parsedRequest.value.channel,
+		};
 	});
 
 // Legacy compatibility surface for POST /v1/latest_price. It returns the native
@@ -119,7 +129,9 @@ export const createLegacyLatestPriceHandler =
 	}: LegacyLatestPriceHandlerDeps) =>
 	(body: string | undefined) =>
 		Effect.gen(function* () {
-			const requestedFeeds = yield* parseRequestedFeeds(body);
+			const { requestedFeeds, channel: requestedChannel } =
+				yield* parseRequest(body);
+			const channel = requestedChannel ?? config.channel;
 
 			if (requestedFeeds.length > config.maxFeedsPerRequest) {
 				return yield* Effect.fail(
@@ -131,11 +143,11 @@ export const createLegacyLatestPriceHandler =
 
 			const priceFeedIds = yield* resolvePriceFeedIds(requestedFeeds);
 			const now = yield* Clock.currentTimeMillis;
-			yield* ensureSubscribedAndTrack(priceFeedIds, now);
+			yield* ensureSubscribedAndTrack(priceFeedIds, channel, now);
 
 			const cachedFeeds: CachedPriceFeed[] = [];
 			for (const priceFeedId of priceFeedIds) {
-				cachedFeeds.push(yield* getOrWaitPrice(priceFeedId));
+				cachedFeeds.push(yield* getOrWaitPrice(priceFeedId, channel));
 			}
 
 			return new Response(

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
@@ -1,0 +1,344 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { Duration, Effect, LogLevel, Logger } from "effect";
+import * as v from "valibot";
+import {
+	type PythLazerModuleConfig,
+	PythLazerModuleRouteSchema,
+} from "../../config/pyth-lazer-module-config";
+import { HAS_PRICE_KEY } from "../../constants";
+import { ModuleService } from "../module";
+
+// Maps the symbols getSymbols is asked about to their numeric feed ids.
+const SYMBOL_IDS: Record<string, number> = { "BTC/USD": 1, "ETH/USD": 2 };
+
+const subscribeMock = mock((_request: { priceFeedIds: number[] }) => {});
+const unsubscribeMock = mock((_subscriptionId: number) => {});
+const getSymbolsMock = mock(async ({ query }: { query: string }) =>
+	query in SYMBOL_IDS
+		? [{ symbol: query, pyth_lazer_id: SYMBOL_IDS[query] }]
+		: [],
+);
+
+// The module registers a single message listener at startup; the test captures it
+// to drive stream updates into the price cache.
+let messageListener: ((event: unknown) => void) | undefined;
+
+mock.module("@pythnetwork/pyth-lazer-sdk", () => ({
+	PythLazerClient: {
+		create: async () => ({
+			addMessageListener: (cb: (event: unknown) => void) => {
+				messageListener = cb;
+			},
+			addAllConnectionsDownListener: () => {},
+			subscribe: subscribeMock,
+			unsubscribe: unsubscribeMock,
+			getSymbols: getSymbolsMock,
+		}),
+	},
+}));
+
+// Imported after mock.module so the module under test binds to the mocked SDK.
+const { PythLazerModuleService } = await import("./pyth-lazer");
+
+beforeEach(() => {
+	subscribeMock.mockClear();
+	unsubscribeMock.mockClear();
+	getSymbolsMock.mockClear();
+	messageListener = undefined;
+});
+
+const baseConfig: PythLazerModuleConfig = {
+	name: "pyth",
+	type: "pyth-lazer",
+	priceFeedIds: [
+		{ name: "BTC/USD", id: 1 },
+		{ name: "ETH/USD", id: 2 },
+	],
+	channel: "real_time",
+	maxFeedsPerRequest: 100,
+	pythLazerApiKeyEnvKey: "PYTH_LAZER_API_KEY",
+	pythLazerApiKey: "test-api-key",
+	priceFeedsCleanupTtl: Duration.hours(1),
+	priceFeedsCleanupInterval: Duration.seconds(30),
+};
+
+const makeConfig = (
+	overrides: Partial<PythLazerModuleConfig>,
+): PythLazerModuleConfig => ({ ...baseConfig, ...overrides });
+
+const latestPriceRoute = v.parse(PythLazerModuleRouteSchema, {
+	type: "pyth-lazer",
+	moduleName: "pyth",
+	path: "/v1/latest_price",
+	method: ["POST"],
+});
+
+const pathRoute = v.parse(PythLazerModuleRouteSchema, {
+	type: "pyth-lazer",
+	moduleName: "pyth",
+	path: "/price/:symbols",
+	method: ["GET"],
+	fetchFromModule: "{:symbols}",
+});
+
+const TIMESTAMP_US = "1700000000000000";
+
+const feed = (priceFeedId: number, price = "9650000000000") => ({
+	priceFeedId,
+	price,
+	exponent: -8,
+	bestBidPrice: "9649000000000",
+	bestAskPrice: "9651000000000",
+	emaPrice: "9648000000000",
+	feedUpdateTimestamp: 1_700_000_000_000_000,
+	marketSession: "regular",
+});
+
+const driveFrame = (
+	priceFeeds: ReturnType<typeof feed>[],
+	timestampUs = TIMESTAMP_US,
+) => {
+	if (!messageListener) {
+		throw new Error("message listener was never registered");
+	}
+	messageListener({
+		type: "json",
+		value: {
+			type: "streamUpdated",
+			parsed: { timestampUs, priceFeeds },
+		},
+	});
+};
+
+// Polls until the subscribe daemon has issued a subscribe frame for each id, proving
+// the module marked them subscribed (so a driven frame will land in the cache).
+const waitForSubscribe = (priceFeedIds: number[]) =>
+	Effect.gen(function* () {
+		for (let attempt = 0; attempt < 100; attempt++) {
+			const subscribed = priceFeedIds.every((id) =>
+				subscribeMock.mock.calls.some((call) =>
+					call[0]?.priceFeedIds?.includes(id),
+				),
+			);
+			if (subscribed) return;
+			yield* Effect.sleep(Duration.millis(5));
+		}
+		throw new Error(`subscribe never issued for ${priceFeedIds}`);
+	});
+
+const latestPriceBody = (feeds: {
+	priceFeedIds?: number[];
+	priceFeedSymbols?: string[];
+}) =>
+	JSON.stringify({
+		channel: "real_time",
+		formats: [],
+		jsonBinaryEncoding: "base64",
+		parsed: true,
+		properties: ["price", "exponent", "feedUpdateTimestamp"],
+		...feeds,
+	});
+
+// Runs a program against a fresh module instance with logs silenced.
+const run = <A, E>(
+	config: PythLazerModuleConfig,
+	program: (svc: typeof ModuleService.Service) => Effect.Effect<A, E, never>,
+) =>
+	Effect.runPromise(
+		Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			return yield* program(svc);
+		}).pipe(
+			Effect.provide(PythLazerModuleService(config)),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		),
+	);
+
+describe("PythLazerModuleService latest_price surface (POST body)", () => {
+	it("returns the parsed shape keyed by request order for numeric ids", async () => {
+		const response = await run(baseConfig, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				yield* waitForSubscribe([1, 2]);
+				driveFrame([feed(1, "111"), feed(2, "222")]);
+				return yield* svc.handleRequest(
+					latestPriceRoute,
+					{},
+					new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+					latestPriceBody({ priceFeedIds: [1, 2] }),
+				);
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			parsed: {
+				timestampUs: string;
+				priceFeeds: { priceFeedId: number; price: string }[];
+			};
+		};
+		expect(body.parsed.timestampUs).toBe(TIMESTAMP_US);
+		expect(body.parsed.priceFeeds.map((f) => f.priceFeedId)).toEqual([1, 2]);
+		expect(body.parsed.priceFeeds[0].price).toBe("111");
+		// The internal partial-response marker must never leak into the parsed shape.
+		expect(JSON.stringify(body)).not.toContain(HAS_PRICE_KEY);
+	});
+
+	it("preserves request order even when it differs from subscription order", async () => {
+		const response = await run(baseConfig, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				yield* waitForSubscribe([1, 2]);
+				driveFrame([feed(1, "111"), feed(2, "222")]);
+				return yield* svc.handleRequest(
+					latestPriceRoute,
+					{},
+					new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+					latestPriceBody({ priceFeedIds: [2, 1] }),
+				);
+			}),
+		);
+
+		const body = (await response.json()) as {
+			parsed: { priceFeeds: { priceFeedId: number }[] };
+		};
+		expect(body.parsed.priceFeeds.map((f) => f.priceFeedId)).toEqual([2, 1]);
+	});
+
+	it("derives timestampUs from requested feeds only", async () => {
+		const response = await run(baseConfig, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				yield* waitForSubscribe([1]);
+				driveFrame([feed(1, "111")], "100");
+				driveFrame([feed(999, "999")], "999");
+				return yield* svc.handleRequest(
+					latestPriceRoute,
+					{},
+					new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+					latestPriceBody({ priceFeedIds: [1] }),
+				);
+			}),
+		);
+
+		const body = (await response.json()) as {
+			parsed: { timestampUs: string };
+		};
+		expect(body.parsed.timestampUs).toBe("100");
+	});
+
+	it("resolves priceFeedSymbols through getSymbols", async () => {
+		const response = await run(baseConfig, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				yield* waitForSubscribe([1]);
+				driveFrame([feed(1, "111")]);
+				return yield* svc.handleRequest(
+					latestPriceRoute,
+					{},
+					new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+					latestPriceBody({ priceFeedSymbols: ["BTC/USD"] }),
+				);
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(getSymbolsMock).toHaveBeenCalledWith({ query: "BTC/USD" });
+		const body = (await response.json()) as {
+			parsed: { priceFeeds: { priceFeedId: number }[] };
+		};
+		expect(body.parsed.priceFeeds.map((f) => f.priceFeedId)).toEqual([1]);
+	});
+
+	it("rejects a body with neither priceFeedIds nor priceFeedSymbols", async () => {
+		const response = await run(baseConfig, (svc) =>
+			svc.handleRequest(
+				latestPriceRoute,
+				{},
+				new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+				JSON.stringify({ channel: "real_time" }),
+			),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects more feeds than maxFeedsPerRequest", async () => {
+		const response = await run(makeConfig({ maxFeedsPerRequest: 2 }), (svc) =>
+			svc.handleRequest(
+				latestPriceRoute,
+				{},
+				new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+				latestPriceBody({ priceFeedIds: [1, 2, 3] }),
+			),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects a malformed JSON body", async () => {
+		const response = await run(baseConfig, (svc) =>
+			svc.handleRequest(
+				latestPriceRoute,
+				{},
+				new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+				"{ not json",
+			),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("rejects a body with incorrectly typed feed ids", async () => {
+		const response = await run(baseConfig, (svc) =>
+			svc.handleRequest(
+				latestPriceRoute,
+				{},
+				new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+				JSON.stringify({ priceFeedIds: ["1"] }),
+			),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("fails the whole request when a requested feed never produces a price", async () => {
+		const response = await run(makeConfig({ priceFeedIds: [] }), (svc) =>
+			svc.handleRequest(
+				latestPriceRoute,
+				{},
+				new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+				latestPriceBody({ priceFeedIds: [99] }),
+			),
+		);
+		// All-or-fail: no partial array, the cache wait times out and surfaces an error.
+		expect(response.status).toBeGreaterThanOrEqual(400);
+	}, 10_000);
+});
+
+describe("PythLazerModuleService path surface (GET array)", () => {
+	it("returns a per-feed array tagged with the price marker", async () => {
+		const response = await run(baseConfig, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				yield* waitForSubscribe([1]);
+				driveFrame([feed(1, "111")]);
+				return yield* svc.handleRequest(
+					pathRoute,
+					{ symbols: "1" },
+					new Request("http://proxy.local/price/1", { method: "GET" }),
+					"",
+				);
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			priceFeedId: number;
+			symbol: string;
+			price: string;
+			[HAS_PRICE_KEY]: boolean;
+		}[];
+		expect(Array.isArray(body)).toBe(true);
+		expect(body[0].priceFeedId).toBe(1);
+		expect(body[0].symbol).toBe("1");
+		expect(body[0].price).toBe("111");
+		expect(body[0][HAS_PRICE_KEY]).toBe(true);
+	});
+});

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
@@ -89,13 +89,19 @@ const feed = (priceFeedId: number, price = "9650000000000") => ({
 	exponent: -8,
 	bestBidPrice: "9649000000000",
 	bestAskPrice: "9651000000000",
+	confidence: 12345,
 	emaPrice: "9648000000000",
+	emaConfidence: 6789,
 	feedUpdateTimestamp: 1_700_000_000_000_000,
+	fundingRate: 12,
+	fundingRateInterval: 3600,
+	fundingTimestamp: 1_700_000_000,
 	marketSession: "regular",
+	publisherCount: 7,
 });
 
 const driveFrame = (
-	priceFeeds: ReturnType<typeof feed>[],
+	priceFeeds: Record<string, unknown>[],
 	timestampUs = TIMESTAMP_US,
 ) => {
 	if (!messageListener) {
@@ -174,14 +180,87 @@ describe("PythLazerModuleService latest_price surface (POST body)", () => {
 		const body = (await response.json()) as {
 			parsed: {
 				timestampUs: string;
-				priceFeeds: { priceFeedId: number; price: string }[];
+				priceFeeds: {
+					priceFeedId: number;
+					price: string;
+					bestAskPrice: string;
+					bestBidPrice: string;
+					confidence: number;
+					emaConfidence: number;
+					emaPrice: string;
+					exponent: number;
+					feedUpdateTimestamp: number;
+					fundingRate: number;
+					fundingRateInterval: number;
+					fundingTimestamp: number;
+					marketSession: string;
+					publisherCount: number;
+				}[];
 			};
 		};
 		expect(body.parsed.timestampUs).toBe(TIMESTAMP_US);
 		expect(body.parsed.priceFeeds.map((f) => f.priceFeedId)).toEqual([1, 2]);
 		expect(body.parsed.priceFeeds[0].price).toBe("111");
+		expect(body.parsed.priceFeeds[0]).toMatchObject({
+			bestAskPrice: "9651000000000",
+			bestBidPrice: "9649000000000",
+			confidence: 12345,
+			emaConfidence: 6789,
+			emaPrice: "9648000000000",
+			exponent: -8,
+			feedUpdateTimestamp: 1_700_000_000_000_000,
+			fundingRate: 12,
+			fundingRateInterval: 3600,
+			fundingTimestamp: 1_700_000_000,
+			marketSession: "regular",
+			publisherCount: 7,
+		});
 		// The internal partial-response marker must never leak into the parsed shape.
 		expect(JSON.stringify(body)).not.toContain(HAS_PRICE_KEY);
+	});
+
+	it("emits the full Pyth Pro compatibility field set with nulls for unavailable values", async () => {
+		const response = await run(baseConfig, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				yield* waitForSubscribe([1]);
+				driveFrame([
+					{
+						priceFeedId: 1,
+						price: "111",
+						exponent: -8,
+						feedUpdateTimestamp: 1_700_000_000_000_000,
+					},
+				]);
+				return yield* svc.handleRequest(
+					latestPriceRoute,
+					{},
+					new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+					latestPriceBody({ priceFeedIds: [1] }),
+				);
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			parsed: { priceFeeds: Record<string, unknown>[] };
+		};
+		expect(body.parsed.priceFeeds[0]).toEqual({
+			priceFeedId: 1,
+			exponent: -8,
+			feedUpdateTimestamp: 1_700_000_000_000_000,
+			bestAskPrice: null,
+			bestBidPrice: null,
+			confidence: null,
+			emaConfidence: null,
+			emaPrice: null,
+			fundingRate: null,
+			fundingRateInterval: null,
+			fundingTimestamp: null,
+			marketSession: null,
+			price: "111",
+			publisherCount: null,
+		});
 	});
 
 	it("preserves request order even when it differs from subscription order", async () => {

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
-import { Duration, Effect, LogLevel, Logger } from "effect";
+import { Duration, Effect, Fiber, LogLevel, Logger } from "effect";
 import * as v from "valibot";
 import {
 	type PythLazerModuleConfig,
@@ -11,7 +11,13 @@ import { ModuleService } from "../module";
 // Maps the symbols getSymbols is asked about to their numeric feed ids.
 const SYMBOL_IDS: Record<string, number> = { "BTC/USD": 1, "ETH/USD": 2 };
 
-const subscribeMock = mock((_request: { priceFeedIds: number[] }) => {});
+const subscribeMock = mock(
+	(_request: {
+		priceFeedIds: number[];
+		channel: string;
+		subscriptionId: number;
+	}) => {},
+);
 const unsubscribeMock = mock((_subscriptionId: number) => {});
 const getSymbolsMock = mock(async ({ query }: { query: string }) =>
 	query in SYMBOL_IDS
@@ -22,18 +28,28 @@ const getSymbolsMock = mock(async ({ query }: { query: string }) =>
 // The module registers a single message listener at startup; the test captures it
 // to drive stream updates into the price cache.
 let messageListener: ((event: unknown) => void) | undefined;
+// The module passes onWebSocketPoolError into create; captured here to simulate a
+// pool error that names a specific feed.
+let poolErrorHandler: ((error: unknown) => void) | undefined;
 
 mock.module("@pythnetwork/pyth-lazer-sdk", () => ({
 	PythLazerClient: {
-		create: async () => ({
-			addMessageListener: (cb: (event: unknown) => void) => {
-				messageListener = cb;
-			},
-			addAllConnectionsDownListener: () => {},
-			subscribe: subscribeMock,
-			unsubscribe: unsubscribeMock,
-			getSymbols: getSymbolsMock,
-		}),
+		create: async (config: {
+			webSocketPoolConfig?: {
+				onWebSocketPoolError?: (error: unknown) => void;
+			};
+		}) => {
+			poolErrorHandler = config.webSocketPoolConfig?.onWebSocketPoolError;
+			return {
+				addMessageListener: (cb: (event: unknown) => void) => {
+					messageListener = cb;
+				},
+				addAllConnectionsDownListener: () => {},
+				subscribe: subscribeMock,
+				unsubscribe: unsubscribeMock,
+				getSymbols: getSymbolsMock,
+			};
+		},
 	},
 }));
 
@@ -45,6 +61,7 @@ beforeEach(() => {
 	unsubscribeMock.mockClear();
 	getSymbolsMock.mockClear();
 	messageListener = undefined;
+	poolErrorHandler = undefined;
 });
 
 const baseConfig: PythLazerModuleConfig = {
@@ -100,41 +117,72 @@ const feed = (priceFeedId: number, price = "9650000000000") => ({
 	publisherCount: 7,
 });
 
+// Drives one streamUpdated frame per feed, each on the subscriptionId the module
+// assigned for (feed, channel). Mirrors the SDK: a subscription covers one feed and
+// emits its own frame, so the frame's subscriptionId is what routes it to a channel.
 const driveFrame = (
-	priceFeeds: Record<string, unknown>[],
+	priceFeeds: (Record<string, unknown> & { priceFeedId: number })[],
 	timestampUs = TIMESTAMP_US,
+	channel = "real_time",
 ) => {
 	if (!messageListener) {
 		throw new Error("message listener was never registered");
 	}
-	messageListener({
-		type: "json",
-		value: {
-			type: "streamUpdated",
-			parsed: { timestampUs, priceFeeds },
-		},
-	});
+	for (const priceFeed of priceFeeds) {
+		const subscription = subscribeMock.mock.calls.find(
+			([req]) =>
+				req?.channel === channel &&
+				req?.priceFeedIds?.includes(priceFeed.priceFeedId),
+		);
+		if (!subscription) {
+			throw new Error(
+				`no subscription for feed ${priceFeed.priceFeedId} on ${channel}`,
+			);
+		}
+		messageListener({
+			type: "json",
+			value: {
+				type: "streamUpdated",
+				subscriptionId: subscription[0].subscriptionId,
+				parsed: { timestampUs, priceFeeds: [priceFeed] },
+			},
+		});
+	}
 };
 
-// Polls until the subscribe daemon has issued a subscribe frame for each id, proving
-// the module marked them subscribed (so a driven frame will land in the cache).
-const waitForSubscribe = (priceFeedIds: number[]) =>
+// Polls until the subscribe daemon has issued a subscribe frame for each id on the
+// given channel, proving the module marked them subscribed (so a driven frame lands).
+const waitForSubscribe = (priceFeedIds: number[], channel = "real_time") =>
 	Effect.gen(function* () {
 		for (let attempt = 0; attempt < 100; attempt++) {
 			const subscribed = priceFeedIds.every((id) =>
-				subscribeMock.mock.calls.some((call) =>
-					call[0]?.priceFeedIds?.includes(id),
+				subscribeMock.mock.calls.some(
+					([req]) =>
+						req?.channel === channel && req?.priceFeedIds?.includes(id),
 				),
 			);
 			if (subscribed) return;
 			yield* Effect.sleep(Duration.millis(5));
 		}
-		throw new Error(`subscribe never issued for ${priceFeedIds}`);
+		throw new Error(`subscribe never issued for ${priceFeedIds} on ${channel}`);
+	});
+
+// Polls until the fiber has parked (suspended on the price wait), so a pool error
+// fired next has a registered waiter to reject rather than racing waiter creation.
+const waitUntilSuspended = <A, E>(fiber: Fiber.RuntimeFiber<A, E>) =>
+	Effect.gen(function* () {
+		for (let attempt = 0; attempt < 100; attempt++) {
+			const status = yield* Fiber.status(fiber);
+			if (status._tag === "Suspended") return;
+			yield* Effect.sleep(Duration.millis(5));
+		}
+		throw new Error("fiber never suspended");
 	});
 
 const latestPriceBody = (feeds: {
 	priceFeedIds?: number[];
 	priceFeedSymbols?: string[];
+	channel?: string;
 }) =>
 	JSON.stringify({
 		channel: "real_time",
@@ -288,9 +336,11 @@ describe("PythLazerModuleService latest_price surface (POST body)", () => {
 		const response = await run(baseConfig, (svc) =>
 			Effect.gen(function* () {
 				yield* svc.start();
-				yield* waitForSubscribe([1]);
+				yield* waitForSubscribe([1, 2]);
 				driveFrame([feed(1, "111")], "100");
-				driveFrame([feed(999, "999")], "999");
+				// A later, higher-timestamp update on another feed must not bleed into
+				// the requested feed's timestampUs.
+				driveFrame([feed(2, "999")], "999");
 				return yield* svc.handleRequest(
 					latestPriceRoute,
 					{},
@@ -420,4 +470,205 @@ describe("PythLazerModuleService path surface (GET array)", () => {
 		expect(body[0].price).toBe("111");
 		expect(body[0][HAS_PRICE_KEY]).toBe(true);
 	});
+
+	it("uses the configured channel for the path surface", async () => {
+		const config = makeConfig({
+			channel: "fixed_rate@50ms",
+			priceFeedIds: [{ name: "BTC/USD", id: 1 }],
+		});
+		const response = await run(config, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				yield* waitForSubscribe([1], "fixed_rate@50ms");
+				driveFrame([feed(1, "111")], TIMESTAMP_US, "fixed_rate@50ms");
+				return yield* svc.handleRequest(
+					pathRoute,
+					{ symbols: "1" },
+					new Request("http://proxy.local/price/1", { method: "GET" }),
+					"",
+				);
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { price: string }[];
+		expect(body[0].price).toBe("111");
+		// The path surface never subscribes on anything but the configured channel.
+		expect(
+			subscribeMock.mock.calls.every(
+				([req]) => req.channel === "fixed_rate@50ms",
+			),
+		).toBe(true);
+	});
+});
+
+describe("PythLazerModuleService channel differentiation", () => {
+	it("subscribes to and serves the channel named in the request body", async () => {
+		const response = await run(baseConfig, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				// The requested channel is not seeded at startup, so the request itself
+				// drives the subscription: fork it, wait for the subscribe, then feed it.
+				const fiber = yield* Effect.fork(
+					svc.handleRequest(
+						latestPriceRoute,
+						{},
+						new Request("http://proxy.local/v1/latest_price", {
+							method: "POST",
+						}),
+						latestPriceBody({
+							priceFeedIds: [1],
+							channel: "fixed_rate@200ms",
+						}),
+					),
+				);
+				yield* waitForSubscribe([1], "fixed_rate@200ms");
+				driveFrame([feed(1, "200ms")], TIMESTAMP_US, "fixed_rate@200ms");
+				return yield* Fiber.join(fiber);
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		// The subscribe for the requested channel actually went out.
+		expect(
+			subscribeMock.mock.calls.find(
+				([req]) =>
+					req.channel === "fixed_rate@200ms" && req.priceFeedIds.includes(1),
+			),
+		).toBeDefined();
+		const body = (await response.json()) as {
+			parsed: { priceFeeds: { price: string }[] };
+		};
+		expect(body.parsed.priceFeeds[0].price).toBe("200ms");
+	});
+
+	it("does not serve a real_time price for a fixed_rate request", async () => {
+		const response = await run(baseConfig, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				// Seed the same feed on the default real_time channel first.
+				yield* waitForSubscribe([1], "real_time");
+				driveFrame([feed(1, "realtime")], TIMESTAMP_US, "real_time");
+
+				// A fixed_rate request must ignore the real_time cache and wait for a
+				// fixed_rate frame instead.
+				const fiber = yield* Effect.fork(
+					svc.handleRequest(
+						latestPriceRoute,
+						{},
+						new Request("http://proxy.local/v1/latest_price", {
+							method: "POST",
+						}),
+						latestPriceBody({
+							priceFeedIds: [1],
+							channel: "fixed_rate@200ms",
+						}),
+					),
+				);
+				yield* waitForSubscribe([1], "fixed_rate@200ms");
+				driveFrame([feed(1, "fixedrate")], TIMESTAMP_US, "fixed_rate@200ms");
+				return yield* Fiber.join(fiber);
+			}),
+		);
+
+		const body = (await response.json()) as {
+			parsed: { priceFeeds: { price: string }[] };
+		};
+		expect(body.parsed.priceFeeds[0].price).toBe("fixedrate");
+	});
+
+	it("falls back to the configured channel when the body omits one", async () => {
+		const config = makeConfig({
+			channel: "fixed_rate@1000ms",
+			priceFeedIds: [{ name: "BTC/USD", id: 1 }],
+		});
+		const response = await run(config, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				yield* waitForSubscribe([1], "fixed_rate@1000ms");
+				driveFrame([feed(1, "111")], TIMESTAMP_US, "fixed_rate@1000ms");
+				return yield* svc.handleRequest(
+					latestPriceRoute,
+					{},
+					new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+					JSON.stringify({ priceFeedIds: [1] }),
+				);
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		// No subscription leaked onto a different channel than the configured default.
+		expect(
+			subscribeMock.mock.calls.every(
+				([req]) => req.channel === "fixed_rate@1000ms",
+			),
+		).toBe(true);
+	});
+
+	it("rejects a body with an invalid channel", async () => {
+		const response = await run(baseConfig, (svc) =>
+			svc.handleRequest(
+				latestPriceRoute,
+				{},
+				new Request("http://proxy.local/v1/latest_price", { method: "POST" }),
+				JSON.stringify({ priceFeedIds: [1], channel: "fixed_rate@9999ms" }),
+			),
+		);
+		expect(response.status).toBe(400);
+	});
+
+	it("fails every channel a feed is subscribed on when a pool error names it", async () => {
+		const responses = await run(baseConfig, (svc) =>
+			Effect.gen(function* () {
+				yield* svc.start();
+				// Feed 1 is pending on two channels at once: real_time (seeded at
+				// startup) and fixed_rate@200ms (driven by the second request). Neither
+				// has a price, so both requests park on the price wait.
+				const realTime = yield* Effect.fork(
+					svc.handleRequest(
+						latestPriceRoute,
+						{},
+						new Request("http://proxy.local/v1/latest_price", {
+							method: "POST",
+						}),
+						latestPriceBody({ priceFeedIds: [1], channel: "real_time" }),
+					),
+				);
+				const fixedRate = yield* Effect.fork(
+					svc.handleRequest(
+						latestPriceRoute,
+						{},
+						new Request("http://proxy.local/v1/latest_price", {
+							method: "POST",
+						}),
+						latestPriceBody({ priceFeedIds: [1], channel: "fixed_rate@200ms" }),
+					),
+				);
+				// Both (feed, channel) subscriptions exist (so the fan-out finds them)
+				// and both requests have parked (so there is a waiter to reject).
+				yield* waitForSubscribe([1], "real_time");
+				yield* waitForSubscribe([1], "fixed_rate@200ms");
+				yield* waitUntilSuspended(realTime);
+				yield* waitUntilSuspended(fixedRate);
+
+				if (!poolErrorHandler) {
+					throw new Error("pool error handler was never registered");
+				}
+				poolErrorHandler("Feeds are not stable: 1");
+
+				return {
+					realTime: yield* Fiber.join(realTime),
+					fixedRate: yield* Fiber.join(fixedRate),
+				};
+			}),
+		);
+
+		// Both channels' waiters are failed by the pool error, not by the wait timeout.
+		for (const response of [responses.realTime, responses.fixedRate]) {
+			expect(response.status).toBe(500);
+			const body = await response.text();
+			expect(body).toContain("Feeds are not stable: 1");
+			expect(body).not.toContain("Timed out");
+		}
+	}, 10_000);
 });

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -27,15 +27,14 @@ import {
 	extractPriceFeedIdFromErrorMessage,
 } from "./errors";
 import { getPriceIdBySymbol } from "./get-symbol-price-id";
+import { createLegacyLatestPriceHandler } from "./legacy-latest-price/latest-price";
+import type { CachedPriceFeed, PriceFeedId, PriceFeedSymbol } from "./types";
 
 export class FailedToCreateLazerClientError extends Data.TaggedError(
 	"FailedToCreateLazerClientError",
 )<{ error: string | unknown }> {
 	message = `Failed to create Pyth Lazer client: ${this.error}`;
 }
-
-type PriceFeedId = number;
-type PriceFeedSymbol = string;
 
 interface PriceFeedWithSymbol extends ParsedFeedPayload {
 	symbol?: string;
@@ -50,7 +49,7 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 			const runtime = yield* Effect.runtime();
 			const priceCache = yield* createPriceCache<
 				PriceFeedId,
-				ParsedFeedPayload
+				CachedPriceFeed
 			>();
 			// The timestamp of the last request to the price feed
 			const lastRequestToPriceFeed = MutableHashMap.empty<
@@ -169,7 +168,10 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 							continue;
 						}
 
-						yield* priceCache.setPrice(priceFeed.priceFeedId, priceFeed);
+						yield* priceCache.setPrice(priceFeed.priceFeedId, {
+							priceFeed,
+							timestampUs: message.timestampUs,
+						});
 					}
 				});
 
@@ -264,42 +266,14 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 					});
 				}).pipe(Effect.annotateLogs("_name", "pyth-lazer"));
 
-			const handleRequest = (
-				route: Route,
-				params: Record<string, string>,
-				request: Request,
-			) =>
+			// Resolve a mixed list of numeric ids and symbols to price feed ids,
+			// caching symbol lookups. Shared by both request surfaces.
+			const resolvePriceFeedIds = (rawTokens: string[]) =>
 				Effect.gen(function* () {
-					if (route.type !== "pyth-lazer") {
-						return yield* Effect.fail(
-							new FailedToHandleRequest({
-								msg: "Route is not a Pyth Lazer module",
-							}),
-						);
-					}
-
-					const priceFeedIdsRaw = replaceParams(
-						route.fetchFromModule,
-						params,
-					).split(",");
-
-					if (priceFeedIdsRaw.length > config.maxFeedsPerRequest) {
-						return yield* Effect.succeed(
-							createErrorResponse(
-								new FailedToHandlePythLazerRequestError({
-									error: `Too many price feed IDs, max is ${config.maxFeedsPerRequest} but got ${priceFeedIdsRaw.length}`,
-								}),
-								400,
-							),
-						);
-					}
-
 					const priceFeedIds: number[] = [];
 
-					// Normalize the ids or symbols to price feed ids
-					for (const symbolOrId of priceFeedIdsRaw) {
+					for (const symbolOrId of rawTokens) {
 						if (Number.isNaN(Number(symbolOrId))) {
-							// Let's check if the symbol exists otherwise
 							const cachedSymbolToPriceFeedId = MutableHashMap.get(
 								symbolsToId,
 								symbolOrId,
@@ -322,10 +296,13 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 						}
 					}
 
-					const prices: PriceFeedWithSymbol[] = [];
-					const now = yield* Clock.currentTimeMillis;
+					return priceFeedIds;
+				});
 
-					// First subscribe to all the symbols that we have not subscribed to yet
+			// Subscribe to feeds not requested before, then mark each as freshly requested.
+			// Subscribing up front keeps the subscriptions in-flight before we wait on prices.
+			const ensureSubscribedAndTrack = (priceFeedIds: number[], now: number) =>
+				Effect.gen(function* () {
 					for (const priceFeedId of priceFeedIds) {
 						if (!MutableHashMap.has(lastRequestToPriceFeed, priceFeedId)) {
 							yield* newPriceFeedRequests.offer(priceFeedId);
@@ -333,8 +310,33 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 
 						MutableHashMap.set(lastRequestToPriceFeed, priceFeedId, now);
 					}
+				});
 
-					// Now since the subscriptions are in-flight, we can fetch the prices concurrently.
+			// Path surface (e.g. GET /price/:symbols): one array entry per requested feed,
+			// each tagged with HAS_PRICE_KEY. A feed without a price keeps its slot (so callers
+			// reading by index stay aligned) and is flagged false rather than failing.
+			const handlePathRequest = (
+				fetchFromModule: string,
+				params: Record<string, string>,
+			) =>
+				Effect.gen(function* () {
+					const priceFeedIdsRaw = replaceParams(fetchFromModule, params).split(
+						",",
+					);
+
+					if (priceFeedIdsRaw.length > config.maxFeedsPerRequest) {
+						return createErrorResponse(
+							new FailedToHandlePythLazerRequestError({
+								error: `Too many price feed IDs, max is ${config.maxFeedsPerRequest} but got ${priceFeedIdsRaw.length}`,
+							}),
+							400,
+						);
+					}
+
+					const priceFeedIds = yield* resolvePriceFeedIds(priceFeedIdsRaw);
+					const now = yield* Clock.currentTimeMillis;
+					yield* ensureSubscribedAndTrack(priceFeedIds, now);
+
 					const results = yield* Effect.forEach(
 						priceFeedIds,
 						(priceFeedId) =>
@@ -342,6 +344,7 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 						{ concurrency: "unbounded" },
 					);
 
+					const prices: PriceFeedWithSymbol[] = [];
 					for (let i = 0; i < priceFeedIds.length; i++) {
 						const priceFeedId = priceFeedIds[i];
 						const price = results[i];
@@ -354,16 +357,43 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 							});
 						} else {
 							prices.push({
-								...price.right,
+								...price.right.priceFeed,
 								symbol: priceFeedIdsRaw.at(i),
 								[HAS_PRICE_KEY]: true,
 							});
 						}
 					}
 
-					return yield* Effect.succeed(
-						new Response(JSON.stringify(prices), { status: 200 }),
-					);
+					return new Response(JSON.stringify(prices), { status: 200 });
+				});
+
+			const handleLegacyLatestPriceRequest = createLegacyLatestPriceHandler({
+				config,
+				ensureSubscribedAndTrack,
+				getOrWaitPrice: priceCache.getOrWaitPrice,
+				resolvePriceFeedIds,
+			});
+
+			const handleRequest = (
+				route: Route,
+				params: Record<string, string>,
+				request: Request,
+				body?: string,
+			) =>
+				Effect.gen(function* () {
+					if (route.type !== "pyth-lazer") {
+						return yield* Effect.fail(
+							new FailedToHandleRequest({
+								msg: "Route is not a Pyth Lazer module",
+							}),
+						);
+					}
+
+					if (route.fetchFromModule !== undefined) {
+						return yield* handlePathRequest(route.fetchFromModule, params);
+					}
+
+					return yield* handleLegacyLatestPriceRequest(body);
 				}).pipe(
 					Effect.withSpan("handlePythLazerRequest"),
 					Effect.catchAll((error) => {

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -15,7 +15,10 @@ import {
 	Runtime,
 } from "effect";
 import type { Route } from "../../config/config-parser";
-import type { PythLazerModuleConfig } from "../../config/pyth-lazer-module-config";
+import type {
+	PythLazerChannel,
+	PythLazerModuleConfig,
+} from "../../config/pyth-lazer-module-config";
 import { HAS_PRICE_KEY } from "../../constants";
 import { createErrorResponse } from "../../controllers/create-error-response";
 import { forkIdleCleanup } from "../../utils/idle-cleanup";
@@ -28,7 +31,13 @@ import {
 } from "./errors";
 import { getPriceIdBySymbol } from "./get-symbol-price-id";
 import { createLegacyLatestPriceHandler } from "./legacy-latest-price/latest-price";
-import type { CachedPriceFeed, PriceFeedId, PriceFeedSymbol } from "./types";
+import {
+	type CachedPriceFeed,
+	type FeedChannelKey,
+	type PriceFeedId,
+	type PriceFeedSymbol,
+	makeFeedChannelKey,
+} from "./types";
 
 export class FailedToCreateLazerClientError extends Data.TaggedError(
 	"FailedToCreateLazerClientError",
@@ -48,21 +57,29 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 			yield* Effect.logInfo("Initializing Pyth Lazer module");
 			const runtime = yield* Effect.runtime();
 			const priceCache = yield* createPriceCache<
-				PriceFeedId,
+				FeedChannelKey,
 				CachedPriceFeed
 			>();
-			// The timestamp of the last request to the price feed
+			// The timestamp of the last request per (feed, channel)
 			const lastRequestToPriceFeed = MutableHashMap.empty<
-				PriceFeedId,
+				FeedChannelKey,
 				number
 			>();
-			const newPriceFeedRequests = yield* Queue.unbounded<PriceFeedId>();
-			// price feed id -> subscription id
-			const subscriptions = MutableHashMap.empty<PriceFeedId, number>();
+			const newPriceFeedRequests = yield* Queue.unbounded<{
+				priceFeedId: PriceFeedId;
+				channel: PythLazerChannel;
+			}>();
+			// (feed, channel) -> subscription id
+			const subscriptions = MutableHashMap.empty<FeedChannelKey, number>();
+			// subscription id -> channel, so inbound frames route back to their channel
+			const subscriptionChannel = MutableHashMap.empty<
+				number,
+				PythLazerChannel
+			>();
 			const symbolsToId = MutableHashMap.empty<PriceFeedSymbol, PriceFeedId>();
 
 			const getSymbolByPriceFeedId = (priceFeedId: PriceFeedId) => {
-				for (const [symbol, id] of MutableHashMap.fromIterable(symbolsToId)) {
+				for (const [symbol, id] of symbolsToId) {
 					if (id === priceFeedId) {
 						return Option.some(symbol);
 					}
@@ -95,14 +112,18 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 
 								if (Option.isSome(priceFeedId)) {
 									const symbol = getSymbolByPriceFeedId(priceFeedId.value);
+									const message = `(${Option.getOrElse(symbol, () => "Unknown/Symbol")}) ${error}`;
 
-									Runtime.runSync(
-										runtime,
-										priceCache.setPriceToError(
-											priceFeedId.value,
-											`(${Option.getOrElse(symbol, () => "Unknown/Symbol")}) ${error}`,
-										),
-									);
+									// Fail every channel this feed is subscribed on; the error
+									// string only carries the feed id, not the channel.
+									for (const [key] of subscriptions) {
+										if (key.priceFeedId === priceFeedId.value) {
+											Runtime.runSync(
+												runtime,
+												priceCache.setPriceToError(key, message),
+											);
+										}
+									}
 								}
 
 								// For some reason the error is encoded to an empty object, the regular console.error does show the actual error
@@ -147,28 +168,49 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 									});
 								}
 
-								yield* handleStreamUpdatedMessage(message.value.parsed);
+								yield* handleStreamUpdatedMessage(
+									message.value.subscriptionId,
+									message.value.parsed,
+								);
 							}
 						}
 					}),
 				);
 			});
 
-			const handleStreamUpdatedMessage = (message: ParsedPayload) =>
+			const handleStreamUpdatedMessage = (
+				subscriptionId: number,
+				message: ParsedPayload,
+			) =>
 				Effect.gen(function* () {
 					yield* Effect.logTrace(
 						"Received stream updated message from Pyth Lazer client",
 						message,
 					);
 
+					const channel = MutableHashMap.get(
+						subscriptionChannel,
+						subscriptionId,
+					);
+					if (Option.isNone(channel)) {
+						return yield* Effect.logWarning(
+							`Received frame for unknown subscription ${subscriptionId}`,
+						);
+					}
+
 					for (const priceFeed of message.priceFeeds) {
-						// To make sure that we don't set the price for a price feed that we are not subscribed to
-						// otherwise requests may get an outdated price
-						if (!MutableHashMap.has(subscriptions, priceFeed.priceFeedId)) {
+						const key = makeFeedChannelKey(
+							priceFeed.priceFeedId,
+							channel.value,
+						);
+
+						// A subscription carries a single feed; ignore any other feed that
+						// arrives on its frame so a stale value can't land in the cache.
+						if (!MutableHashMap.has(subscriptions, key)) {
 							continue;
 						}
 
-						yield* priceCache.setPrice(priceFeed.priceFeedId, {
+						yield* priceCache.setPrice(key, {
 							priceFeed,
 							timestampUs: message.timestampUs,
 						});
@@ -181,37 +223,43 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 
 					const now = yield* Clock.currentTimeMillis;
 					for (const priceFeed of config.priceFeedIds) {
-						yield* newPriceFeedRequests.offer(priceFeed.id);
+						const key = makeFeedChannelKey(priceFeed.id, config.channel);
+						yield* newPriceFeedRequests.offer({
+							priceFeedId: priceFeed.id,
+							channel: config.channel,
+						});
 						// Add a request timestamp so it is tracked in the cleanup interval
-						MutableHashMap.set(lastRequestToPriceFeed, priceFeed.id, now);
+						MutableHashMap.set(lastRequestToPriceFeed, key, now);
 					}
 
 					yield* Effect.forkDaemon(
 						Effect.gen(function* () {
-							const newPriceFeedId = yield* newPriceFeedRequests.take;
+							const { priceFeedId, channel } = yield* newPriceFeedRequests.take;
+							const key = makeFeedChannelKey(priceFeedId, channel);
 
-							if (MutableHashMap.has(subscriptions, newPriceFeedId)) {
+							if (MutableHashMap.has(subscriptions, key)) {
 								yield* Effect.logDebug(
-									`Price feed ${newPriceFeedId} is already subscribed`,
+									`Price feed ${priceFeedId} is already subscribed on ${channel}`,
 								);
 								return;
 							}
 
 							yield* Effect.logInfo(
-								`Subscribing to price feed ${newPriceFeedId}`,
+								`Subscribing to price feed ${priceFeedId} on ${channel}`,
 							);
 
 							const newSubscriptionId = subscriptionId++;
 
+							MutableHashMap.set(subscriptions, key, newSubscriptionId);
 							MutableHashMap.set(
-								subscriptions,
-								newPriceFeedId,
+								subscriptionChannel,
 								newSubscriptionId,
+								channel,
 							);
 
 							lazerClient.subscribe({
 								type: "subscribe",
-								channel: config.channel,
+								channel,
 								formats: ["solana"],
 								properties: [
 									"bestAskPrice",
@@ -229,7 +277,7 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 									"publisherCount",
 								],
 								subscriptionId: newSubscriptionId,
-								priceFeedIds: [newPriceFeedId],
+								priceFeedIds: [priceFeedId],
 								// Recommended by Pyth case a previously valid feed id becomes invalid (delisting, id changed, etc.)
 								ignoreInvalidFeedIds: true,
 							});
@@ -240,26 +288,37 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 						lastRequest: lastRequestToPriceFeed,
 						ttl: config.priceFeedsCleanupTtl,
 						interval: config.priceFeedsCleanupInterval,
-						onExpire: (priceFeedId) =>
+						onExpire: (key) =>
 							Effect.gen(function* () {
-								yield* Effect.logInfo(`Cleaning up price feed ${priceFeedId}`);
-								yield* priceCache.deletePrice(priceFeedId);
-
-								const subscriptionId = MutableHashMap.get(
-									subscriptions,
-									priceFeedId,
+								const { priceFeedId, channel } = key;
+								yield* Effect.logInfo(
+									`Cleaning up price feed ${priceFeedId} on ${channel}`,
 								);
+								yield* priceCache.deletePrice(key);
+
+								const subscriptionId = MutableHashMap.get(subscriptions, key);
 								if (Option.isSome(subscriptionId)) {
 									lazerClient.unsubscribe(subscriptionId.value);
-									MutableHashMap.remove(subscriptions, priceFeedId);
+									MutableHashMap.remove(subscriptions, key);
+									MutableHashMap.remove(
+										subscriptionChannel,
+										subscriptionId.value,
+									);
 
-									const symbol = getSymbolByPriceFeedId(priceFeedId);
-									if (Option.isSome(symbol)) {
-										MutableHashMap.remove(symbolsToId, symbol.value);
+									// Drop the symbol mapping only once no channel for this feed
+									// remains; symbol -> id resolution is shared across channels.
+									const feedStillSubscribed = Array.from(subscriptions).some(
+										([remaining]) => remaining.priceFeedId === priceFeedId,
+									);
+									if (!feedStillSubscribed) {
+										const symbol = getSymbolByPriceFeedId(priceFeedId);
+										if (Option.isSome(symbol)) {
+											MutableHashMap.remove(symbolsToId, symbol.value);
+										}
 									}
 
 									yield* Effect.logInfo(
-										`Unsubscribed from price feed ${priceFeedId}`,
+										`Unsubscribed from price feed ${priceFeedId} on ${channel}`,
 									);
 								}
 							}),
@@ -299,16 +358,22 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 					return priceFeedIds;
 				});
 
-			// Subscribe to feeds not requested before, then mark each as freshly requested.
-			// Subscribing up front keeps the subscriptions in-flight before we wait on prices.
-			const ensureSubscribedAndTrack = (priceFeedIds: number[], now: number) =>
+			// Subscribe to feeds not requested before on this channel, then mark each
+			// as freshly requested. Subscribing up front keeps the subscriptions
+			// in-flight before we wait on prices.
+			const ensureSubscribedAndTrack = (
+				priceFeedIds: number[],
+				channel: PythLazerChannel,
+				now: number,
+			) =>
 				Effect.gen(function* () {
 					for (const priceFeedId of priceFeedIds) {
-						if (!MutableHashMap.has(lastRequestToPriceFeed, priceFeedId)) {
-							yield* newPriceFeedRequests.offer(priceFeedId);
+						const key = makeFeedChannelKey(priceFeedId, channel);
+						if (!MutableHashMap.has(lastRequestToPriceFeed, key)) {
+							yield* newPriceFeedRequests.offer({ priceFeedId, channel });
 						}
 
-						MutableHashMap.set(lastRequestToPriceFeed, priceFeedId, now);
+						MutableHashMap.set(lastRequestToPriceFeed, key, now);
 					}
 				});
 
@@ -335,12 +400,16 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 
 					const priceFeedIds = yield* resolvePriceFeedIds(priceFeedIdsRaw);
 					const now = yield* Clock.currentTimeMillis;
-					yield* ensureSubscribedAndTrack(priceFeedIds, now);
+					yield* ensureSubscribedAndTrack(priceFeedIds, config.channel, now);
 
 					const results = yield* Effect.forEach(
 						priceFeedIds,
 						(priceFeedId) =>
-							Effect.either(priceCache.getOrWaitPrice(priceFeedId)),
+							Effect.either(
+								priceCache.getOrWaitPrice(
+									makeFeedChannelKey(priceFeedId, config.channel),
+								),
+							),
 						{ concurrency: "unbounded" },
 					);
 
@@ -370,7 +439,8 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 			const handleLegacyLatestPriceRequest = createLegacyLatestPriceHandler({
 				config,
 				ensureSubscribedAndTrack,
-				getOrWaitPrice: priceCache.getOrWaitPrice,
+				getOrWaitPrice: (priceFeedId, channel) =>
+					priceCache.getOrWaitPrice(makeFeedChannelKey(priceFeedId, channel)),
 				resolvePriceFeedIds,
 			});
 

--- a/workspace/data-proxy/src/modules/pyth-lazer/types.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/types.ts
@@ -1,4 +1,6 @@
 import type { ParsedFeedPayload } from "@pythnetwork/pyth-lazer-sdk";
+import { Data } from "effect";
+import type { PythLazerChannel } from "../../config/pyth-lazer-module-config";
 
 export type PriceFeedId = number;
 export type PriceFeedSymbol = string;
@@ -7,6 +9,21 @@ export interface CachedPriceFeed {
 	priceFeed: ParsedFeedPayload;
 	timestampUs: string;
 }
+
+// Cache and subscription identity. The same feed on two channels (real_time vs
+// fixed_rate@200ms) is two distinct entries, so a request is served the channel
+// it asked for instead of whichever one happened to be subscribed first.
+export type FeedChannelKey = {
+	readonly priceFeedId: PriceFeedId;
+	readonly channel: PythLazerChannel;
+};
+
+// Data.struct gives the key structural Hash/Equal, so it works directly as a
+// MutableHashMap key while staying a plain readonly object for field access.
+export const makeFeedChannelKey = (
+	priceFeedId: PriceFeedId,
+	channel: PythLazerChannel,
+): FeedChannelKey => Data.struct({ priceFeedId, channel });
 
 export type PythLazerHandlerError = {
 	_tag: string;

--- a/workspace/data-proxy/src/modules/pyth-lazer/types.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/types.ts
@@ -1,0 +1,15 @@
+import type { ParsedFeedPayload } from "@pythnetwork/pyth-lazer-sdk";
+
+export type PriceFeedId = number;
+export type PriceFeedSymbol = string;
+
+export interface CachedPriceFeed {
+	priceFeed: ParsedFeedPayload;
+	timestampUs: string;
+}
+
+export type PythLazerHandlerError = {
+	_tag: string;
+	message: string;
+	status: number;
+};


### PR DESCRIPTION
## Summary

- Add the POST `/v1/latest_price` pyth-lazer surface expected by deployed pyth_pro oracle programs.
- Keep the existing GET `/price/:symbols` array surface backed by the same websocket cache.
- Preserve all-or-fail request ordering for latest_price so response entries align with requested feed positions.
- Store per-feed stream timestamps in cache so `parsed.timestampUs` is derived from the returned feeds, not unrelated updates.

## Validation

- `bun test workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts`
- `bunx biome check workspace/data-proxy/src/config/pyth-lazer-module-config.ts workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts`
- `bun run check-ts`
- `bun test`
