### PR TITLE
Surface hydromancer REST fallback and WS reconnects in traces

### DIFF
--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
@@ -84,7 +84,9 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 						yield* Effect.logDebug(
 							"Hydromancer module received unsupported body, forwarding to REST",
 						);
-						return yield* executeHydromancerRestRequest(config, body);
+						return yield* executeHydromancerRestRequest(config, body).pipe(
+							Effect.annotateSpans("restFallbackReason", "unsupported-body"),
+						);
 					}
 
 					// We need to know if the request is for a single coin or a batch of coins as the response shape is different.
@@ -150,6 +152,11 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 						const restBatch = yield* fetchAssetContextsFromRest(
 							config,
 							toFetch,
+						).pipe(
+							Effect.annotateSpans(
+								"restFallbackReason",
+								socketHealthy ? "stale-cache" : "socket-error",
+							),
 						);
 						for (const coin of toFetch) {
 							const ctx = restBatch[coin];

--- a/workspace/data-proxy/src/modules/hydromancer/ws-client.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/ws-client.ts
@@ -198,7 +198,12 @@ export const createHydromancerWS = (
 			});
 
 			yield* Deferred.await(closed);
-		}).pipe(Effect.scoped);
+		}).pipe(
+			Effect.scoped,
+			Effect.withSpan("connectHydromancerWs", {
+				attributes: { name: config.name },
+			}),
+		);
 
 		const loop = connectOnce.pipe(
 			Effect.tapError((error) =>


### PR DESCRIPTION
The hydromancer module had no trace visibility into two operational events: when a request falls back to REST and when the upstream websocket reconnects. This tags the existing REST-fallback spans (`fetchAssetContextsFromRest`, `executeHydromancerRestRequest`) with the reason it fired via `annotateSpans`, and wraps each websocket connection attempt in a `connectHydromancerWs` span, so fallback rate and reconnect frequency are queryable instead of invisible.