### PR TITLE
feat(binance): add Binance websocket price-relay module

### DIFF
--- a/workspace/data-proxy/src/config/binance-module-config.ts
+++ b/workspace/data-proxy/src/config/binance-module-config.ts
@@ -1,0 +1,76 @@
+import { Duration, Effect, Option } from "effect";
+import * as v from "valibot";
+import { RouteSchema } from "./route-config";
+
+export const BINANCE_STREAM_TYPES = [
+	"bookTicker",
+	"aggTrade",
+	"trade",
+	"ticker",
+	"miniTicker",
+] as const;
+
+export type BinanceStreamType = (typeof BINANCE_STREAM_TYPES)[number];
+
+export const BinanceModuleConfigSchema = v.strictObject({
+	name: v.string(),
+	type: v.literal("binance"),
+	wsUrl: v.optional(v.string(), "wss://stream.binance.com:9443/stream"),
+	streamType: v.optional(v.picklist(BINANCE_STREAM_TYPES), "bookTicker"),
+	subscriptionSymbols: v.optional(v.array(v.string()), []),
+	maxSymbolsPerRequest: v.optional(v.number(), 100),
+	reconnectMaxBackoff: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((value) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(value),
+				() => new Error("Invalid reconnectMaxBackoff duration"),
+			),
+		),
+	),
+	reconnectStableThreshold: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((value) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(value),
+				() => new Error("Invalid reconnectStableThreshold duration"),
+			),
+		),
+	),
+	symbolsCleanupTtl: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "1 hour"),
+		v.transform((ttl) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(ttl),
+				() => new Error("Invalid symbols cleanup TTL"),
+			),
+		),
+	),
+	symbolsCleanupInterval: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((interval) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(interval),
+				() => new Error("Invalid symbols cleanup interval"),
+			),
+		),
+	),
+});
+
+export type BinanceModuleConfig = v.InferOutput<
+	typeof BinanceModuleConfigSchema
+>;
+
+export const BinanceModuleRouteSchema = v.strictObject({
+	...RouteSchema.entries,
+	moduleName: v.string(),
+	fetchFromModule: v.string(),
+	type: v.literal("binance"),
+});
+
+export type BinanceModuleRoute = v.InferOutput<typeof BinanceModuleRouteSchema>;
+
+export const validateBinanceModuleRoute = (_route: BinanceModuleRoute) =>
+	Effect.gen(function* () {
+		return yield* Effect.void;
+	});

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -13,6 +13,11 @@ import {
 } from "../constants";
 import { replaceParams } from "../utils/replace-params";
 import {
+	type BinanceModuleRoute,
+	BinanceModuleRouteSchema,
+	validateBinanceModuleRoute,
+} from "./binance-module-config";
+import {
 	type ChainlinkStreamsModuleRoute,
 	ChainlinkStreamsModuleRouteSchema,
 	validateChainlinkStreamsModuleRoute,
@@ -130,6 +135,7 @@ const ConfigSchema = v.strictObject(
 				HydromancerModuleRouteSchema,
 				LoTechModuleRouteSchema,
 				PmInsightsModuleRouteSchema,
+				BinanceModuleRouteSchema,
 			]),
 		),
 		baseURL: maybe(v.string()),
@@ -165,7 +171,8 @@ export type Route =
 	| DxFeedModuleRoute
 	| HydromancerModuleRoute
 	| LoTechModuleRoute
-	| PmInsightsModuleRoute;
+	| PmInsightsModuleRoute
+	| BinanceModuleRoute;
 
 export interface Config extends v.InferOutput<typeof ConfigSchema> {
 	modules: Modules[];
@@ -279,6 +286,11 @@ export const parseConfig = (
 
 			if (route.type === "pm-insights") {
 				yield* validatePmInsightsModuleRoute(route);
+				continue;
+			}
+
+			if (route.type === "binance") {
+				yield* validateBinanceModuleRoute(route);
 				continue;
 			}
 
@@ -519,6 +531,10 @@ export const parseConfig = (
 						envSecrets.add(password);
 						return Effect.succeed({ ...m, email, password } satisfies Modules);
 					}),
+					Match.when({ type: "binance" }, (m) =>
+						// Public market-data streams need no credentials.
+						Effect.succeed({ ...m } satisfies Modules),
+					),
 					Match.exhaustive,
 				),
 			);

--- a/workspace/data-proxy/src/config/module-config.ts
+++ b/workspace/data-proxy/src/config/module-config.ts
@@ -1,4 +1,6 @@
 import * as v from "valibot";
+import type { BinanceModuleConfig } from "./binance-module-config";
+import { BinanceModuleConfigSchema } from "./binance-module-config";
 import type { ChainlinkStreamsModuleConfig } from "./chainlink-streams-module-config";
 import { ChainlinkStreamsModuleConfigSchema } from "./chainlink-streams-module-config";
 import type { DxFeedModuleConfig } from "./dxfeed-module-config";
@@ -21,6 +23,7 @@ export const ModulesSchema = v.optional(
 			HydromancerModuleConfigSchema,
 			LoTechModuleConfigSchema,
 			PmInsightsModuleConfigSchema,
+			BinanceModuleConfigSchema,
 		]),
 	),
 	[],
@@ -32,4 +35,5 @@ export type Modules =
 	| DxFeedModuleConfig
 	| HydromancerModuleConfig
 	| LoTechModuleConfig
-	| PmInsightsModuleConfig;
+	| PmInsightsModuleConfig
+	| BinanceModuleConfig;

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -127,6 +127,16 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 					);
 				}),
 			),
