### PR TITLE
LO:TECH support for multiple exchanges

### DIFF
--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "2.8.3",
+	"version": "2.9.0",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -341,9 +341,10 @@ describe("parseConfig", () => {
 							type: "lo-tech",
 							name: "lotech",
 							baseUrl: "wss://data.lo.tech/ws/v1",
-							exchange: "binance",
 							loTechApiKeyEnvKey: "LOTECH_API_KEY",
-							priceFeeds: [{ symbol: "BTC-USDT:SPOT", dataType: "PRICE" }],
+							priceFeeds: [
+								{ symbol: "NVDA", exchange: "us_equities", dataType: "PRICE" },
+							],
 						},
 					],
 				}),
@@ -365,9 +366,10 @@ describe("parseConfig", () => {
 							type: "lo-tech",
 							name: "lotech",
 							baseUrl: "wss://data.lo.tech/ws/v1",
-							exchange: "binance",
 							loTechApiKeyEnvKey: "LOTECH_API_KEY",
-							priceFeeds: [{ symbol: "BTC-USDT:SPOT", dataType: "PRICE" }],
+							priceFeeds: [
+								{ symbol: "NVDA", exchange: "us_equities", dataType: "PRICE" },
+							],
 						},
 					],
 				}),
@@ -379,6 +381,103 @@ describe("parseConfig", () => {
 				throw new Error(`expected lo-tech, got ${module.type}`);
 			}
 			expect(module.loTechApiKey).toBe("lo-tech-secret");
+			expect(module.priceFeeds[0]?.exchange).toBe("us_equities");
+			expect(module.supportedExchanges).toEqual(["us_equities", "futures"]);
+			process.env.LOTECH_API_KEY = undefined;
+		});
+
+		it("should reject a lo-tech module with an unsupported exchange", () => {
+			process.env.LOTECH_API_KEY = "lo-tech-secret";
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "lo-tech",
+							name: "lotech",
+							baseUrl: "wss://data.lo.tech/ws/v1",
+							loTechApiKeyEnvKey: "LOTECH_API_KEY",
+							priceFeeds: [
+								{
+									symbol: "BTC-USDT:SPOT",
+									exchange: "binance",
+									dataType: "PRICE",
+								},
+							],
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				'Unsupported LO:TECH exchange "binance". Supported exchanges: us_equities, futures',
+			);
+			process.env.LOTECH_API_KEY = undefined;
+		});
+
+		it("should resolve per-feed exchanges for a lo-tech module", () => {
+			process.env.LOTECH_API_KEY = "lo-tech-secret";
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "lo-tech",
+							name: "lotech",
+							baseUrl: "wss://data.lo.tech/ws/v1",
+							loTechApiKeyEnvKey: "LOTECH_API_KEY",
+							priceFeeds: [
+								{
+									symbol: "NVDA",
+									exchange: "us_equities",
+									dataType: "PRICE",
+								},
+								{
+									symbol: "BTC-USDT:SPOT",
+									exchange: "futures",
+									dataType: "PRICE",
+								},
+							],
+						},
+					],
+				}),
+			);
+
+			assertIsOkResult(result);
+			const module = result.value.config.modules[0];
+			if (module.type !== "lo-tech") {
+				throw new Error(`expected lo-tech, got ${module.type}`);
+			}
+			expect(module.priceFeeds).toEqual([
+				{ symbol: "NVDA", exchange: "us_equities", dataType: "PRICE" },
+				{ symbol: "BTC-USDT:SPOT", exchange: "futures", dataType: "PRICE" },
+			]);
+			process.env.LOTECH_API_KEY = undefined;
+		});
+
+		it("should reject a lo-tech module without exchange on each price feed", () => {
+			process.env.LOTECH_API_KEY = "lo-tech-secret";
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [],
+					modules: [
+						{
+							type: "lo-tech",
+							name: "lotech",
+							baseUrl: "wss://data.lo.tech/ws/v1",
+							loTechApiKeyEnvKey: "LOTECH_API_KEY",
+							priceFeeds: [{ symbol: "NVDA", dataType: "PRICE" }],
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				'.modules.0.priceFeeds.0.exchange: Invalid key: Expected "exchange" but received undefined',
+			);
 			process.env.LOTECH_API_KEY = undefined;
 		});
 

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -30,6 +30,7 @@ import {
 import {
 	type LoTechModuleRoute,
 	LoTechModuleRouteSchema,
+	resolveLoTechModule,
 	validateLoTechModuleRoute,
 } from "./lo-tech-module-config";
 import { type Modules, ModulesSchema } from "./module-config";
@@ -483,16 +484,24 @@ export const parseConfig = (
 							hydromancerApiKey,
 						} satisfies Modules);
 					}),
