### PR TITLE
feat(lighter): add Lighter websocket ticker-relay module

### DIFF
--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -33,6 +33,11 @@ import {
 	validateHydromancerModuleRoute,
 } from "./hydromancer-module-config";
 import {
+	type LighterModuleRoute,
+	LighterModuleRouteSchema,
+	validateLighterModuleRoute,
+} from "./lighter-module-config";
+import {
 	type LoTechModuleRoute,
 	LoTechModuleRouteSchema,
 	resolveLoTechModule,
@@ -136,6 +141,7 @@ const ConfigSchema = v.strictObject(
 				LoTechModuleRouteSchema,
 				PmInsightsModuleRouteSchema,
 				BinanceModuleRouteSchema,
+				LighterModuleRouteSchema,
 			]),
 		),
 		baseURL: maybe(v.string()),
@@ -172,7 +178,8 @@ export type Route =
 	| HydromancerModuleRoute
 	| LoTechModuleRoute
 	| PmInsightsModuleRoute
-	| BinanceModuleRoute;
+	| BinanceModuleRoute
+	| LighterModuleRoute;
 
 export interface Config extends v.InferOutput<typeof ConfigSchema> {
 	modules: Modules[];
@@ -291,6 +298,11 @@ export const parseConfig = (
 
 			if (route.type === "binance") {
 				yield* validateBinanceModuleRoute(route);
+				continue;
+			}
+
+			if (route.type === "lighter") {
+				yield* validateLighterModuleRoute(route);
 				continue;
 			}
 
@@ -532,6 +544,10 @@ export const parseConfig = (
 						return Effect.succeed({ ...m, email, password } satisfies Modules);
 					}),
 					Match.when({ type: "binance" }, (m) =>
+						// Public market-data streams need no credentials.
+						Effect.succeed({ ...m } satisfies Modules),
+					),
+					Match.when({ type: "lighter" }, (m) =>
 						// Public market-data streams need no credentials.
 						Effect.succeed({ ...m } satisfies Modules),
 					),

--- a/workspace/data-proxy/src/config/lighter-module-config.ts
+++ b/workspace/data-proxy/src/config/lighter-module-config.ts
@@ -1,0 +1,75 @@
+import { Duration, Effect, Option } from "effect";
+import * as v from "valibot";
+import { RouteSchema } from "./route-config";
+
+export const LighterModuleConfigSchema = v.strictObject({
+	name: v.string(),
+	type: v.literal("lighter"),
+	wsUrl: v.optional(v.string(), "wss://mainnet.zklighter.elliot.ai/stream"),
+	// Lighter numeric market ids (e.g. 1 for BTC) to subscribe at startup.
+	subscriptionMarketIds: v.optional(v.array(v.number()), []),
+	maxMarketsPerRequest: v.optional(v.number(), 100),
+	keepaliveInterval: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "60 seconds"),
+		v.transform((value) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(value),
+				() => new Error("Invalid keepaliveInterval duration"),
+			),
+		),
+	),
+	reconnectMaxBackoff: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((value) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(value),
+				() => new Error("Invalid reconnectMaxBackoff duration"),
+			),
+		),
+	),
+	reconnectStableThreshold: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((value) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(value),
+				() => new Error("Invalid reconnectStableThreshold duration"),
+			),
+		),
+	),
+	marketsCleanupTtl: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "1 hour"),
+		v.transform((ttl) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(ttl),
+				() => new Error("Invalid markets cleanup TTL"),
+			),
+		),
+	),
+	marketsCleanupInterval: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "30 seconds"),
+		v.transform((interval) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(interval),
+				() => new Error("Invalid markets cleanup interval"),
+			),
+		),
+	),
+});
+
+export type LighterModuleConfig = v.InferOutput<
+	typeof LighterModuleConfigSchema
+>;
+
+export const LighterModuleRouteSchema = v.strictObject({
+	...RouteSchema.entries,
+	moduleName: v.string(),
+	fetchFromModule: v.string(),
+	type: v.literal("lighter"),
+});
+
+export type LighterModuleRoute = v.InferOutput<typeof LighterModuleRouteSchema>;
+
+export const validateLighterModuleRoute = (_route: LighterModuleRoute) =>
+	Effect.gen(function* () {
+		return yield* Effect.void;
+	});

--- a/workspace/data-proxy/src/config/module-config.ts
+++ b/workspace/data-proxy/src/config/module-config.ts
@@ -7,6 +7,8 @@ import type { DxFeedModuleConfig } from "./dxfeed-module-config";
 import { DxFeedModuleConfigSchema } from "./dxfeed-module-config";
 import type { HydromancerModuleConfig } from "./hydromancer-module-config";
 import { HydromancerModuleConfigSchema } from "./hydromancer-module-config";
+import type { LighterModuleConfig } from "./lighter-module-config";
+import { LighterModuleConfigSchema } from "./lighter-module-config";
 import type { LoTechModuleConfig } from "./lo-tech-module-config";
 import { LoTechModuleConfigSchema } from "./lo-tech-module-config";
 import type { PmInsightsModuleConfig } from "./pm-insights-module-config";
@@ -24,6 +26,7 @@ export const ModulesSchema = v.optional(
 			LoTechModuleConfigSchema,
 			PmInsightsModuleConfigSchema,
 			BinanceModuleConfigSchema,
+			LighterModuleConfigSchema,
 		]),
 	),
 	[],
@@ -36,4 +39,5 @@ export type Modules =
 	| HydromancerModuleConfig
 	| LoTechModuleConfig
 	| PmInsightsModuleConfig