+			Match.when({ type: "binance" }, (binanceModuleRoute) =>
+				Effect.gen(function* () {
+					yield* Effect.logDebug("Handling Binance request");
+					return yield* moduleService.handleRequest(
+						binanceModuleRoute,
+						params,
+						request,
+					);
+				}),
+			),
 			Match.when({ type: "upstream" }, (upstreamModuleRoute) =>
 				Effect.gen(function* () {
 					yield* Effect.logDebug("Handling upstream request");

--- a/workspace/data-proxy/src/modules/binance/binance.test.ts
+++ b/workspace/data-proxy/src/modules/binance/binance.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Duration, Effect, LogLevel, Logger } from "effect";
+import * as v from "valibot";
+import {
+	type BinanceModuleConfig,
+	BinanceModuleRouteSchema,
+} from "../../config/binance-module-config";
+import { ModuleService } from "../module";
+import { BinanceModuleService } from "./binance";
+import type { BinancePriceFrame } from "./ws-client";
+
+const btcBook: BinancePriceFrame = {
+	u: 400900217,
+	s: "BTCUSDT",
+	b: "67123.44",
+	B: "1.2",
+	a: "67123.46",
+	A: "0.8",
+};
+
+const ethBook: BinancePriceFrame = {
+	u: 400900218,
+	s: "ETHUSDT",
+	b: "3500.10",
+	B: "5.0",
+	a: "3500.20",
+	A: "4.1",
+};
+
+const baseConfig: BinanceModuleConfig = {
+	name: "binance",
+	type: "binance",
+	wsUrl: "wss://stream.binance.test/stream",
+	streamType: "bookTicker",
+	subscriptionSymbols: [],
+	maxSymbolsPerRequest: 100,
+	reconnectMaxBackoff: Duration.seconds(30),
+	reconnectStableThreshold: Duration.seconds(30),
+	symbolsCleanupTtl: Duration.minutes(2),
+	symbolsCleanupInterval: Duration.seconds(30),
+};
+
+const buildRoute = () =>
+	v.parse(BinanceModuleRouteSchema, {
+		type: "binance",
+		moduleName: "binance",
+		path: "/price/:symbols",
+		fetchFromModule: "{:symbols}",
+		method: ["GET"],
+	});
+
+const dummyRequest = new Request("http://proxy.local/price/x", {
+	method: "GET",
+});
+
+const parseControl = (raw: string) =>
+	JSON.parse(raw) as { method: string; params: string[]; id: number };
+
+class FakeWebSocket extends EventTarget {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: FakeWebSocket[] = [];
+
+	url: string;
+	readyState = FakeWebSocket.CONNECTING;
+	sent: string[] = [];
+
+	constructor(url: string) {
+		super();
+		this.url = url;
+		FakeWebSocket.instances.push(this);
+	}
+
+	send(data: string): void {
+		this.sent.push(data);
+	}
+
+	close(): void {
+		if (this.readyState === FakeWebSocket.CLOSED) return;
+		this.readyState = FakeWebSocket.CLOSED;
+		this.dispatchEvent(new Event("close"));
+	}
+
+	triggerOpen(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.dispatchEvent(new Event("open"));
+	}
+
+	triggerMessage(data: string): void {
+		this.dispatchEvent(new MessageEvent("message", { data }));
+	}
+}
+
+const waitFor = async (
+	predicate: () => boolean,
+	label: string,
+	timeoutMs = 2000,
+) => {
+	for (let i = 0; i < timeoutMs; i++) {
+		if (predicate()) return;
+		await new Promise<void>((r) => setTimeout(r, 1));
+	}
+	throw new Error(`Timed out waiting for ${label}`);
+};
+
+const subscribeFrames = (ws: FakeWebSocket) =>
+	ws.sent.filter((raw) => parseControl(raw).method === "SUBSCRIBE");
+
+const originalWebSocket = globalThis.WebSocket;
+
+beforeEach(() => {
+	FakeWebSocket.instances = [];
+	globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+	globalThis.WebSocket = originalWebSocket;
+});
+
+describe("BinanceModuleService.handleRequest", () => {
+	it("subscribes new symbols, returns seeded prices, and flags unseeded ones", async () => {
+		const route = buildRoute();
+		const params = { symbols: "ETHUSDT,BTCUSDT,DOGEUSDT" };
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			yield* svc.start();
+			return yield* svc.handleRequest(route, params, dummyRequest);
+		}).pipe(
+			Effect.provide(BinanceModuleService(baseConfig)),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		);
+
+		const resultPromise = Effect.runPromise(program);
+
+		await waitFor(
+			() => FakeWebSocket.instances.length >= 1,
+			"WebSocket instance",
+		);
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		// A subscribe frame proves all three symbols reached the desired set.
+		await waitFor(() => ws.sent.length >= 1, "subscribe frame");
+		expect(parseControl(ws.sent[0]).params).toEqual([
+			"ethusdt@bookTicker",
+			"btcusdt@bookTicker",
+			"dogeusdt@bookTicker",
+		]);
+
+		ws.triggerMessage(
+			JSON.stringify({ stream: "ethusdt@bookTicker", data: ethBook }),
+		);
+		ws.triggerMessage(
+			JSON.stringify({ stream: "btcusdt@bookTicker", data: btcBook }),
+		);
+
+		const response = await resultPromise;
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual([
+			{ symbol: "ETHUSDT", ...ethBook, __sedaHasPrice: true },
+			{ symbol: "BTCUSDT", ...btcBook, __sedaHasPrice: true },
+			{ symbol: "DOGEUSDT", __sedaHasPrice: false },
+		]);
+	}, 10_000);
+
+	it("does not re-subscribe a symbol already requested", async () => {
+		const route = buildRoute();
+		const params = { symbols: "BTCUSDT" };
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			yield* svc.start();
+			const r1 = yield* svc.handleRequest(route, params, dummyRequest);
+			const r2 = yield* svc.handleRequest(route, params, dummyRequest);
+			return [r1, r2] as const;
+		}).pipe(
+			Effect.provide(BinanceModuleService(baseConfig)),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		);
+
+		const resultPromise = Effect.runPromise(program);
+
+		await waitFor(
+			() => FakeWebSocket.instances.length >= 1,
+			"WebSocket instance",
+		);
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await waitFor(() => ws.sent.length >= 1, "subscribe frame");
+		ws.triggerMessage(
+			JSON.stringify({ stream: "btcusdt@bookTicker", data: btcBook }),
+		);
+
+		const [r1, r2] = await resultPromise;
+		expect(r1.status).toBe(200);
+		expect(r2.status).toBe(200);
+		// Only the first request subscribes; the repeat is served from cache.
+		expect(subscribeFrames(ws).length).toBe(1);
+	});
+
+	it("rejects when more symbols than maxSymbolsPerRequest are requested", async () => {
+		const route = buildRoute();
+		const config: BinanceModuleConfig = {
+			...baseConfig,
+			maxSymbolsPerRequest: 2,
+		};
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			return yield* svc.handleRequest(
+				route,
+				{ symbols: "BTCUSDT,ETHUSDT,SOLUSDT" },
+				dummyRequest,
+			);
+		}).pipe(
+			Effect.provide(BinanceModuleService(config)),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		);
+
+		const response = await Effect.runPromise(program);
+		expect(response.status).toBe(400);
+	});
+});
+
+describe("BinanceModuleService lifecycle", () => {
+	it("seeds subscriptionSymbols on start", async () => {
+		const config: BinanceModuleConfig = {
+			...baseConfig,
+			subscriptionSymbols: ["BTCUSDT", "ETHUSDT"],
+		};
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			yield* svc.start();
+		}).pipe(
+			Effect.provide(BinanceModuleService(config)),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		);
+
+		await Effect.runPromise(program);
+
+		await waitFor(
+			() => FakeWebSocket.instances.length >= 1,
+			"WebSocket instance",
+		);
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await waitFor(() => ws.sent.length >= 1, "subscribe frame");
+
+		expect(parseControl(ws.sent[0]).method).toBe("SUBSCRIBE");
+		expect(parseControl(ws.sent[0]).params).toEqual([
+			"btcusdt@bookTicker",
+			"ethusdt@bookTicker",
+		]);
+	});
+
+	it("unsubscribes a symbol once it has been idle past symbolsCleanupTtl", async () => {
+		const config: BinanceModuleConfig = {
+			...baseConfig,
+			subscriptionSymbols: ["BTCUSDT"],
+			// TTL is long enough that the socket opens first, short enough to keep the test fast.
+			symbolsCleanupTtl: Duration.millis(150),
+			symbolsCleanupInterval: Duration.millis(20),
+		};
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			yield* svc.start();
+		}).pipe(
+			Effect.provide(BinanceModuleService(config)),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		);
+
+		await Effect.runPromise(program);
+
+		await waitFor(
+			() => FakeWebSocket.instances.length >= 1,
+			"WebSocket instance",
+		);
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await waitFor(() => ws.sent.length >= 1, "subscribe frame");
+
+		await waitFor(
+			() => ws.sent.some((raw) => parseControl(raw).method === "UNSUBSCRIBE"),
+			"unsubscribe frame",
+		);
+		const unsubscribe = ws.sent.find(
+			(raw) => parseControl(raw).method === "UNSUBSCRIBE",
+		);
+		expect(parseControl(unsubscribe as string).params).toEqual([
+			"btcusdt@bookTicker",
+		]);
+	});
+});