-					Match.when({ type: "lo-tech" }, (m) => {
-						const loTechApiKey = process.env[m.loTechApiKeyEnvKey];
-						if (!loTechApiKey) {
-							return Effect.fail(
-								`Module ${m.type} requires ${m.loTechApiKeyEnvKey} to be set`,
-							);
-						}
-						envSecrets.add(loTechApiKey);
-						return Effect.succeed({ ...m, loTechApiKey } satisfies Modules);
-					}),
+					Match.when({ type: "lo-tech" }, (m) =>
+						Effect.gen(function* () {
+							const loTechApiKey = process.env[m.loTechApiKeyEnvKey];
+							if (!loTechApiKey) {
+								return yield* Effect.fail(
+									`Module ${m.type} requires ${m.loTechApiKeyEnvKey} to be set`,
+								);
+							}
+
+							const resolvedModule = yield* resolveLoTechModule(m);
+
+							envSecrets.add(loTechApiKey);
+							return {
+								...resolvedModule,
+								loTechApiKey,
+							} satisfies Modules;
+						}),
+					),
 					Match.when({ type: "pm-insights" }, (m) => {
 						const email = process.env[m.emailEnvKey];
 						const password = process.env[m.passwordEnvKey];

--- a/workspace/data-proxy/src/config/lo-tech-module-config.ts
+++ b/workspace/data-proxy/src/config/lo-tech-module-config.ts
@@ -3,6 +3,18 @@ import * as v from "valibot";
 import { RouteSchema } from "./route-config";
 
 export const LO_TECH_DATA_TYPE_PRICE = "PRICE" as const;
+export const LO_TECH_EXCHANGE_PATH_PARAM = "exchange" as const;
+export const LO_TECH_EXCHANGE_US_EQUITIES = "us_equities" as const;
+export const LO_TECH_EXCHANGE_FUTURES = "futures" as const;
+
+export const DEFAULT_LO_TECH_SUPPORTED_EXCHANGES = [
+	LO_TECH_EXCHANGE_US_EQUITIES,
+	LO_TECH_EXCHANGE_FUTURES,
+] as const;
+
+export type LoTechExchange =
+	(typeof DEFAULT_LO_TECH_SUPPORTED_EXCHANGES)[number];
+
 export const LoTechDataTypeSchema = v.picklist([LO_TECH_DATA_TYPE_PRICE]);
 
 export type LoTechDataType = v.InferOutput<typeof LoTechDataTypeSchema>;
@@ -10,6 +22,8 @@ export type LoTechDataType = v.InferOutput<typeof LoTechDataTypeSchema>;
 export const LoTechModulePriceFeedSchema = v.object({
 	// LO:TECH normalized symbol, e.g. BTC-USDT:SPOT (see the symbology section in the LO:TECH API docs).
 	symbol: v.string(),
+	// LO:TECH exchange, e.g. us_equities or futures.
+	exchange: v.string(),
 	// Type of data to subscribe to.
 	dataType: v.optional(LoTechDataTypeSchema, LO_TECH_DATA_TYPE_PRICE),
 });
@@ -18,10 +32,17 @@ export type LoTechModulePriceFeed = v.InferOutput<
 	typeof LoTechModulePriceFeedSchema
 >;
 
+export type ResolvedLoTechModulePriceFeed = LoTechModulePriceFeed & {
+	exchange: string;
+};
+
 export const LoTechModuleConfigSchema = v.strictObject({
 	name: v.string(),
 	baseUrl: v.string(),
-	exchange: v.string(),
+	// List of supported exchanges.
+	supportedExchanges: v.optional(v.array(v.string()), [
+		...DEFAULT_LO_TECH_SUPPORTED_EXCHANGES,
+	]),
 	priceFeeds: v.array(LoTechModulePriceFeedSchema),
 	maxFeedsPerRequest: v.optional(v.number(), 100),
 	loTechApiKeyEnvKey: v.string(),
@@ -48,8 +69,9 @@ export const LoTechModuleConfigSchema = v.strictObject({
 });
 
 export interface LoTechModuleConfig
-	extends v.InferOutput<typeof LoTechModuleConfigSchema> {
+	extends Omit<v.InferOutput<typeof LoTechModuleConfigSchema>, "priceFeeds"> {
 	loTechApiKey: string;
+	priceFeeds: ResolvedLoTechModulePriceFeed[];
 }
 
 export const LoTechModuleRouteSchema = v.strictObject({
@@ -64,4 +86,43 @@ export type LoTechModuleRoute = v.InferOutput<typeof LoTechModuleRouteSchema>;
 export const validateLoTechModuleRoute = (_route: LoTechModuleRoute) =>
 	Effect.gen(function* () {
 		return yield* Effect.void;
+	});
+
+export const assertSupportedLoTechExchange = (
+	exchange: string,
+	supportedExchanges: readonly string[],
+): Effect.Effect<void, string> =>
+	supportedExchanges.includes(exchange)
+		? Effect.void
+		: Effect.fail(
+				`Unsupported LO:TECH exchange "${exchange}". Supported exchanges: ${supportedExchanges.join(", ")}`,
+			);
+
+export const resolveLoTechModule = (
+	module: v.InferOutput<typeof LoTechModuleConfigSchema>,
+): Effect.Effect<Omit<LoTechModuleConfig, "loTechApiKey">, string> =>
+	Effect.gen(function* () {
+		const { supportedExchanges } = module;
+
+		const priceFeeds: ResolvedLoTechModulePriceFeed[] = [];
+		for (const feed of module.priceFeeds) {
+			if (feed.exchange === undefined) {
+				return yield* Effect.fail(
+					`Module lo-tech requires "exchange" on each priceFeed`,
+				);
+			}
+
+			yield* assertSupportedLoTechExchange(feed.exchange, supportedExchanges);
+
+			priceFeeds.push({
+				symbol: feed.symbol,
+				dataType: feed.dataType,
+				exchange: feed.exchange,
+			});
+		}
+
+		return {
+			...module,
+			priceFeeds,
+		};
 	});

--- a/workspace/data-proxy/src/modules/lo-tech/lo-tech.test.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/lo-tech.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { FailedToHandleLoTechRequestError } from "./errors";
+import {
+	parsePriceFeedKey,
+	priceFeedKey,
+	resolveLoTechExchange,
+} from "./lo-tech";
+
+const moduleConfig = {
+	supportedExchanges: ["us_equities", "futures"],
+};
+
+describe("lo-tech price feed keys", () => {
+	it("should build and parse a composite exchange:symbol key", () => {
+		const key = priceFeedKey("us_equities", "NVDA");
+		expect(key).toBe("us_equities:NVDA");
+		expect(parsePriceFeedKey(key)).toEqual({
+			exchange: "us_equities",
+			symbol: "NVDA",
+		});
+	});
+});
+
+describe("resolveLoTechExchange", () => {
+	it("should use the path exchange when provided", () => {
+		expect(Effect.runSync(resolveLoTechExchange("futures", moduleConfig))).toBe(
+			"futures",
+		);
+	});
+
+	it("should fail when the exchange path parameter is missing", () => {
+		const result = Effect.runSync(
+			Effect.either(resolveLoTechExchange(undefined, moduleConfig)),
+		);
+
+		expect(result._tag).toBe("Left");
+		if (result._tag === "Left") {
+			expect(result.left).toBeInstanceOf(FailedToHandleLoTechRequestError);
+			expect(result.left.error).toBe(
+				'Missing required "exchange" path parameter',
+			);
+		}
+	});
+
+	it("should reject an unsupported path exchange", () => {
+		const result = Effect.runSync(
+			Effect.either(resolveLoTechExchange("invalid_exchange", moduleConfig)),
+		);
+
+		expect(result._tag).toBe("Left");
+		if (result._tag === "Left") {
+			expect(result.left).toBeInstanceOf(FailedToHandleLoTechRequestError);
+			expect(result.left.error).toBe(
+				'Unsupported LO:TECH exchange "invalid_exchange". Supported exchanges: us_equities, futures',
+			);
+		}
+	});
+});

--- a/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/lo-tech.ts
@@ -13,7 +13,9 @@ import {
 import type { Route } from "../../config/config-parser";
 import {
 	LO_TECH_DATA_TYPE_PRICE,
+	LO_TECH_EXCHANGE_PATH_PARAM,
 	type LoTechModuleConfig,
+	assertSupportedLoTechExchange,
 } from "../../config/lo-tech-module-config";
 import { HAS_PRICE_KEY } from "../../constants";
 import { createErrorResponse } from "../../controllers/create-error-response";
@@ -31,7 +33,51 @@ import type {
 import { LoTechSubscriptionFailureCode } from "./schema";
 import { makeLoTechWebSocketService } from "./ws-client";
 
-export type PriceFeedSymbol = string;
+export type PriceFeedKey = `${string}:${string}`;
+
+type PriceFeedSubscription = {
+	symbol: string;
+	exchange: string;
+};
+
+export const priceFeedKey = (exchange: string, symbol: string): PriceFeedKey =>
+	`${exchange}:${symbol}`;
+
+export const parsePriceFeedKey = (key: PriceFeedKey): PriceFeedSubscription => {
+	const separatorIndex = key.indexOf(":");
+	return {
+		exchange: key.slice(0, separatorIndex),
+		symbol: key.slice(separatorIndex + 1),
+	};
+};
+
+// Resolve the exchange for the given request from the required path parameter.
+export const resolveLoTechExchange = (
+	exchange: string | undefined,
+	moduleConfig: Pick<LoTechModuleConfig, "supportedExchanges">,
+): Effect.Effect<string, FailedToHandleLoTechRequestError> =>
+	Effect.gen(function* () {
+		if (exchange === undefined || exchange === "") {
+			return yield* Effect.fail(
+				new FailedToHandleLoTechRequestError({
+					error: `Missing required "${LO_TECH_EXCHANGE_PATH_PARAM}" path parameter`,
+				}),
+			);
+		}
+
+		yield* assertSupportedLoTechExchange(
+			exchange,
+			moduleConfig.supportedExchanges,
+		).pipe(
+			Effect.mapError(
+				(error) =>
+					new FailedToHandleLoTechRequestError({
+						error,
+					}),
+			),
+		);
+		return exchange;
+	});
 
 export const LoTechModuleService = (config: LoTechModuleConfig) =>
 	Layer.effect(
@@ -43,57 +89,65 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 
 			// Monotonically increasing counter for price feed IDs.
 			let latestPriceFeedId = 0;
-			// Map from price feed IDs to symbols. (Used to process acks)
-			const priceFeedIds = MutableHashMap.empty<number, PriceFeedSymbol>();
-			// Map from subscribed symbols to price feed IDs.
-			const priceFeeds = MutableHashMap.empty<PriceFeedSymbol, number>();
-			// Queue of new symbols to subscribe to.
-			const newPriceFeedQueue = yield* Queue.unbounded<PriceFeedSymbol>();
+			// Map from price feed IDs to cache keys. (Used to process acks)
+			const priceFeedIds = MutableHashMap.empty<number, PriceFeedKey>();
+			// Map from subscribed price feed keys to price feed IDs.
+			const priceFeeds = MutableHashMap.empty<PriceFeedKey, number>();
+			// Queue of new price feeds to subscribe to.
+			const newPriceFeedQueue = yield* Queue.unbounded<PriceFeedSubscription>();
 			// Timestamp of the last request to the price feed. (Used for cleanup)
 			const lastRequestToPriceFeed = MutableHashMap.empty<
-				PriceFeedSymbol,
+				PriceFeedKey,
 				number
 			>();
 			const priceCache = yield* createPriceCache<
-				PriceFeedSymbol,
+				PriceFeedKey,
 				LoTechDataPrice
 			>();
+			const exchanges = new Set(
+				config.priceFeeds.map((priceFeed) => priceFeed.exchange),
+			);
+			const wsByExchange = new Map<
+				string,
+				Effect.Effect.Success<ReturnType<typeof makeLoTechWebSocketService>>
+			>();
 
-			const updatePrice = (data: LoTechDataPrice) =>
+			const updatePrice = (exchange: string, data: LoTechDataPrice) =>
 				Effect.gen(function* () {
 					yield* Effect.logDebug("Received message from LO:TECH client", data);
 
-					// Set the price if the symbol is subscribed to.
-					const { symbol } = data;
-					if (!MutableHashMap.has(priceFeeds, symbol)) {
+					const key = priceFeedKey(exchange, data.symbol);
+					if (!MutableHashMap.has(priceFeeds, key)) {
 						return;
 					}
-					yield* priceCache.setPrice(symbol, data);
+					yield* priceCache.setPrice(key, data);
 				});
 
-			const handleDataMessage = (data: LoTechParsedData) =>
-				Match.value(data).pipe(
-					Match.discriminatorsExhaustive("type")({
-						[LO_TECH_DATA_TYPE_PRICE]: (priceData) => updatePrice(priceData),
-					}),
-				);
+			const makeHandleDataMessage =
+				(exchange: string) => (data: LoTechParsedData) =>
+					Match.value(data).pipe(
+						Match.discriminatorsExhaustive("type")({
+							[LO_TECH_DATA_TYPE_PRICE]: (priceData) =>
+								updatePrice(exchange, priceData),
+						}),
+					);
 
 			const handleAckMessage = (msg: LoTechAck) =>
 				Effect.gen(function* () {
 					yield* Effect.logDebug("handling ack", { msg });
 
-					const symbol = MutableHashMap.get(priceFeedIds, msg.ack.id);
-					if (Option.isNone(symbol)) {
+					const key = MutableHashMap.get(priceFeedIds, msg.ack.id);
+					if (Option.isNone(key)) {
 						yield* Effect.logWarning("Received ack for unknown price feed ID", {
 							msg,
 						});
 						return;
 					}
 
-					MutableHashMap.set(priceFeeds, symbol.value, msg.ack.id);
+					MutableHashMap.set(priceFeeds, key.value, msg.ack.id);
 
 					const now = yield* Clock.currentTimeMillis;
-					MutableHashMap.set(lastRequestToPriceFeed, symbol.value, now);
+					MutableHashMap.set(lastRequestToPriceFeed, key.value, now);
 				});
 
 			const handleErrorMessage = (msg: LoTechErrorMessage) =>
@@ -109,30 +163,70 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 					yield* Effect.logWarning("Unexpected LO:TECH error message", { msg });
 				});
 
-			const loTechWs = yield* makeLoTechWebSocketService({
-				config,
-				runtime,
-				onConnected: (api) =>
-					Effect.gen(function* () {
-						for (const priceFeed of config.priceFeeds) {
-							yield* Effect.logInfo(
-								`Subscribing to price feed ${priceFeed.symbol}`,
-							);
+			const getOrCreateWs = (exchange: string) =>
+				Effect.gen(function* () {
+					const existing = wsByExchange.get(exchange);
+					if (existing !== undefined) {
+						return existing;
+					}
 
-							const newSubscriptionId = latestPriceFeedId++;
-							MutableHashMap.set(
-								priceFeedIds,
-								newSubscriptionId,
-								priceFeed.symbol,
-							);
+					yield* Effect.logInfo(
+						"Creating LO:TECH websocket connection for exchange",
+						{ exchange },
+					);
 
-							yield* api.subscribePrice(priceFeed.symbol, newSubscriptionId);
-						}
-					}),
-				handleDataMessage,
-				handleAckMessage,
-				handleErrorMessage,
-			});
+					const ws = yield* makeLoTechWebSocketService({
+						config,
+						exchange,
+						runtime,
+						handleDataMessage: makeHandleDataMessage(exchange),
+						handleAckMessage,
+						handleErrorMessage,
+					});
+
+					wsByExchange.set(exchange, ws);
+					exchanges.add(exchange);
+					return ws;
+				});
+
+			const subscribePriceOnExchange = (
+				exchange: string,
+				symbol: string,
+				priceFeedId: number,
+			) =>
+				Effect.gen(function* () {
+					const ws = yield* getOrCreateWs(exchange);
+					yield* ws.subscribePrice(symbol, priceFeedId);
+				});
+
+			const unsubscribePriceOnExchange = (exchange: string, symbol: string) =>
+				Effect.gen(function* () {
+					const ws = wsByExchange.get(exchange);
+					if (ws === undefined) {
+						yield* Effect.logError(
+							"No LO:TECH websocket connection for exchange",
+							{ exchange, symbol },
+						);
+						return;
+					}
+
+					yield* ws.unsubscribePrice(symbol);
+				});
+
+			for (const priceFeed of config.priceFeeds) {
+				const key = priceFeedKey(priceFeed.exchange, priceFeed.symbol);
+				const newSubscriptionId = latestPriceFeedId++;
+				MutableHashMap.set(priceFeedIds, newSubscriptionId, key);
+
+				yield* Effect.logInfo(
+					`Subscribing to price feed ${priceFeed.symbol} on ${priceFeed.exchange}`,
+				);
+				yield* subscribePriceOnExchange(
+					priceFeed.exchange,
+					priceFeed.symbol,
+					newSubscriptionId,
+				);
+			}
 
 			const start = () =>
 				Effect.gen(function* () {
@@ -141,15 +235,24 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 					// Background fiber for handling new price feed subscriptions
 					yield* Effect.forkDaemon(
 						Effect.gen(function* () {
-							const newSymbol = yield* newPriceFeedQueue.take;
+							while (true) {
+								const { symbol, exchange } = yield* newPriceFeedQueue.take;
+								const key = priceFeedKey(exchange, symbol);
 
-							yield* Effect.logInfo(`Subscribing to price feed ${newSymbol}`);
+								yield* Effect.logInfo(
+									`Subscribing to price feed ${symbol} on ${exchange}`,
+								);
 
-							const newSubscriptionId = latestPriceFeedId++;
-							MutableHashMap.set(priceFeedIds, newSubscriptionId, newSymbol);
+								const newSubscriptionId = latestPriceFeedId++;
+								MutableHashMap.set(priceFeedIds, newSubscriptionId, key);
 
-							yield* loTechWs.subscribePrice(newSymbol, newSubscriptionId);
-						}).pipe(Effect.forever),
+								yield* subscribePriceOnExchange(
+									exchange,
+									symbol,
+									newSubscriptionId,
+								);
+							}
+						}),
 					);
 
 					// Background fiber for cleaning up price feeds subscriptions
@@ -161,7 +264,7 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 							);
 
 							for (const [
-								symbol,
+								key,
 								lastRequestTimestamp,
 							] of lastRequestToPriceFeed) {
 								const cleanupInterval = Duration.toMillis(
@@ -170,25 +273,29 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 								const timeSinceLastRequest = now - lastRequestTimestamp;
 
 								yield* Effect.logDebug(
-									`Time since last request for price feed ${symbol}: ${Duration.format(Duration.decode(timeSinceLastRequest))}`,
+									`Time since last request for price feed ${key}: ${Duration.format(Duration.decode(timeSinceLastRequest))}`,
 								);
 
 								if (timeSinceLastRequest > cleanupInterval) {
-									yield* Effect.logInfo(`Cleaning up price feed ${symbol}`);
-									MutableHashMap.remove(lastRequestToPriceFeed, symbol);
-									yield* priceCache.deletePrice(symbol);
+									const { exchange, symbol } = parsePriceFeedKey(key);
+									yield* Effect.logInfo(
+										`Cleaning up price feed ${symbol} on ${exchange}`,
+									);
+									MutableHashMap.remove(lastRequestToPriceFeed, key);
+									yield* priceCache.deletePrice(key);
 
-									const priceFeedId = MutableHashMap.get(priceFeeds, symbol);
+									const priceFeedId = MutableHashMap.get(priceFeeds, key);
 
 									if (Option.isSome(priceFeedId)) {
-										yield* loTechWs.unsubscribePrice(symbol);
-										MutableHashMap.remove(priceFeeds, symbol);
+										yield* unsubscribePriceOnExchange(exchange, symbol);
+										MutableHashMap.remove(priceFeeds, key);
 										MutableHashMap.remove(priceFeedIds, priceFeedId.value);
 									} else {
 										yield* Effect.logError(
 											"Failed to find price feed ID for symbol",
 											{
 												symbol,
+												exchange,
 											},
 										);
 									}
@@ -233,23 +340,35 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 						);
 					}
 
+					const exchange = yield* resolveLoTechExchange(
+						params.exchange,
+						config,
+					);
+					const symbolRequests = symbols.map((symbol) => ({
+						symbol,
+						exchange,
+					}));
+
 					const responses: LoTechResponse[] = [];
 					const now = yield* Clock.currentTimeMillis;
 
 					// Subscribe to the symbols that we have not subscribed to yet.
-					for (const symbol of symbols) {
-						if (!MutableHashMap.has(priceFeeds, symbol)) {
-							yield* newPriceFeedQueue.offer(symbol);
+					for (const { symbol, exchange } of symbolRequests) {
+						const key = priceFeedKey(exchange, symbol);
+
+						if (!MutableHashMap.has(priceFeeds, key)) {
+							yield* newPriceFeedQueue.offer({ symbol, exchange });
 						}
 
-						if (MutableHashMap.has(lastRequestToPriceFeed, symbol)) {
-							MutableHashMap.set(lastRequestToPriceFeed, symbol, now);
-						}
+						MutableHashMap.set(lastRequestToPriceFeed, key, now);
 					}
 
 					const prices = yield* Effect.forEach(
-						symbols,
-						(symbol) => Effect.either(priceCache.getOrWaitPrice(symbol)),
+						symbolRequests,
+						({ symbol, exchange }) =>
+							Effect.either(
+								priceCache.getOrWaitPrice(priceFeedKey(exchange, symbol)),
+							),
 						{ concurrency: "unbounded" },
 					);
 
@@ -276,7 +395,7 @@ export const LoTechModuleService = (config: LoTechModuleConfig) =>
 				}).pipe(
 					Effect.withSpan("handleLoTechRequest"),
 					Effect.catchAll((error) => {
-						return Effect.succeed(createErrorResponse(error, 500));
+						return Effect.succeed(createErrorResponse(error, error.status));
 					}),
 				);
 

--- a/workspace/data-proxy/src/modules/lo-tech/schema.test.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/schema.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import * as v from "valibot";
+import { LoTechDataMessageSchema } from "./schema";
+
+describe("LoTechDataMessageSchema", () => {
+	it("should parse us_equities price messages", () => {
+		const result = v.safeParse(LoTechDataMessageSchema, {
+			egress_ts: 1781207288221783,
+			data: {
+				type: "PRICE",
+				symbol: "NVDA",
+				ingress_ts: 1781207288221783,
+				publish_ts: 1781207288178000,
+				transaction_ts: 1781207288177000,
+				price: 204.469,
+				spread: 0.04,
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("should parse futures price messages", () => {
+		const result = v.safeParse(LoTechDataMessageSchema, {
+			egress_ts: 1781208650070012,
+			data: {
+				type: "PRICE",
+				symbol: "WTIN6",
+				generic_symbol: "WTI/1",
+				ingress_ts: 1781208650069961,
+				publish_ts: 1781208650015000,
+				transaction_ts: null,
+				price: 86.373,
+				spread: 0.02,
+				expiry_date: "2026-06-22",
+				roll_date: "2026-06-22",
+			},
+		});
+
+		expect(result.success).toBe(true);
+		if (!result.success) {
+			throw new Error(v.summarize(result.issues));
+		}
+
+		expect(result.output.data.symbol).toBe("WTIN6");
+		expect(result.output.data.generic_symbol).toBe("WTI/1");
+	});
+});

--- a/workspace/data-proxy/src/modules/lo-tech/schema.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/schema.ts
@@ -17,14 +17,17 @@ export type LoTechResponse =
 /*
  * Data messages
  */
-export const LoTechDataPriceSchema = v.strictObject({
+export const LoTechDataPriceSchema = v.object({
 	type: v.literal(LO_TECH_DATA_TYPE_PRICE),
 	symbol: v.string(),
+	generic_symbol: v.optional(v.string()),
 	ingress_ts: v.number(),
 	publish_ts: v.nullable(v.number()),
-	transaction_ts: v.number(),
+	transaction_ts: v.nullable(v.number()),
 	price: v.number(),
 	spread: v.number(),
+	expiry_date: v.optional(v.string()),
+	roll_date: v.optional(v.string()),
 });
 
 export type LoTechDataPrice = v.InferOutput<typeof LoTechDataPriceSchema>;

--- a/workspace/data-proxy/src/modules/lo-tech/ws-client.ts
+++ b/workspace/data-proxy/src/modules/lo-tech/ws-client.ts
@@ -38,7 +38,11 @@ export type LoTechWebSocketServiceApi = {
 };
 
 export type LoTechWebSocketServiceDeps = {
-	config: LoTechModuleConfig;
+	config: Pick<
+		LoTechModuleConfig,
+		"baseUrl" | "loTechApiKey" | "reconnectDelayMs"
+	>;
+	exchange: string;
 	runtime: Runtime.Runtime<never>;
 	/* Runs immediately after the socket is OPEN */
 	onConnected?: (api: LoTechWebSocketServiceApi) => Effect.Effect<void>;
@@ -53,6 +57,7 @@ export const makeLoTechWebSocketService = (
 	Effect.gen(function* () {
 		const {
 			config,
+			exchange,
 			runtime,
 			onConnected,
 			handleDataMessage,
@@ -111,7 +116,7 @@ export const makeLoTechWebSocketService = (
 
 		const runWebSocketSession = (): Promise<void> =>
 			new Promise((resolve) => {
-				const url = `${config.baseUrl}/${config.exchange}`;
+				const url = `${config.baseUrl}/${exchange}`;
 				let pingTimer: ReturnType<typeof setInterval> | undefined;
 
 				let socket: WebSocket;


### PR DESCRIPTION
## Motivation

To support futures in addition to US equities, we need the LO:TECH module to establish and maintain multiple WebSocket connections.

## Explanation of Changes

To prevent unbounded creation of WebSocket connections, we use configuration to specify a list of supported exchanges. By default, it is set to `futures` and `us_equities`.

## Testing

Example configuration:
```json
{
	"modules": [
		{
			"type": "lo-tech",
			"baseUrl": "wss://data.lo.tech/ws/v1",
			"name": "lotech",
			"supportedExchanges": ["us_equities", "futures"],
			"loTechApiKeyEnvKey": "LOTECH_API_KEY",
			"priceFeeds": [
				{
					"symbol": "NVDA",
					"exchange": "us_equities",
					"dataType": "PRICE"
				},
				{
					"symbol": "WTIN6",
					"exchange": "futures",
					"dataType": "PRICE"
				}
			]
		}
	],
	"routes": [
		{
			"type": "lo-tech",
			"moduleName": "lotech",
			"path": "/:exchange/:priceSymbol",
			"method": "GET",
			"fetchFromModule": "{:priceSymbol}"
		}
	]
}

```

Example requests:
```bash
curl http://localhost:5384/proxy/us_equities /NVDA
curl http://localhost:5384/proxy/futures/WTIN6
```