-	| BinanceModuleConfig;
+	| BinanceModuleConfig
+	| LighterModuleConfig;

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -137,6 +137,16 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 					);
 				}),
 			),
+			Match.when({ type: "lighter" }, (lighterModuleRoute) =>
+				Effect.gen(function* () {
+					yield* Effect.logDebug("Handling Lighter request");
+					return yield* moduleService.handleRequest(
+						lighterModuleRoute,
+						params,
+						request,
+					);
+				}),
+			),
 			Match.when({ type: "upstream" }, (upstreamModuleRoute) =>
 				Effect.gen(function* () {
 					yield* Effect.logDebug("Handling upstream request");

--- a/workspace/data-proxy/src/modules/lighter/errors.ts
+++ b/workspace/data-proxy/src/modules/lighter/errors.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+export class FailedToHandleLighterRequestError extends Data.TaggedError(
+	"FailedToHandleLighterRequestError",
+)<{ error: string; status: number }> {
+	message = `Lighter error: ${this.error}`;
+}

--- a/workspace/data-proxy/src/modules/lighter/lighter.test.ts
+++ b/workspace/data-proxy/src/modules/lighter/lighter.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Duration, Effect, LogLevel, Logger } from "effect";
+import type { Route } from "../../config/config-parser";
+import type { LighterModuleConfig } from "../../config/lighter-module-config";
+import { HAS_PRICE_KEY } from "../../constants";
+import { ModuleService } from "../module";
+import { LighterModuleService } from "./lighter";
+import { buildSubscribeFrame } from "./ws-client";
+
+const innerTicker = (symbol: string) => ({
+	s: symbol,
+	a: { price: "63327.1", size: "0.05874" },
+	b: { price: "63327.0", size: "0.28342" },
+	last_updated_at: 1780940152376949,
+});
+
+const tickerMessage = (marketId: number, symbol: string) =>
+	JSON.stringify({
+		channel: `ticker:${marketId}`,
+		ticker: innerTicker(symbol),
+		timestamp: 1780940152623,
+		type: "update/ticker",
+	});
+
+const routeFor = (fetchFromModule: string): Route =>
+	({
+		type: "lighter",
+		moduleName: "lighter",
+		fetchFromModule,
+		path: "/price/:markets",
+		method: ["GET"],
+	}) as unknown as Route;
+
+class FakeWebSocket extends EventTarget {
+	static readonly OPEN = 1;
+	static readonly CLOSED = 3;
+	static instances: FakeWebSocket[] = [];
+
+	url: string;
+	readyState = 0;
+	sent: string[] = [];
+
+	constructor(url: string) {
+		super();
+		this.url = url;
+		FakeWebSocket.instances.push(this);
+	}
+
+	send(data: string): void {
+		this.sent.push(data);
+	}
+
+	close(): void {
+		if (this.readyState === FakeWebSocket.CLOSED) return;
+		this.readyState = FakeWebSocket.CLOSED;
+		this.dispatchEvent(new Event("close"));
+	}
+
+	triggerOpen(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.dispatchEvent(new Event("open"));
+	}
+
+	triggerMessage(data: string): void {
+		this.dispatchEvent(new MessageEvent("message", { data }));
+	}
+}
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+const baseConfig: LighterModuleConfig = {
+	name: "lighter",
+	type: "lighter",
+	wsUrl: "wss://lighter.test/stream",
+	subscriptionMarketIds: [],
+	maxMarketsPerRequest: 100,
+	keepaliveInterval: Duration.seconds(60),
+	reconnectMaxBackoff: Duration.seconds(30),
+	reconnectStableThreshold: Duration.seconds(30),
+	marketsCleanupTtl: Duration.hours(1),
+	marketsCleanupInterval: Duration.seconds(30),
+};
+
+const originalWebSocket = globalThis.WebSocket;
+
+beforeEach(() => {
+	FakeWebSocket.instances = [];
+	globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+	globalThis.WebSocket = originalWebSocket;
+});
+
+const quiet = <A, E>(effect: Effect.Effect<A, E>) =>
+	effect.pipe(Logger.withMinimumLogLevel(LogLevel.None));
+
+const buildService = (config: LighterModuleConfig) =>
+	Effect.runPromise(
+		quiet(ModuleService.pipe(Effect.provide(LighterModuleService(config)))),
+	);
+
+describe("LighterModuleService", () => {
+	it("subscribes seeded markets, caches a delivered ticker, and serves it in request order", async () => {
+		const service = await buildService({
+			...baseConfig,
+			subscriptionMarketIds: [1],
+		});
+		await Effect.runPromise(quiet(service.start()));
+		await flush();
+
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		// The seeded market's subscribe frame actually went out.
+		expect(ws.sent).toContain(buildSubscribeFrame(1));
+
+		ws.triggerMessage(tickerMessage(1, "BTC"));
+		await flush();
+
+		const response = await Effect.runPromise(
+			service.handleRequest(routeFor("1,NOPE"), {}, new Request("http://x")),
+		);
+		expect(response.status).toBe(200);
+		// "1" resolves to a price; "NOPE" is not a market id, so it short-circuits to a miss.
+		expect(await response.json()).toEqual([
+			{ marketId: "1", ...innerTicker("BTC"), [HAS_PRICE_KEY]: true },
+			{ marketId: "NOPE", [HAS_PRICE_KEY]: false },
+		]);
+	});
+
+	it("subscribes a market requested for the first time and resolves once its ticker lands", async () => {
+		const service = await buildService(baseConfig);
+		await Effect.runPromise(quiet(service.start()));
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		// Market 2 was not seeded; the request itself drives the subscription, then
+		// waits on the cache. Deliver the ticker while that wait is in flight.
+		const responsePromise = Effect.runPromise(
+			service.handleRequest(routeFor("2"), {}, new Request("http://x")),
+		);
+		await flush();
+		expect(ws.sent).toContain(buildSubscribeFrame(2));
+
+		ws.triggerMessage(tickerMessage(2, "ETH"));
+		const response = await responsePromise;
+
+		expect(await response.json()).toEqual([
+			{ marketId: "2", ...innerTicker("ETH"), [HAS_PRICE_KEY]: true },
+		]);
+	});
+
+	it("rejects a request over maxMarketsPerRequest with 400", async () => {
+		const service = await buildService({
+			...baseConfig,
+			maxMarketsPerRequest: 1,
+		});
+
+		const response = await Effect.runPromise(
+			service.handleRequest(routeFor("1,2"), {}, new Request("http://x")),
+		);
+
+		expect(response.status).toBe(400);
+	});
+});

--- a/workspace/data-proxy/src/modules/lighter/lighter.test.ts
+++ b/workspace/data-proxy/src/modules/lighter/lighter.test.ts
@@ -154,6 +154,38 @@ describe("LighterModuleService", () => {
 		]);
 	});
 