--- a/workspace/data-proxy/src/modules/binance/binance.test.ts
+++ b/workspace/data-proxy/src/modules/binance/binance.test.ts
@@ -201,6 +201,45 @@ describe("BinanceModuleService.handleRequest", () => {
 		expect(subscribeFrames(ws).length).toBe(1);
 	});
 
+	it("stops vouching for cached prices once the socket has errored", async () => {
+		const route = buildRoute();
+		const params = { symbols: "BTCUSDT" };
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			yield* svc.start();
+			const fresh = yield* svc.handleRequest(route, params, dummyRequest);
+			// Socket drops; the ws-client flags hasError until it reconnects.
+			FakeWebSocket.instances[0].close();
+			const afterError = yield* svc.handleRequest(route, params, dummyRequest);
+			return [fresh, afterError] as const;
+		}).pipe(
+			Effect.provide(BinanceModuleService(baseConfig)),
+			Logger.withMinimumLogLevel(LogLevel.None),
+		);
+
+		const resultPromise = Effect.runPromise(program);
+
+		await waitFor(
+			() => FakeWebSocket.instances.length >= 1,
+			"WebSocket instance",
+		);
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await waitFor(() => ws.sent.length >= 1, "subscribe frame");
+		ws.triggerMessage(
+			JSON.stringify({ stream: "btcusdt@bookTicker", data: btcBook }),
+		);
+
+		const [fresh, afterError] = await resultPromise;
+		const freshBody = await fresh.json();
+		expect(freshBody[0].__sedaHasPrice).toBe(true);
+		// Same symbol is still cached, but the unhealthy socket means it is no
+		// longer presented as a live price.
+		const afterBody = await afterError.json();
+		expect(afterBody).toEqual([{ symbol: "BTCUSDT", __sedaHasPrice: false }]);
+	}, 10_000);
+
 	it("rejects when more symbols than maxSymbolsPerRequest are requested", async () => {
 		const route = buildRoute();
 		const config: BinanceModuleConfig = {

--- a/workspace/data-proxy/src/modules/binance/binance.ts
+++ b/workspace/data-proxy/src/modules/binance/binance.ts
@@ -90,6 +90,9 @@ export const BinanceModuleService = (config: BinanceModuleConfig) =>
 					}
 
 					const now = yield* Clock.currentTimeMillis;
+					// When the socket has errored its cached prices may be stale, so
+					// do not vouch for them (mirrors the hydromancer module).
+					const socketHealthy = !(yield* ws.hasError());
 					const newSymbols: string[] = [];
 					for (const requested of requestedSymbols) {
 						const symbol = requested.toUpperCase();
@@ -116,7 +119,7 @@ export const BinanceModuleService = (config: BinanceModuleConfig) =>
 						const requested = requestedSymbols[i];
 						const result = results[i];
 
-						if (Either.isLeft(result)) {
+						if (Either.isLeft(result) || !socketHealthy) {
 							prices.push({ symbol: requested, [HAS_PRICE_KEY]: false });
 						} else {
 							prices.push({

--- a/workspace/data-proxy/src/modules/binance/binance.ts
+++ b/workspace/data-proxy/src/modules/binance/binance.ts
@@ -1,0 +1,146 @@
+import { Clock, Effect, Either, Layer, MutableHashMap } from "effect";
+import type { BinanceModuleConfig } from "../../config/binance-module-config";
+import type { Route } from "../../config/config-parser";
+import { HAS_PRICE_KEY } from "../../constants";
+import { createErrorResponse } from "../../controllers/create-error-response";
+import { forkIdleCleanup } from "../../utils/idle-cleanup";
+import { replaceParams } from "../../utils/replace-params";
+import { FailedToHandleRequest, ModuleService } from "../module";
+import { createPriceCache } from "../shared/price-cache";
+import { FailedToHandleBinanceRequestError } from "./errors";
+import { type BinancePriceFrame, createBinanceWS } from "./ws-client";
+
+type BinancePriceEntry =
+	| ({ symbol: string } & BinancePriceFrame & { [HAS_PRICE_KEY]: true })
+	| { symbol: string; [HAS_PRICE_KEY]: false };
+
+export const BinanceModuleService = (config: BinanceModuleConfig) =>
+	Layer.effect(
+		ModuleService,
+		Effect.gen(function* () {
+			yield* Effect.logInfo("Initializing Binance module", {
+				name: config.name,
+				wsUrl: config.wsUrl,
+				streamType: config.streamType,
+			});
+
+			const cache = yield* createPriceCache<string, BinancePriceFrame>();
+			const ws = yield* createBinanceWS(config, cache);
+			// Symbol -> timestamp of the last request, drives the idle cleanup pass.
+			const lastRequestToSymbol = MutableHashMap.empty<string, number>();
+
+			const start = () =>
+				Effect.gen(function* () {
+					yield* Effect.logInfo("Starting Binance module", {
+						name: config.name,
+					});
+
+					yield* ws.start();
+
+					if (config.subscriptionSymbols.length > 0) {
+						const now = yield* Clock.currentTimeMillis;
+						const seeded = config.subscriptionSymbols.map((symbol) =>
+							symbol.toUpperCase(),
+						);
+						for (const symbol of seeded) {
+							MutableHashMap.set(lastRequestToSymbol, symbol, now);
+						}
+						yield* ws.subscribe(seeded);
+					}
+
+					yield* forkIdleCleanup({
+						lastRequest: lastRequestToSymbol,
+						ttl: config.symbolsCleanupTtl,
+						interval: config.symbolsCleanupInterval,
+						onExpire: (symbol) =>
+							Effect.gen(function* () {
+								yield* Effect.logInfo("Cleaning up idle symbol", { symbol });
+								yield* cache.deletePrice(symbol);
+								yield* ws.unsubscribe([symbol]);
+							}),
+					});
+				}).pipe(Effect.annotateLogs("_name", "binance"));
+
+			const handleRequest = (
+				route: Route,
+				params: Record<string, string>,
+				_request: Request,
+			) =>
+				Effect.gen(function* () {
+					if (route.type !== "binance") {
+						return yield* Effect.fail(
+							new FailedToHandleRequest({
+								msg: "Route is not a Binance module",
+							}),
+						);
+					}
+
+					const requestedSymbols = replaceParams(route.fetchFromModule, params)
+						.split(",")
+						.map((symbol) => symbol.trim())
+						.filter((symbol) => symbol.length > 0);
+
+					if (requestedSymbols.length > config.maxSymbolsPerRequest) {
+						return yield* Effect.fail(
+							new FailedToHandleBinanceRequestError({
+								error: `Too many symbols, max is ${config.maxSymbolsPerRequest} but got ${requestedSymbols.length}`,
+								status: 400,
+							}),
+						);
+					}
+
+					const now = yield* Clock.currentTimeMillis;
+					const newSymbols: string[] = [];
+					for (const requested of requestedSymbols) {
+						const symbol = requested.toUpperCase();
+						if (!MutableHashMap.has(lastRequestToSymbol, symbol)) {
+							newSymbols.push(symbol);
+						}
+						MutableHashMap.set(lastRequestToSymbol, symbol, now);
+					}
+
+					if (newSymbols.length > 0) {
+						yield* ws.subscribe(newSymbols);
+					}
+
+					// Subscriptions are in-flight; resolve every requested symbol concurrently.
+					const results = yield* Effect.forEach(
+						requestedSymbols,
+						(requested) =>
+							Effect.either(cache.getOrWaitPrice(requested.toUpperCase())),
+						{ concurrency: "unbounded" },
+					);
+
+					const prices: BinancePriceEntry[] = [];
+					for (let i = 0; i < requestedSymbols.length; i++) {
+						const requested = requestedSymbols[i];
+						const result = results[i];
+
+						if (Either.isLeft(result)) {
+							prices.push({ symbol: requested, [HAS_PRICE_KEY]: false });
+						} else {
+							prices.push({
+								symbol: requested,
+								...result.right,
+								[HAS_PRICE_KEY]: true,
+							});
+						}
+					}
+
+					return new Response(JSON.stringify(prices), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}).pipe(
+					Effect.withSpan("handleBinanceRequest"),
+					Effect.catchAll((error) =>
+						Effect.succeed(createErrorResponse(error, error.status)),
+					),
+				);
+
+			return {
+				start,
+				handleRequest,
+			};
+		}),
+	);

--- a/workspace/data-proxy/src/modules/binance/binance.ts
+++ b/workspace/data-proxy/src/modules/binance/binance.ts
@@ -90,8 +90,6 @@ export const BinanceModuleService = (config: BinanceModuleConfig) =>
 					}
 
 					const now = yield* Clock.currentTimeMillis;
-					// When the socket has errored its cached prices may be stale, so
-					// do not vouch for them (mirrors the hydromancer module).
 					const socketHealthy = !(yield* ws.hasError());
 					const newSymbols: string[] = [];
 					for (const requested of requestedSymbols) {

--- a/workspace/data-proxy/src/modules/binance/errors.ts
+++ b/workspace/data-proxy/src/modules/binance/errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+export class FailedToHandleBinanceRequestError extends Data.TaggedError(
+	"FailedToHandleBinanceRequestError",
+)<{ error: string; status: number }> {
+	message = `Binance error: ${this.error}`;
+}

--- a/workspace/data-proxy/src/modules/binance/ws-client.test.ts
+++ b/workspace/data-proxy/src/modules/binance/ws-client.test.ts
@@ -1,0 +1,450 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Duration, Effect, Fiber, LogLevel, Logger, Schedule } from "effect";
+import type { BinanceModuleConfig } from "../../config/binance-module-config";
+import { createPriceCache } from "../shared/price-cache";
+import {
+	type BinancePriceFrame,
+	buildStreamName,
+	buildSubscribeFrame,
+	buildUnsubscribeFrame,
+	createBinanceWS,
+	parseInboundFrame,
+} from "./ws-client";
+
+const btcBook: BinancePriceFrame = {
+	u: 400900217,
+	s: "BTCUSDT",
+	b: "67123.44",
+	B: "1.2",
+	a: "67123.46",
+	A: "0.8",
+};
+
+const ethBook: BinancePriceFrame = {
+	u: 400900218,
+	s: "ETHUSDT",
+	b: "3500.10",
+	B: "5.0",
+	a: "3500.20",
+	A: "4.1",
+};
+
+describe("buildStreamName", () => {
+	it("lowercases the symbol and appends the stream type", () => {
+		expect(buildStreamName("BTCUSDT", "bookTicker")).toBe("btcusdt@bookTicker");
+		expect(buildStreamName("ethusdt", "aggTrade")).toBe("ethusdt@aggTrade");
+	});
+});
+
+describe("buildSubscribeFrame / buildUnsubscribeFrame", () => {
+	it("produces the documented subscribe control frame", () => {
+		expect(JSON.parse(buildSubscribeFrame(["btcusdt@bookTicker"], 1))).toEqual({
+			method: "SUBSCRIBE",
+			params: ["btcusdt@bookTicker"],
+			id: 1,
+		});
+	});
+
+	it("produces the documented unsubscribe control frame", () => {
+		expect(
+			JSON.parse(
+				buildUnsubscribeFrame(["btcusdt@bookTicker", "ethusdt@bookTicker"], 7),
+			),
+		).toEqual({
+			method: "UNSUBSCRIBE",
+			params: ["btcusdt@bookTicker", "ethusdt@bookTicker"],
+			id: 7,
+		});
+	});
+});
+
+describe("parseInboundFrame", () => {
+	it("unwraps a combined-stream envelope", () => {
+		const raw = JSON.stringify({ stream: "btcusdt@bookTicker", data: btcBook });
+		expect(parseInboundFrame(raw)).toEqual({
+			symbol: "BTCUSDT",
+			frame: btcBook,
+		});
+	});
+
+	it("accepts a bare (raw-stream) payload", () => {
+		expect(parseInboundFrame(JSON.stringify(ethBook))).toEqual({
+			symbol: "ETHUSDT",
+			frame: ethBook,
+		});
+	});
+
+	it("uppercases the symbol so cache keys stay consistent", () => {
+		const result = parseInboundFrame(JSON.stringify({ s: "btcusdt", b: "1" }));
+		expect(result?.symbol).toBe("BTCUSDT");
+	});
+
+	it("returns null for a control ack with no symbol", () => {
+		expect(
+			parseInboundFrame(JSON.stringify({ result: null, id: 1 })),
+		).toBeNull();
+	});
+
+	it("returns null for malformed JSON", () => {
+		expect(parseInboundFrame("not json")).toBeNull();
+	});
+
+	it("returns null when the payload has no string symbol", () => {
+		expect(parseInboundFrame(JSON.stringify({ b: "1", a: "2" }))).toBeNull();
+	});
+});
+
+class FakeWebSocket extends EventTarget {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: FakeWebSocket[] = [];
+	static sendImpl?: (instance: FakeWebSocket, data: string) => void;
+
+	url: string;
+	readyState = FakeWebSocket.CONNECTING;
+	sent: string[] = [];
+
+	constructor(url: string) {
+		super();
+		this.url = url;
+		FakeWebSocket.instances.push(this);
+	}
+
+	send(data: string): void {
+		if (FakeWebSocket.sendImpl) {
+			FakeWebSocket.sendImpl(this, data);
+			return;
+		}
+		this.sent.push(data);
+	}
+
+	close(): void {
+		if (this.readyState === FakeWebSocket.CLOSED) return;
+		this.readyState = FakeWebSocket.CLOSED;
+		this.dispatchEvent(new Event("close"));
+	}
+
+	triggerOpen(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.dispatchEvent(new Event("open"));
+	}
+
+	triggerMessage(data: string): void {
+		this.dispatchEvent(new MessageEvent("message", { data }));
+	}
+
+	triggerClose(): void {
+		if (this.readyState === FakeWebSocket.CLOSED) return;
+		this.readyState = FakeWebSocket.CLOSED;
+		this.dispatchEvent(new Event("close"));
+	}
+}
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+const parseControl = (raw: string) =>
+	JSON.parse(raw) as { method: string; params: string[]; id: number };
+
+const baseConfig: BinanceModuleConfig = {
+	name: "binance",
+	type: "binance",
+	wsUrl: "wss://stream.binance.test/stream",
+	streamType: "bookTicker",
+	subscriptionSymbols: ["BTCUSDT", "ETHUSDT"],
+	maxSymbolsPerRequest: 100,
+	reconnectMaxBackoff: Duration.seconds(30),
+	reconnectStableThreshold: Duration.seconds(30),
+	symbolsCleanupTtl: Duration.minutes(2),
+	symbolsCleanupInterval: Duration.seconds(30),
+};
+
+const originalWebSocket = globalThis.WebSocket;
+
+beforeEach(() => {
+	FakeWebSocket.instances = [];
+	FakeWebSocket.sendImpl = undefined;
+	globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+	globalThis.WebSocket = originalWebSocket;
+});
+
+const startService = (
+	config: BinanceModuleConfig,
+	preSubscribed: string[] = config.subscriptionSymbols,
+	options?: Parameters<typeof createBinanceWS>[2],
+) =>
+	Effect.gen(function* () {
+		const cache = yield* createPriceCache<string, BinancePriceFrame>();
+		const ws = yield* createBinanceWS(
+			config,
+			cache,
+			options ?? { reconnectSchedule: Schedule.spaced(Duration.minutes(10)) },
+		);
+		yield* ws.subscribe(preSubscribed);
+		const fiber = yield* ws.start();
+		return { cache, ws, fiber };
+	}).pipe(Logger.withMinimumLogLevel(LogLevel.None));
+
+describe("createBinanceWS", () => {
+	it("opens the WS at the configured url and batches the subscribe on open", async () => {
+		const { fiber, ws: service } = await Effect.runPromise(
+			startService(baseConfig),
+		);
+		await flush();
+
+		expect(FakeWebSocket.instances.length).toBe(1);
+		const ws = FakeWebSocket.instances[0];
+		expect(ws.url).toBe("wss://stream.binance.test/stream");
+
+		ws.triggerOpen();
+		await flush();
+
+		expect(ws.sent.length).toBe(1);
+		const frame = parseControl(ws.sent[0]);
+		expect(frame.method).toBe("SUBSCRIBE");
+		expect(frame.params).toEqual(["btcusdt@bookTicker", "ethusdt@bookTicker"]);
+		expect(typeof frame.id).toBe("number");
+		expect(await Effect.runPromise(service.hasError())).toBe(false);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("writes inbound frames for desired symbols into the cache", async () => {
+		const { cache, fiber } = await Effect.runPromise(startService(baseConfig));
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		ws.triggerMessage(
+			JSON.stringify({ stream: "btcusdt@bookTicker", data: btcBook }),
+		);
+		await flush();
+
+		const price = await Effect.runPromise(cache.getOrWaitPrice("BTCUSDT"));
+		expect(price).toEqual(btcBook);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("drops inbound frames for symbols not in the desired set", async () => {
+		const { cache, fiber } = await Effect.runPromise(
+			startService(baseConfig, ["BTCUSDT"]),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		ws.triggerMessage(
+			JSON.stringify({ stream: "ethusdt@bookTicker", data: ethBook }),
+		);
+		await flush();
+
+		expect(cache.size()).toBe(0);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("marks hasError after the socket closes", async () => {
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+		expect(await Effect.runPromise(service.hasError())).toBe(false);
+
+		ws.triggerClose();
+		await flush();
+
+		expect(await Effect.runPromise(service.hasError())).toBe(true);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("ignores control acks and non-json frames", async () => {
+		const { cache, fiber } = await Effect.runPromise(startService(baseConfig));
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		ws.triggerMessage(JSON.stringify({ result: null, id: 1 }));
+		ws.triggerMessage("not json");
+		await flush();
+
+		expect(cache.size()).toBe(0);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("subscribe is idempotent: a duplicate symbol sends no extra frame", async () => {
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, ["BTCUSDT"]),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+		expect(ws.sent.length).toBe(1);
+
+		await Effect.runPromise(service.subscribe(["BTCUSDT"]));
+		await Effect.runPromise(service.subscribe(["BTCUSDT"]));
+		await flush();
+
+		expect(ws.sent.length).toBe(1);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("subscribe batches multiple new symbols into one frame", async () => {
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, []),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+		expect(ws.sent.length).toBe(0);
+
+		await Effect.runPromise(
+			service.subscribe(["BTCUSDT", "ETHUSDT", "SOLUSDT"]),
+		);
+		await flush();
+
+		expect(ws.sent.length).toBe(1);
+		const frame = parseControl(ws.sent[0]);
+		expect(frame.method).toBe("SUBSCRIBE");
+		expect(frame.params).toEqual([
+			"btcusdt@bookTicker",
+			"ethusdt@bookTicker",
+			"solusdt@bookTicker",
+		]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("unsubscribe removes the symbol and sends an unsubscribe frame", async () => {
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, ["BTCUSDT"]),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+		expect(ws.sent.length).toBe(1);
+
+		// Unknown symbol: no frame.
+		await Effect.runPromise(service.unsubscribe(["ETHUSDT"]));
+		await flush();
+		expect(ws.sent.length).toBe(1);
+
+		await Effect.runPromise(service.unsubscribe(["BTCUSDT"]));
+		await flush();
+		expect(ws.sent.length).toBe(2);
+		const frame = parseControl(ws.sent[1]);
+		expect(frame.method).toBe("UNSUBSCRIBE");
+		expect(frame.params).toEqual(["btcusdt@bookTicker"]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("reconnects after a close, producing a second WebSocket instance", async () => {
+		const fastSchedule = Schedule.spaced(Duration.millis(10));
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, baseConfig.subscriptionSymbols, {
+				reconnectSchedule: fastSchedule,
+			}),
+		);
+		await flush();
+
+		expect(FakeWebSocket.instances.length).toBe(1);
+		const ws1 = FakeWebSocket.instances[0];
+		ws1.triggerOpen();
+		await flush();
+
+		ws1.triggerClose();
+		await new Promise<void>((r) => setTimeout(r, 40));
+
+		expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+		const ws2 = FakeWebSocket.instances[1];
+		expect(ws2).not.toBe(ws1);
+
+		ws2.triggerOpen();
+		await flush();
+		expect(await Effect.runPromise(service.hasError())).toBe(false);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("re-subscribes every desired symbol after reconnect", async () => {
+		const fastSchedule = Schedule.spaced(Duration.millis(10));
+		const { fiber } = await Effect.runPromise(
+			startService(baseConfig, baseConfig.subscriptionSymbols, {
+				reconnectSchedule: fastSchedule,
+			}),
+		);
+		await flush();
+
+		const ws1 = FakeWebSocket.instances[0];
+		ws1.triggerOpen();
+		await flush();
+		expect(parseControl(ws1.sent[0]).params).toEqual([
+			"btcusdt@bookTicker",
+			"ethusdt@bookTicker",
+		]);
+
+		ws1.triggerClose();
+		await new Promise<void>((r) => setTimeout(r, 40));
+
+		const ws2 = FakeWebSocket.instances[1];
+		ws2.triggerOpen();
+		await flush();
+
+		expect(parseControl(ws2.sent[0]).params).toEqual([
+			"btcusdt@bookTicker",
+			"ethusdt@bookTicker",
+		]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("recovers from a send error by closing the socket and reconnecting", async () => {
+		const fastSchedule = Schedule.spaced(Duration.millis(10));
+		// First instance throws on send; second instance accepts normally.
+		FakeWebSocket.sendImpl = (instance, data) => {
+			if (FakeWebSocket.instances.indexOf(instance) === 0) {
+				throw new Error("send-blew-up");
+			}
+			instance.sent.push(data);
+		};
+
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, ["BTCUSDT"], {
+				reconnectSchedule: fastSchedule,
+			}),
+		);
+		await flush();
+
+		const ws1 = FakeWebSocket.instances[0];
+		ws1.triggerOpen();
+		await flush();
+
+		await new Promise<void>((r) => setTimeout(r, 40));
+		expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+		const ws2 = FakeWebSocket.instances[1];
+		ws2.triggerOpen();
+		await flush();
+
+		expect(parseControl(ws2.sent[0]).params).toEqual(["btcusdt@bookTicker"]);
+		expect(await Effect.runPromise(service.hasError())).toBe(false);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+});

--- a/workspace/data-proxy/src/modules/binance/ws-client.ts
+++ b/workspace/data-proxy/src/modules/binance/ws-client.ts
@@ -1,0 +1,247 @@
+import {
+	Deferred,
+	Duration,
+	Effect,
+	type Fiber,
+	MutableHashMap,
+	Option,
+	Runtime,
+	Schedule,
+} from "effect";
+import type { BinanceModuleConfig } from "../../config/binance-module-config";
+
+/** A raw Binance market-data payload. Always carries the symbol in `s`; the rest
+ * of the fields depend on the configured stream type and are relayed verbatim. */
+export interface BinancePriceFrame {
+	s: string;
+	[key: string]: unknown;
+}
+
+/** The subset of the shared price cache the WS daemon writes to. */
+interface PriceSink {
+	setPrice: (key: string, price: BinancePriceFrame) => Effect.Effect<void>;
+}
+
+export const buildStreamName = (symbol: string, streamType: string): string =>
+	`${symbol.toLowerCase()}@${streamType}`;
+
+export const buildSubscribeFrame = (
+	streamNames: string[],
+	id: number,
+): string => JSON.stringify({ method: "SUBSCRIBE", params: streamNames, id });
+
+export const buildUnsubscribeFrame = (
+	streamNames: string[],
+	id: number,
+): string => JSON.stringify({ method: "UNSUBSCRIBE", params: streamNames, id });
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+/** Extracts {symbol, frame} from an inbound message, or null if it is not a
+ * market-data payload (control acks like {result, id} and malformed frames). */
+export const parseInboundFrame = (
+	raw: string,
+): { symbol: string; frame: BinancePriceFrame } | null => {
+	let json: unknown;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+
+	// Combined streams wrap the payload as { stream, data }; raw streams send it bare.
+	let payload: unknown = json;
+	if (
+		isRecord(json) &&
+		typeof json.stream === "string" &&
+		isRecord(json.data)
+	) {
+		payload = json.data;
+	}
+
+	if (!isRecord(payload) || typeof payload.s !== "string") {
+		return null;
+	}
+
+	return {
+		symbol: payload.s.toUpperCase(),
+		frame: payload as BinancePriceFrame,
+	};
+};
+
+export const defaultReconnectSchedule = (config: BinanceModuleConfig) =>
+	Schedule.exponential(Duration.seconds(1)).pipe(
+		Schedule.either(Schedule.spaced(config.reconnectMaxBackoff)),
+		Schedule.resetAfter(config.reconnectStableThreshold),
+	);
+
+export interface BinanceWS {
+	/** Forks the WS daemon. The daemon owns reconnect with backoff and resubscribes on each open. */
+	start(): Effect.Effect<Fiber.RuntimeFiber<unknown, unknown>, never, never>;
+	/** Adds the symbols to the desired set and sends one subscribe frame for the new ones if connected. Idempotent. */
+	subscribe(symbols: string[]): Effect.Effect<void, never, never>;
+	/** Removes the symbols from the desired set and sends one unsubscribe frame for the removed ones if connected. Idempotent. */
+	unsubscribe(symbols: string[]): Effect.Effect<void, never, never>;
+	/** True while the socket is disconnected, errored, or has a pending send failure. */
+	hasError(): Effect.Effect<boolean, never, never>;
+}
+
+export interface CreateBinanceWSOptions {
+	reconnectSchedule?: Schedule.Schedule<unknown, unknown, never>;
+}
+
+export const createBinanceWS = (
+	config: BinanceModuleConfig,
+	cache: PriceSink,
+	options?: CreateBinanceWSOptions,
+): Effect.Effect<BinanceWS, never, never> =>
+	Effect.gen(function* () {
+		const runtime = yield* Effect.runtime<never>();
+		const desiredSymbols = MutableHashMap.empty<string, true>();
+		let currentWS: WebSocket | null = null;
+		let socketError: string | undefined;
+		let controlId = 0;
+		const schedule =
+			options?.reconnectSchedule ?? defaultReconnectSchedule(config);
+
+		const nextControlId = () => ++controlId;
+
+		const streamNamesFor = (symbols: string[]) =>
+			symbols.map((symbol) => buildStreamName(symbol, config.streamType));
+
+		const trySend = (frame: string) =>
+			Effect.gen(function* () {
+				const ws = currentWS;
+				if (ws === null || ws.readyState !== WebSocket.OPEN) return;
+				try {
+					ws.send(frame);
+				} catch (err) {
+					socketError = `ws send failed: ${String(err)}`;
+					yield* Effect.logWarning("Binance WS send failed", {
+						error: String(err),
+					});
+					try {
+						ws.close();
+					} catch {
+						// best-effort; the close listener will trigger the reconnect loop.
+					}
+				}
+			});
+
+		const subscribe = (symbols: string[]) =>
+			Effect.gen(function* () {
+				const fresh: string[] = [];
+				for (const raw of symbols) {
+					const symbol = raw.toUpperCase();
+					if (Option.isSome(MutableHashMap.get(desiredSymbols, symbol)))
+						continue;
+					MutableHashMap.set(desiredSymbols, symbol, true);
+					fresh.push(symbol);
+				}
+				if (fresh.length === 0) return;
+				// Binance caps inbound control messages at 5/sec; one frame per batch stays under it.
+				yield* trySend(
+					buildSubscribeFrame(streamNamesFor(fresh), nextControlId()),
+				);
+			});
+
+		const unsubscribe = (symbols: string[]) =>
+			Effect.gen(function* () {
+				const removed: string[] = [];
+				for (const raw of symbols) {
+					const symbol = raw.toUpperCase();
+					if (Option.isNone(MutableHashMap.get(desiredSymbols, symbol)))
+						continue;
+					MutableHashMap.remove(desiredSymbols, symbol);
+					removed.push(symbol);
+				}
+				if (removed.length === 0) return;
+				yield* trySend(
+					buildUnsubscribeFrame(streamNamesFor(removed), nextControlId()),
+				);
+			});
+
+		const hasError = () => Effect.sync(() => socketError !== undefined);
+
+		const handleOpen = (ws: WebSocket) =>
+			Effect.gen(function* () {
+				yield* Effect.logInfo("Binance WS open", { name: config.name });
+				socketError = undefined;
+				currentWS = ws;
+				const symbols: string[] = [];
+				for (const [symbol] of desiredSymbols) symbols.push(symbol);
+				if (symbols.length > 0) {
+					yield* trySend(
+						buildSubscribeFrame(streamNamesFor(symbols), nextControlId()),
+					);
+				}
+			});
+
+		const handleInboundMessage = (raw: string) =>
+			Effect.gen(function* () {
+				const parsed = parseInboundFrame(raw);
+				if (!parsed) return;
+				if (Option.isNone(MutableHashMap.get(desiredSymbols, parsed.symbol))) {
+					return;
+				}
+				yield* cache.setPrice(parsed.symbol, parsed.frame);
+			});
+
+		const handleDisconnect = (
+			reason: "close" | "error",
+			closed: Deferred.Deferred<void, "close" | "error">,
+		) =>
+			Effect.gen(function* () {
+				yield* Effect.logWarning("Binance WS disconnected", { reason });
+				socketError = `ws ${reason}`;
+				currentWS = null;
+				yield* Deferred.fail(closed, reason);
+			});
+
+		const connectOnce = Effect.gen(function* () {
+			const closed = yield* Deferred.make<void, "close" | "error">();
+
+			yield* Effect.logInfo("Binance WS connecting", { name: config.name });
+
+			const ws = yield* Effect.acquireRelease(
+				Effect.sync(() => new WebSocket(config.wsUrl)),
+				(socket) =>
+					Effect.sync(() => {
+						if (socket.readyState !== WebSocket.CLOSED) {
+							socket.close();
+						}
+					}),
+			);
+
+			ws.addEventListener("open", () => {
+				Runtime.runSync(runtime, handleOpen(ws));
+			});
+			ws.addEventListener("message", (event) => {
+				if (typeof event.data !== "string") return;
+				Runtime.runSync(runtime, handleInboundMessage(event.data));
+			});
+			ws.addEventListener("close", () => {
+				Runtime.runSync(runtime, handleDisconnect("close", closed));
+			});
+			ws.addEventListener("error", () => {
+				Runtime.runSync(runtime, handleDisconnect("error", closed));
+			});
+
+			yield* Deferred.await(closed);
+		}).pipe(Effect.scoped);
+
+		const loop = connectOnce.pipe(
+			Effect.tapError((error) =>
+				Effect.sync(() => {
+					socketError = `ws connect failed: ${String(error)}`;
+				}),
+			),
+			Effect.retry(schedule),
+		);
+
+		const cachedStart = yield* Effect.cached(Effect.forkDaemon(loop));
+		const start = () => cachedStart;
+
+		return { start, subscribe, unsubscribe, hasError } satisfies BinanceWS;
+	});

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -8,6 +8,7 @@ import { Elysia } from "elysia";
 import { type Config, getHttpMethods } from "./config/config-parser";
 import { DATA_PROXY_ID, DEFAULT_PROXY_ROUTE_GROUP } from "./constants";
 import { handleProxyRequest } from "./controllers/proxy/handle-proxy-request";
+import { BinanceModuleService } from "./modules/binance/binance";
 import { ChainlinkStreamsModuleService } from "./modules/chainlink-streams/chainlink-streams";
 import { DxFeedModuleService } from "./modules/dxfeed/dxfeed";
 import { HydromancerModuleService } from "./modules/hydromancer/hydromancer";
@@ -58,6 +59,9 @@ export const startProxyServer = (
 				Match.when({ type: "pm-insights" }, (m) =>
 					Layer.memoize(PmInsightsModuleService(m)),
 				),
+				Match.when({ type: "binance" }, (m) =>
+					Layer.memoize(BinanceModuleService(m)),
+				),
 				Match.exhaustive,
 			);
 
@@ -77,7 +81,8 @@ export const startProxyServer = (
 				route.type === "dxfeed" ||
 				route.type === "hydromancer" ||
 				route.type === "lo-tech" ||
-				route.type === "pm-insights"
+				route.type === "pm-insights" ||
+				route.type === "binance"
 			) {
 				const moduleLayer = MutableHashMap.get(modules, route.moduleName);
 				if (Option.isNone(moduleLayer)) {


### PR DESCRIPTION
Adds a Binance market-data module that relays websocket price frames through the proxy, following the same shape as the existing hydromancer and lo-tech stream modules: a config schema with a no-op route validator, a reconnecting ws-client, and a service backed by the shared price-cache and idle-cleanup. A request subscribes any not-yet-tracked symbols, waits on the shared cache, and returns one entry per requested symbol in request order, each flagged with `__sedaHasPrice` so callers reading by index stay aligned. Symbols nobody has requested within the TTL are unsubscribed and evicted by the shared idle-cleanup daemon. Stream type (bookTicker, aggTrade, trade, ticker, miniTicker) and reconnect backoff are config-driven, and subscribe frames are batched one-per-call to stay under Binance's 5/sec control-message cap.

- Binance public market-data streams need no credentials, so the config parser's match arm adds no env secrets, unlike the credentialed modules.
- The ws-client's connect/reconnect machinery is a third near-copy of the hydromancer/lo-tech pattern. Extracting a shared `reconnecting-ws` helper is deliberately left to a follow-up rather than bundled here.