+	it("stops vouching for cached prices once the socket has errored", async () => {
+		const service = await buildService({
+			...baseConfig,
+			subscriptionMarketIds: [1],
+		});
+		await Effect.runPromise(quiet(service.start()));
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+		ws.triggerMessage(tickerMessage(1, "BTC"));
+		await flush();
+
+		const fresh = await Effect.runPromise(
+			service.handleRequest(routeFor("1"), {}, new Request("http://x")),
+		);
+		expect((await fresh.json())[0][HAS_PRICE_KEY]).toBe(true);
+
+		// Socket drops; the ws-client reports hasError until it reconnects.
+		ws.close();
+		await flush();
+
+		const afterError = await Effect.runPromise(
+			service.handleRequest(routeFor("1"), {}, new Request("http://x")),
+		);
+		// Market 1 is still cached, but the unhealthy socket means it is no longer
+		// presented as a live price.
+		expect(await afterError.json()).toEqual([
+			{ marketId: "1", [HAS_PRICE_KEY]: false },
+		]);
+	});
+
 	it("rejects a request over maxMarketsPerRequest with 400", async () => {
 		const service = await buildService({
 			...baseConfig,

--- a/workspace/data-proxy/src/modules/lighter/lighter.ts
+++ b/workspace/data-proxy/src/modules/lighter/lighter.ts
@@ -98,6 +98,9 @@ export const LighterModuleService = (config: LighterModuleConfig) =>
 					}));
 
 					const now = yield* Clock.currentTimeMillis;
+					// When the socket has errored its cached prices may be stale, so
+					// do not vouch for them (mirrors the hydromancer module).
+					const socketHealthy = !(yield* ws.hasError());
 					const newMarketIds: number[] = [];
 					for (const { marketId } of requested) {
 						if (marketId === null) continue;
@@ -136,7 +139,7 @@ export const LighterModuleService = (config: LighterModuleConfig) =>
 						const { token } = requested[i];
 						const result = results[i];
 
-						if (Either.isLeft(result)) {
+						if (Either.isLeft(result) || !socketHealthy) {
 							prices.push({ marketId: token, [HAS_PRICE_KEY]: false });
 						} else {
 							prices.push({

--- a/workspace/data-proxy/src/modules/lighter/lighter.ts
+++ b/workspace/data-proxy/src/modules/lighter/lighter.ts
@@ -1,0 +1,166 @@
+import { Clock, Effect, Either, Layer, MutableHashMap } from "effect";
+import type { Route } from "../../config/config-parser";
+import type { LighterModuleConfig } from "../../config/lighter-module-config";
+import { HAS_PRICE_KEY } from "../../constants";
+import { createErrorResponse } from "../../controllers/create-error-response";
+import { forkIdleCleanup } from "../../utils/idle-cleanup";
+import { replaceParams } from "../../utils/replace-params";
+import { FailedToHandleRequest, ModuleService } from "../module";
+import { FailedToGetPriceError, createPriceCache } from "../shared/price-cache";
+import { FailedToHandleLighterRequestError } from "./errors";
+import { type LighterPriceFrame, createLighterWS } from "./ws-client";
+
+type LighterPriceEntry =
+	| ({ marketId: string } & LighterPriceFrame & { [HAS_PRICE_KEY]: true })
+	| { marketId: string; [HAS_PRICE_KEY]: false };
+
+// Request tokens are Lighter numeric market ids (e.g. "1" for BTC). A token that
+// is not a non-negative integer can never name a market, so it resolves to a miss.
+const parseMarketId = (token: string): number | null => {
+	const id = Number(token);
+	return Number.isInteger(id) && id >= 0 ? id : null;
+};
+
+export const LighterModuleService = (config: LighterModuleConfig) =>
+	Layer.effect(
+		ModuleService,
+		Effect.gen(function* () {
+			yield* Effect.logInfo("Initializing Lighter module", {
+				name: config.name,
+				wsUrl: config.wsUrl,
+			});
+
+			const cache = yield* createPriceCache<number, LighterPriceFrame>();
+			const ws = yield* createLighterWS(config, cache);
+			// Market id -> timestamp of the last request, drives the idle cleanup pass.
+			const lastRequestToMarketId = MutableHashMap.empty<number, number>();
+
+			const start = () =>
+				Effect.gen(function* () {
+					yield* Effect.logInfo("Starting Lighter module", {
+						name: config.name,
+					});
+
+					yield* ws.start();
+
+					if (config.subscriptionMarketIds.length > 0) {
+						const now = yield* Clock.currentTimeMillis;
+						for (const marketId of config.subscriptionMarketIds) {
+							MutableHashMap.set(lastRequestToMarketId, marketId, now);
+						}
+						yield* ws.subscribe(config.subscriptionMarketIds);
+					}
+
+					yield* forkIdleCleanup({
+						lastRequest: lastRequestToMarketId,
+						ttl: config.marketsCleanupTtl,
+						interval: config.marketsCleanupInterval,
+						onExpire: (marketId) =>
+							Effect.gen(function* () {
+								yield* Effect.logInfo("Cleaning up idle market", { marketId });
+								yield* cache.deletePrice(marketId);
+								yield* ws.unsubscribe([marketId]);
+							}),
+					});
+				}).pipe(Effect.annotateLogs("_name", "lighter"));
+
+			const handleRequest = (
+				route: Route,
+				params: Record<string, string>,
+				_request: Request,
+			) =>
+				Effect.gen(function* () {
+					if (route.type !== "lighter") {
+						return yield* Effect.fail(
+							new FailedToHandleRequest({
+								msg: "Route is not a Lighter module",
+							}),
+						);
+					}
+
+					const requestedTokens = replaceParams(route.fetchFromModule, params)
+						.split(",")
+						.map((token) => token.trim())
+						.filter((token) => token.length > 0);
+
+					if (requestedTokens.length > config.maxMarketsPerRequest) {
+						return yield* Effect.fail(
+							new FailedToHandleLighterRequestError({
+								error: `Too many markets, max is ${config.maxMarketsPerRequest} but got ${requestedTokens.length}`,
+								status: 400,
+							}),
+						);
+					}
+
+					const requested = requestedTokens.map((token) => ({
+						token,
+						marketId: parseMarketId(token),
+					}));
+
+					const now = yield* Clock.currentTimeMillis;
+					const newMarketIds: number[] = [];
+					for (const { marketId } of requested) {
+						if (marketId === null) continue;
+						if (!MutableHashMap.has(lastRequestToMarketId, marketId)) {
+							newMarketIds.push(marketId);
+						}
+						MutableHashMap.set(lastRequestToMarketId, marketId, now);
+					}
+
+					if (newMarketIds.length > 0) {
+						yield* ws.subscribe(newMarketIds);
+					}
+
+					// Subscriptions are in-flight; resolve every requested market concurrently.
+					// A token that is not a market id can never land in the cache, so it
+					// short-circuits to a miss instead of blocking on the wait.
+					const results = yield* Effect.forEach(
+						requested,
+						({ token, marketId }) => {
+							if (marketId === null) {
+								return Effect.succeed(
+									Either.left(
+										new FailedToGetPriceError({
+											error: `Invalid market id ${token}`,
+										}),
+									),
+								);
+							}
+							return Effect.either(cache.getOrWaitPrice(marketId));
+						},
+						{ concurrency: "unbounded" },
+					);
+
+					const prices: LighterPriceEntry[] = [];
+					for (let i = 0; i < requested.length; i++) {
+						const { token } = requested[i];
+						const result = results[i];
+
+						if (Either.isLeft(result)) {
+							prices.push({ marketId: token, [HAS_PRICE_KEY]: false });
+						} else {
+							prices.push({
+								marketId: token,
+								...result.right,
+								[HAS_PRICE_KEY]: true,
+							});
+						}
+					}
+
+					return new Response(JSON.stringify(prices), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}).pipe(
+					Effect.withSpan("handleLighterRequest"),
+					Effect.catchAll((error) =>
+						Effect.succeed(createErrorResponse(error, error.status)),
+					),
+				);
+
+			return {
+				start,
+				handleRequest,
+			};
+		}),
+	);

--- a/workspace/data-proxy/src/modules/lighter/lighter.ts
+++ b/workspace/data-proxy/src/modules/lighter/lighter.ts
@@ -98,8 +98,6 @@ export const LighterModuleService = (config: LighterModuleConfig) =>
 					}));
 
 					const now = yield* Clock.currentTimeMillis;
-					// When the socket has errored its cached prices may be stale, so
-					// do not vouch for them (mirrors the hydromancer module).
 					const socketHealthy = !(yield* ws.hasError());
 					const newMarketIds: number[] = [];
 					for (const { marketId } of requested) {

--- a/workspace/data-proxy/src/modules/lighter/ws-client.test.ts
+++ b/workspace/data-proxy/src/modules/lighter/ws-client.test.ts
@@ -1,0 +1,377 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Duration, Effect, Fiber, LogLevel, Logger, Schedule } from "effect";
+import type { LighterModuleConfig } from "../../config/lighter-module-config";
+import { createPriceCache } from "../shared/price-cache";
+import {
+	type LighterPriceFrame,
+	buildSubscribeFrame,
+	buildUnsubscribeFrame,
+	createLighterWS,
+	parseInboundFrame,
+} from "./ws-client";
+
+const PING = JSON.stringify({ type: "ping" });
+const PONG = JSON.stringify({ type: "pong" });
+
+const innerTicker = (symbol: string) => ({
+	s: symbol,
+	a: { price: "63327.1", size: "0.05874" },
+	b: { price: "63327.0", size: "0.28342" },
+	last_updated_at: 1780940152376949,
+});
+
+const tickerMessage = (
+	marketId: number,
+	symbol: string,
+	type: "subscribed/ticker" | "update/ticker" = "update/ticker",
+) =>
+	JSON.stringify({
+		channel: `ticker:${marketId}`,
+		last_updated_at: 1780940152376949,
+		nonce: 14176467251,
+		ticker: innerTicker(symbol),
+		timestamp: 1780940152623,
+		type,
+	});
+
+describe("buildSubscribeFrame / buildUnsubscribeFrame", () => {
+	it("sends the ticker channel with a slash separator", () => {
+		expect(JSON.parse(buildSubscribeFrame(1))).toEqual({
+			type: "subscribe",
+			channel: "ticker/1",
+		});
+		expect(JSON.parse(buildUnsubscribeFrame(42))).toEqual({
+			type: "unsubscribe",
+			channel: "ticker/42",
+		});
+	});
+});
+
+describe("parseInboundFrame", () => {
+	it("extracts market id and verbatim frame from an update/ticker", () => {
+		expect(parseInboundFrame(tickerMessage(1, "BTC"))).toEqual({
+			kind: "ticker",
+			marketId: 1,
+			frame: innerTicker("BTC"),
+		});
+	});
+
+	it("treats the subscribed/ticker snapshot the same as an update", () => {
+		const parsed = parseInboundFrame(
+			tickerMessage(2, "ETH", "subscribed/ticker"),
+		);
+		expect(parsed).toEqual({
+			kind: "ticker",
+			marketId: 2,
+			frame: innerTicker("ETH"),
+		});
+	});
+
+	it("classifies a keepalive ping", () => {
+		expect(parseInboundFrame(JSON.stringify({ type: "ping" }))).toEqual({
+			kind: "ping",
+		});
+	});
+
+	it("returns null for the connected control frame", () => {
+		expect(
+			parseInboundFrame(JSON.stringify({ session_id: "x", type: "connected" })),
+		).toBeNull();
+	});
+
+	it("returns null for an error frame", () => {
+		expect(
+			parseInboundFrame(
+				JSON.stringify({ error: { code: 30005, message: "Invalid Channel" } }),
+			),
+		).toBeNull();
+	});
+
+	it("returns null for malformed JSON", () => {
+		expect(parseInboundFrame("not json")).toBeNull();
+	});
+});
+
+class FakeWebSocket extends EventTarget {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: FakeWebSocket[] = [];
+	static sendImpl?: (instance: FakeWebSocket, data: string) => void;
+
+	url: string;
+	readyState = FakeWebSocket.CONNECTING;
+	sent: string[] = [];
+
+	constructor(url: string) {
+		super();
+		this.url = url;
+		FakeWebSocket.instances.push(this);
+	}
+
+	send(data: string): void {
+		if (FakeWebSocket.sendImpl) {
+			FakeWebSocket.sendImpl(this, data);
+			return;
+		}
+		this.sent.push(data);
+	}
+
+	close(): void {
+		if (this.readyState === FakeWebSocket.CLOSED) return;
+		this.readyState = FakeWebSocket.CLOSED;
+		this.dispatchEvent(new Event("close"));
+	}
+
+	triggerOpen(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.dispatchEvent(new Event("open"));
+	}
+
+	triggerMessage(data: string): void {
+		this.dispatchEvent(new MessageEvent("message", { data }));
+	}
+
+	triggerClose(): void {
+		if (this.readyState === FakeWebSocket.CLOSED) return;
+		this.readyState = FakeWebSocket.CLOSED;
+		this.dispatchEvent(new Event("close"));
+	}
+}
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+const baseConfig: LighterModuleConfig = {
+	name: "lighter",
+	type: "lighter",
+	wsUrl: "wss://lighter.test/stream",
+	subscriptionMarketIds: [],
+	maxMarketsPerRequest: 100,
+	keepaliveInterval: Duration.seconds(60),
+	reconnectMaxBackoff: Duration.seconds(30),
+	reconnectStableThreshold: Duration.seconds(30),
+	marketsCleanupTtl: Duration.hours(1),
+	marketsCleanupInterval: Duration.seconds(30),
+};
+
+const originalWebSocket = globalThis.WebSocket;
+
+beforeEach(() => {
+	FakeWebSocket.instances = [];
+	FakeWebSocket.sendImpl = undefined;
+	globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+	globalThis.WebSocket = originalWebSocket;
+});
+
+const startService = (
+	config: LighterModuleConfig,
+	preSubscribed: number[] = [],
+	options?: Parameters<typeof createLighterWS>[2],
+) =>
+	Effect.gen(function* () {
+		const cache = yield* createPriceCache<number, LighterPriceFrame>();
+		const ws = yield* createLighterWS(
+			config,
+			cache,
+			options ?? { reconnectSchedule: Schedule.spaced(Duration.minutes(10)) },
+		);
+		if (preSubscribed.length > 0) {
+			yield* ws.subscribe(preSubscribed);
+		}
+		const fiber = yield* ws.start();
+		return { cache, ws, fiber };
+	}).pipe(Logger.withMinimumLogLevel(LogLevel.None));
+
+describe("createLighterWS", () => {
+	it("opens the configured WS and subscribes desired markets on open", async () => {
+		const { fiber } = await Effect.runPromise(startService(baseConfig, [1, 2]));
+		await flush();
+
+		expect(FakeWebSocket.instances.length).toBe(1);
+		const ws = FakeWebSocket.instances[0];
+		expect(ws.url).toBe("wss://lighter.test/stream");
+
+		ws.triggerOpen();
+		await flush();
+
+		expect(ws.sent).toEqual([buildSubscribeFrame(1), buildSubscribeFrame(2)]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("writes an inbound ticker into the cache keyed by market id", async () => {
+		const { cache, fiber } = await Effect.runPromise(
+			startService(baseConfig, [1]),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		ws.triggerMessage(tickerMessage(1, "BTC"));
+		await flush();
+
+		expect(cache.size()).toBe(1);
+		const price = await Effect.runPromise(cache.getOrWaitPrice(1));
+		expect(price).toEqual(innerTicker("BTC"));
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("drops an inbound ticker for a market not in the desired set", async () => {
+		const { cache, fiber } = await Effect.runPromise(
+			startService(baseConfig, [1]),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		ws.triggerMessage(tickerMessage(2, "ETH"));
+		await flush();
+
+		expect(cache.size()).toBe(0);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("replies pong to a server ping", async () => {
+		const { fiber } = await Effect.runPromise(startService(baseConfig, [1]));
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+		ws.sent.length = 0;
+
+		ws.triggerMessage(JSON.stringify({ type: "ping" }));
+		await flush();
+
+		expect(ws.sent).toEqual([PONG]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("sends keepalive pings on the configured interval", async () => {
+		const { fiber } = await Effect.runPromise(
+			startService(
+				{ ...baseConfig, keepaliveInterval: Duration.millis(10) },
+				[1],
+			),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+		ws.sent.length = 0;
+
+		await new Promise<void>((r) => setTimeout(r, 50));
+
+		expect(ws.sent.filter((frame) => frame === PING).length).toBeGreaterThan(0);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("subscribe is idempotent: a duplicate market id sends no extra frame", async () => {
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, [1]),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+		expect(ws.sent).toEqual([buildSubscribeFrame(1)]);
+
+		await Effect.runPromise(service.subscribe([1]));
+		await Effect.runPromise(service.subscribe([1]));
+		await flush();
+
+		expect(ws.sent).toEqual([buildSubscribeFrame(1)]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("unsubscribe is idempotent and removes from the desired set", async () => {
+		const { ws: service, fiber } = await Effect.runPromise(
+			startService(baseConfig, [1]),
+		);
+		await flush();
+		const ws = FakeWebSocket.instances[0];
+		ws.triggerOpen();
+		await flush();
+
+		// Unknown market id: no frame.
+		await Effect.runPromise(service.unsubscribe([2]));
+		await flush();
+		expect(ws.sent).toEqual([buildSubscribeFrame(1)]);
+
+		await Effect.runPromise(service.unsubscribe([1]));
+		await flush();
+		expect(ws.sent).toEqual([buildSubscribeFrame(1), buildUnsubscribeFrame(1)]);
+
+		// Repeat: already removed, no frame.
+		await Effect.runPromise(service.unsubscribe([1]));
+		await flush();
+		expect(ws.sent).toEqual([buildSubscribeFrame(1), buildUnsubscribeFrame(1)]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("reconnects after a close and re-subscribes every desired market", async () => {
+		const { fiber } = await Effect.runPromise(
+			startService(baseConfig, [1, 2], {
+				reconnectSchedule: Schedule.spaced(Duration.millis(10)),
+			}),
+		);
+		await flush();
+		const ws1 = FakeWebSocket.instances[0];
+		ws1.triggerOpen();
+		await flush();
+		expect(ws1.sent).toEqual([buildSubscribeFrame(1), buildSubscribeFrame(2)]);
+
+		ws1.triggerClose();
+		await new Promise<void>((r) => setTimeout(r, 40));
+
+		expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+		const ws2 = FakeWebSocket.instances[1];
+		expect(ws2).not.toBe(ws1);
+		ws2.triggerOpen();
+		await flush();
+
+		expect(ws2.sent).toEqual([buildSubscribeFrame(1), buildSubscribeFrame(2)]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+
+	it("recovers from a send error by closing the socket and reconnecting", async () => {
+		FakeWebSocket.sendImpl = (instance, data) => {
+			if (FakeWebSocket.instances.indexOf(instance) === 0) {
+				throw new Error("send-blew-up");
+			}
+			instance.sent.push(data);
+		};
+
+		const { fiber } = await Effect.runPromise(
+			startService(baseConfig, [1], {
+				reconnectSchedule: Schedule.spaced(Duration.millis(10)),
+			}),
+		);
+		await flush();
+		const ws1 = FakeWebSocket.instances[0];
+		ws1.triggerOpen();
+		await flush();
+
+		await new Promise<void>((r) => setTimeout(r, 40));
+		expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+		const ws2 = FakeWebSocket.instances[1];
+		ws2.triggerOpen();
+		await flush();
+
+		expect(ws2.sent).toEqual([buildSubscribeFrame(1)]);
+
+		await Effect.runPromise(Fiber.interrupt(fiber));
+	});
+});

--- a/workspace/data-proxy/src/modules/lighter/ws-client.ts
+++ b/workspace/data-proxy/src/modules/lighter/ws-client.ts
@@ -85,6 +85,8 @@ export interface LighterWS {
 	subscribe(marketIds: number[]): Effect.Effect<void, never, never>;
 	/** Removes the market ids from the desired set and sends an unsubscribe frame for each removed one if connected. Idempotent. */
 	unsubscribe(marketIds: number[]): Effect.Effect<void, never, never>;
+	/** True while there is no open connection, so cached prices may be stale. */
+	hasError(): Effect.Effect<boolean, never, never>;
 }
 
 export interface CreateLighterWSOptions {
@@ -234,5 +236,9 @@ export const createLighterWS = (
 		);
 		const start = () => cachedStart;
 
-		return { start, subscribe, unsubscribe } satisfies LighterWS;
+		// The socket is healthy only while a connection is open; currentWS is
+		// nulled on every disconnect and reset on open.
+		const hasError = () => Effect.sync(() => currentWS === null);
+
+		return { start, subscribe, unsubscribe, hasError } satisfies LighterWS;
 	});

--- a/workspace/data-proxy/src/modules/lighter/ws-client.ts
+++ b/workspace/data-proxy/src/modules/lighter/ws-client.ts
@@ -1,0 +1,238 @@
+import {
+	Deferred,
+	Duration,
+	Effect,
+	type Fiber,
+	MutableHashMap,
+	Option,
+	Runtime,
+	Schedule,
+} from "effect";
+import type { LighterModuleConfig } from "../../config/lighter-module-config";
+
+/** A Lighter `ticker` payload. Always carries the symbol in `s`; the best
+ * bid/ask sit in `b`/`a` and are relayed verbatim. */
+export interface LighterPriceFrame {
+	s: string;
+	[key: string]: unknown;
+}
+
+/** The subset of the shared price cache the WS daemon writes to, keyed by market id. */
+interface PriceSink {
+	setPrice: (key: number, price: LighterPriceFrame) => Effect.Effect<void>;
+}
+
+const PING_FRAME = JSON.stringify({ type: "ping" });
+const PONG_FRAME = JSON.stringify({ type: "pong" });
+
+export const buildSubscribeFrame = (marketId: number): string =>
+	JSON.stringify({ type: "subscribe", channel: `ticker/${marketId}` });
+
+export const buildUnsubscribeFrame = (marketId: number): string =>
+	JSON.stringify({ type: "unsubscribe", channel: `ticker/${marketId}` });
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+/** The inbound `channel` is `ticker:{id}` (colon) even though subscribe sends
+ * `ticker/{id}` (slash); accept either separator. */
+const parseMarketId = (channel: unknown): number | null => {
+	if (typeof channel !== "string") return null;
+	const last = channel.split(/[:/]/).pop();
+	if (last === undefined) return null;
+	const id = Number(last);
+	return Number.isInteger(id) ? id : null;
+};
+
+export type ParsedInbound =
+	| { kind: "ping" }
+	| { kind: "ticker"; marketId: number | null; frame: LighterPriceFrame };
+
+/** Classifies an inbound message: a keepalive ping, a ticker payload (snapshot
+ * `subscribed/ticker` or `update/ticker`, both carry `.ticker`), or null for
+ * control frames like `{type:connected}`, error frames, and malformed input. */
+export const parseInboundFrame = (raw: string): ParsedInbound | null => {
+	let json: unknown;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	if (!isRecord(json)) return null;
+	if (json.type === "ping") return { kind: "ping" };
+
+	const ticker = json.ticker;
+	if (isRecord(ticker) && typeof ticker.s === "string") {
+		return {
+			kind: "ticker",
+			marketId: parseMarketId(json.channel),
+			frame: ticker as LighterPriceFrame,
+		};
+	}
+	return null;
+};
+
+export const defaultReconnectSchedule = (config: LighterModuleConfig) =>
+	Schedule.exponential(Duration.seconds(1)).pipe(
+		Schedule.either(Schedule.spaced(config.reconnectMaxBackoff)),
+		Schedule.resetAfter(config.reconnectStableThreshold),
+	);
+
+export interface LighterWS {
+	/** Forks the WS daemon (reconnect with backoff, resubscribe on open) and the keepalive daemon. */
+	start(): Effect.Effect<Fiber.RuntimeFiber<unknown, unknown>, never, never>;
+	/** Adds the market ids to the desired set and sends a subscribe frame for each new one if connected. Idempotent. */
+	subscribe(marketIds: number[]): Effect.Effect<void, never, never>;
+	/** Removes the market ids from the desired set and sends an unsubscribe frame for each removed one if connected. Idempotent. */
+	unsubscribe(marketIds: number[]): Effect.Effect<void, never, never>;
+}
+
+export interface CreateLighterWSOptions {
+	reconnectSchedule?: Schedule.Schedule<unknown, unknown, never>;
+}
+
+export const createLighterWS = (
+	config: LighterModuleConfig,
+	cache: PriceSink,
+	options?: CreateLighterWSOptions,
+): Effect.Effect<LighterWS, never, never> =>
+	Effect.gen(function* () {
+		const runtime = yield* Effect.runtime<never>();
+		const desiredMarkets = MutableHashMap.empty<number, true>();
+		let currentWS: WebSocket | null = null;
+		const schedule =
+			options?.reconnectSchedule ?? defaultReconnectSchedule(config);
+
+		const trySend = (frame: string) =>
+			Effect.gen(function* () {
+				const ws = currentWS;
+				if (ws === null || ws.readyState !== WebSocket.OPEN) return;
+				try {
+					ws.send(frame);
+				} catch (err) {
+					yield* Effect.logWarning("Lighter WS send failed", {
+						error: String(err),
+					});
+					try {
+						ws.close();
+					} catch {
+						// best-effort; the close listener will trigger the reconnect loop.
+					}
+				}
+			});
+
+		const subscribe = (marketIds: number[]) =>
+			Effect.gen(function* () {
+				for (const marketId of marketIds) {
+					if (Option.isSome(MutableHashMap.get(desiredMarkets, marketId)))
+						continue;
+					MutableHashMap.set(desiredMarkets, marketId, true);
+					yield* trySend(buildSubscribeFrame(marketId));
+				}
+			});
+
+		const unsubscribe = (marketIds: number[]) =>
+			Effect.gen(function* () {
+				for (const marketId of marketIds) {
+					if (Option.isNone(MutableHashMap.get(desiredMarkets, marketId)))
+						continue;
+					MutableHashMap.remove(desiredMarkets, marketId);
+					yield* trySend(buildUnsubscribeFrame(marketId));
+				}
+			});
+
+		const handleOpen = (ws: WebSocket) =>
+			Effect.gen(function* () {
+				yield* Effect.logInfo("Lighter WS open", { name: config.name });
+				currentWS = ws;
+				for (const [marketId] of desiredMarkets) {
+					yield* trySend(buildSubscribeFrame(marketId));
+				}
+			});
+
+		const handleInboundMessage = (raw: string) =>
+			Effect.gen(function* () {
+				const parsed = parseInboundFrame(raw);
+				if (!parsed) return;
+				if (parsed.kind === "ping") {
+					yield* trySend(PONG_FRAME);
+					return;
+				}
+				// Drop frames with no parseable id, or for a market we have since
+				// unsubscribed (post-unsubscribe race).
+				if (
+					parsed.marketId === null ||
+					Option.isNone(MutableHashMap.get(desiredMarkets, parsed.marketId))
+				) {
+					return;
+				}
+				yield* cache.setPrice(parsed.marketId, parsed.frame);
+			});
+
+		const handleDisconnect = (
+			reason: "close" | "error",
+			closed: Deferred.Deferred<void, "close" | "error">,
+		) =>
+			Effect.gen(function* () {
+				yield* Effect.logWarning("Lighter WS disconnected", { reason });
+				currentWS = null;
+				yield* Deferred.fail(closed, reason);
+			});
+
+		const connectOnce = Effect.gen(function* () {
+			const closed = yield* Deferred.make<void, "close" | "error">();
+
+			yield* Effect.logInfo("Lighter WS connecting", { name: config.name });
+
+			const ws = yield* Effect.acquireRelease(
+				Effect.sync(() => new WebSocket(config.wsUrl)),
+				(socket) =>
+					Effect.sync(() => {
+						if (socket.readyState !== WebSocket.CLOSED) {
+							socket.close();
+						}
+					}),
+			);
+
+			ws.addEventListener("open", () => {
+				Runtime.runSync(runtime, handleOpen(ws));
+			});
+			ws.addEventListener("message", (event) => {
+				if (typeof event.data !== "string") return;
+				Runtime.runSync(runtime, handleInboundMessage(event.data));
+			});
+			ws.addEventListener("close", () => {
+				Runtime.runSync(runtime, handleDisconnect("close", closed));
+			});
+			ws.addEventListener("error", () => {
+				Runtime.runSync(runtime, handleDisconnect("error", closed));
+			});
+
+			yield* Deferred.await(closed);
+		}).pipe(Effect.scoped);
+
+		const loop = connectOnce.pipe(
+			Effect.tapError((error) =>
+				Effect.logWarning("Lighter WS connect failed", {
+					error: String(error),
+				}),
+			),
+			Effect.retry(schedule),
+		);
+
+		// Lighter closes a connection with no client frames for 2 minutes; ping on a
+		// shorter cadence. trySend no-ops while disconnected, so this is harmless then.
+		const keepaliveLoop = trySend(PING_FRAME).pipe(
+			Effect.schedule(Schedule.spaced(config.keepaliveInterval)),
+		);
+
+		const cachedStart = yield* Effect.cached(
+			Effect.gen(function* () {
+				yield* Effect.forkDaemon(keepaliveLoop);
+				return yield* Effect.forkDaemon(loop);
+			}),
+		);
+		const start = () => cachedStart;
+
+		return { start, subscribe, unsubscribe } satisfies LighterWS;
+	});

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -12,6 +12,7 @@ import { BinanceModuleService } from "./modules/binance/binance";
 import { ChainlinkStreamsModuleService } from "./modules/chainlink-streams/chainlink-streams";
 import { DxFeedModuleService } from "./modules/dxfeed/dxfeed";
 import { HydromancerModuleService } from "./modules/hydromancer/hydromancer";
+import { LighterModuleService } from "./modules/lighter/lighter";
 import { LoTechModuleService } from "./modules/lo-tech/lo-tech";
 import { EmptyModuleService, ModuleService } from "./modules/module";
 import { PmInsightsModuleService } from "./modules/pm-insights/pm-insights";
@@ -62,6 +63,9 @@ export const startProxyServer = (
 				Match.when({ type: "binance" }, (m) =>
 					Layer.memoize(BinanceModuleService(m)),
 				),
+				Match.when({ type: "lighter" }, (m) =>
+					Layer.memoize(LighterModuleService(m)),
+				),
 				Match.exhaustive,
 			);
 
@@ -82,7 +86,8 @@ export const startProxyServer = (
 				route.type === "hydromancer" ||
 				route.type === "lo-tech" ||
 				route.type === "pm-insights" ||
-				route.type === "binance"
+				route.type === "binance" ||
+				route.type === "lighter"
 			) {
 				const moduleLayer = MutableHashMap.get(modules, route.moduleName);
 				if (Option.isNone(moduleLayer)) {


### PR DESCRIPTION
Add a price-relay module for Lighter's perp DEX, mirroring the existing websocket stream modules. Requests carry Lighter's numeric market ids directly (1 for BTC, 110 for NVDA); the module subscribes to `ticker/{id}` over one reconnecting websocket, caches each frame by market id, and returns one entry per requested id flagged with `__sedaHasPrice`. A proactive ping holds the connection under Lighter's two-minute idle timeout, and markets nobody is requesting are dropped by the shared idle-cleanup daemon. It relays public market data, so the module needs no credentials.

- The request contract is market-id-based (`/price/1,110`), unlike the symbol-based sibling modules. Callers map a symbol to its id out of band via Lighter's `/api/v1/orderBooks`.
- A non-integer token short-circuits to a miss; a valid-but-nonexistent numeric id just yields no price (Lighter replies with a harmless error frame and the socket stays up).
