### PR TITLE
feat(pyth-lazer): coalesce feeds into one bulk subscription

### DIFF
--- a/workspace/data-proxy/src/config/pyth-lazer-module-config.ts
+++ b/workspace/data-proxy/src/config/pyth-lazer-module-config.ts
@@ -39,6 +39,28 @@ export const PythLazerModuleConfigSchema = v.strictObject({
 			),
 		),
 	),
+	// How often the compaction pass folds individual subscriptions into one
+	// bulk subscription.
+	bulkCompactInterval: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "60 seconds"),
+		v.transform((interval) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(interval),
+				() => new Error("Invalid bulk compaction interval"),
+			),
+		),
+	),
+	// Make-before-break overlap: how long the new bulk subscription runs
+	// alongside the subscriptions it replaces before they are dropped.
+	bulkOverlap: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "1 second"),
+		v.transform((overlap) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(overlap),
+				() => new Error("Invalid bulk overlap"),
+			),
+		),
+	),
 	type: v.literal("pyth-lazer"),
 });
 

--- a/workspace/data-proxy/src/modules/pyth-lazer/get-symbol-price-id.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/get-symbol-price-id.ts
@@ -2,7 +2,10 @@ import type { PythLazerClient } from "@pythnetwork/pyth-lazer-sdk";
 import { Effect, Option } from "effect";
 import { FailedToGetSymbolPriceIdError } from "./errors";
 
-export const getPriceIdBySymbol = (symbol: string, client: PythLazerClient) => {
+export const getPriceIdBySymbol = (
+	symbol: string,
+	client: Pick<PythLazerClient, "getSymbols">,
+) => {
 	return Effect.gen(function* () {
 		const symbols = yield* Effect.tryPromise({
 			try: () =>

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from "bun:test";
+import type {
+	JsonOrBinaryResponse,
+	SymbolResponse,
+} from "@pythnetwork/pyth-lazer-sdk";
+import {
+	Duration,
+	Effect,
+	LogLevel,
+	Logger,
+	TestClock,
+	TestContext,
+} from "effect";
+import * as v from "valibot";
+import {
+	PythLazerModuleConfigSchema,
+	PythLazerModuleRouteSchema,
+} from "../../config/pyth-lazer-module-config";
+import { type LazerClient, makePythLazerModule } from "./pyth-lazer";
+
+const makeConfig = (
+	overrides: Partial<v.InferInput<typeof PythLazerModuleConfigSchema>> = {},
+) => ({
+	...v.parse(PythLazerModuleConfigSchema, {
+		name: "pyth",
+		type: "pyth-lazer",
+		priceFeedIds: [],
+		pythLazerApiKeyEnvKey: "PYTH_LAZER_API_KEY",
+		...overrides,
+	}),
+	pythLazerApiKey: "test-api-key",
+});
+
+const route = v.parse(PythLazerModuleRouteSchema, {
+	type: "pyth-lazer",
+	moduleName: "pyth",
+	path: "/price/:symbols",
+	method: ["GET"],
+	fetchFromModule: "{:symbols}",
+});
+
+interface FakeClientOptions {
+	/** symbol -> price feed id served by getSymbols */
+	symbolTable?: Record<string, number>;
+	/** real-time delay per getSymbols call */
+	symbolLookupDelayMs?: number;
+	/** push a price for every feed id as soon as it is subscribed */
+	autoDeliver?: boolean;
+}
+
+const makeFakeLazerClient = (options: FakeClientOptions = {}) => {
+	const subscribeCalls: Array<{
+		subscriptionId: number;
+		priceFeedIds: number[];
+	}> = [];
+	const unsubscribeCalls: number[] = [];
+	const symbolLookups: string[] = [];
+	let inFlightLookups = 0;
+	let maxInFlightLookups = 0;
+	let messageListener: ((event: JsonOrBinaryResponse) => void) | undefined;
+
+	const deliverPrice = (priceFeedIds: number[]) => {
+		messageListener?.({
+			type: "json",
+			value: {
+				type: "streamUpdated",
+				subscriptionId: 0,
+				parsed: {
+					timestampUs: "0",
+					priceFeeds: priceFeedIds.map((priceFeedId) => ({
+						priceFeedId,
+						price: `${priceFeedId * 100}`,
+					})),
+				},
+			},
+		});
+	};
+
+	const client: LazerClient = {
+		subscribe(request) {
+			if (request.type !== "subscribe") {
+				return;
+			}
+			const priceFeedIds = request.priceFeedIds ?? [];
+			subscribeCalls.push({
+				subscriptionId: request.subscriptionId,
+				priceFeedIds,
+			});
+			if (options.autoDeliver) {
+				deliverPrice(priceFeedIds);
+			}
+		},
+		unsubscribe(subscriptionId) {
+			unsubscribeCalls.push(subscriptionId);
+		},
+		addMessageListener(handler) {
+			messageListener = handler;
+		},
+		addAllConnectionsDownListener() {},
+		async getSymbols(params) {
+			const query = params?.query ?? "";
+			symbolLookups.push(query);
+			inFlightLookups++;
+			maxInFlightLookups = Math.max(maxInFlightLookups, inFlightLookups);
+			await new Promise((resolve) =>
+				setTimeout(resolve, options.symbolLookupDelayMs ?? 0),
+			);
+			inFlightLookups--;
+			const id = options.symbolTable?.[query];
+			if (id === undefined) {
+				return [];
+			}
+			return [{ symbol: query, pyth_lazer_id: id } as SymbolResponse];
+		},
+	};
+
+	return {
+		client,
+		deliverPrice,
+		subscribeCalls,
+		unsubscribeCalls,
+		symbolLookups,
+		maxInFlightLookups: () => maxInFlightLookups,
+	};
+};
+
+const silenceLogs = Logger.withMinimumLogLevel(LogLevel.None);
+
+const runLive = <A, E>(effect: Effect.Effect<A, E, never>) =>
+	Effect.runPromise(effect.pipe(silenceLogs));
+
+const runWithTestClock = <A, E>(effect: Effect.Effect<A, E, never>) =>
+	Effect.runPromise(
+		effect.pipe(Effect.provide(TestContext.TestContext), silenceLogs),
+	);
+
+const requestSymbols = (symbols: string) =>
+	[route, { symbols }, new Request("http://localhost/")] as const;
+
+describe("makePythLazerModule", () => {
+	it("resolves unknown symbols concurrently instead of one metadata round trip at a time", async () => {
+		const fake = makeFakeLazerClient({
+			symbolTable: { A: 1, B: 2, C: 3, D: 4, E: 5 },
+			symbolLookupDelayMs: 30,
+			autoDeliver: true,
+		});
+
+		await runLive(
+			Effect.gen(function* () {
+				const module = yield* makePythLazerModule(makeConfig(), () =>
+					Effect.succeed(fake.client),
+				);
+				yield* module.start();
+
+				const startedAt = performance.now();
+				const response = yield* module.handleRequest(
+					...requestSymbols("A,B,C,D,E"),
+				);
+				const elapsedMs = performance.now() - startedAt;
+
+				expect(response.status).toBe(200);
+				const body = (yield* Effect.promise(() => response.json())) as Array<{
+					priceFeedId: number;
+				}>;
+				expect(body.map((p) => p.priceFeedId)).toEqual([1, 2, 3, 4, 5]);
+
+				expect(fake.symbolLookups).toHaveLength(5);
+				expect(fake.maxInFlightLookups()).toBe(5);
+				// Five sequential 30ms lookups would take >=150ms
+				expect(elapsedMs).toBeLessThan(100);
+			}),
+		);
+	});
+
+	it("serves symbols listed in the module config without hitting the metadata service", async () => {
+		const fake = makeFakeLazerClient({ autoDeliver: true });
+
+		await runLive(
+			Effect.gen(function* () {
+				const module = yield* makePythLazerModule(
+					makeConfig({ priceFeedIds: [{ name: "BTC/USD", id: 1 }] }),
+					() => Effect.succeed(fake.client),
+				);
+				yield* module.start();
+
+				const response = yield* module.handleRequest(
+					...requestSymbols("BTC/USD"),
+				);
+
+				expect(response.status).toBe(200);
+				const body = (yield* Effect.promise(() => response.json())) as Array<{
+					priceFeedId: number;
+					symbol: string;
+				}>;
+				expect(body).toHaveLength(1);
+				expect(body[0].priceFeedId).toBe(1);
+				expect(body[0].symbol).toBe("BTC/USD");
+				expect(fake.symbolLookups).toHaveLength(0);
+			}),
+		);
+	});
+
+	it("caches a resolved symbol so repeat requests skip the metadata service", async () => {
+		const fake = makeFakeLazerClient({
+			symbolTable: { "NVDA/USD": 9 },
+			autoDeliver: true,
+		});
+
+		await runLive(
+			Effect.gen(function* () {
+				const module = yield* makePythLazerModule(makeConfig(), () =>
+					Effect.succeed(fake.client),
+				);
+				yield* module.start();
+
+				yield* module.handleRequest(...requestSymbols("NVDA/USD"));
+				yield* module.handleRequest(...requestSymbols("NVDA/USD"));
+
+				expect(fake.symbolLookups).toHaveLength(1);
+			}),
+		);
+	});
+
+	it("subscribes a feed once across repeated requests", async () => {
+		const fake = makeFakeLazerClient({ autoDeliver: true });
+
+		await runLive(
+			Effect.gen(function* () {
+				const module = yield* makePythLazerModule(makeConfig(), () =>
+					Effect.succeed(fake.client),
+				);
+				yield* module.start();
+
+				yield* module.handleRequest(...requestSymbols("1"));
+				yield* module.handleRequest(...requestSymbols("1"));
+
+				expect(fake.subscribeCalls).toHaveLength(1);
+				expect(fake.subscribeCalls[0].priceFeedIds).toEqual([1]);
+			}),
+		);
+	});
+
+	it("re-subscribes a feed after the idle cleanup dropped it", async () => {
+		const fake = makeFakeLazerClient({ autoDeliver: true });
+
+		await runWithTestClock(
+			Effect.gen(function* () {
+				const module = yield* makePythLazerModule(
+					makeConfig({
+						priceFeedsCleanupTtl: "20 seconds",
+						priceFeedsCleanupInterval: "10 seconds",
+					}),
+					() => Effect.succeed(fake.client),
+				);
+				yield* module.start();
+
+				const first = yield* module.handleRequest(...requestSymbols("7"));
+				expect(first.status).toBe(200);
+				expect(fake.subscribeCalls).toHaveLength(1);
+
+				// Cross the TTL (but stay below the first 60s compaction pass)
+				// so the cleanup unsubscribes the idle feed
+				yield* TestClock.adjust(Duration.seconds(31));
+				expect(fake.unsubscribeCalls).toContain(
+					fake.subscribeCalls[0].subscriptionId,
+				);
+
+				const second = yield* module.handleRequest(...requestSymbols("7"));
+				expect(second.status).toBe(200);
+				expect(fake.subscribeCalls).toHaveLength(2);
+				expect(fake.subscribeCalls[1].priceFeedIds).toEqual([7]);
+			}),
+		);
+	});
+
+	describe("bulk subscription compaction", () => {
+		it("absorbs delivered side subscriptions into one bulk subscription", async () => {
+			const fake = makeFakeLazerClient({ autoDeliver: true });
+
+			await runWithTestClock(
+				Effect.gen(function* () {
+					const module = yield* makePythLazerModule(
+						makeConfig({
+							priceFeedIds: [
+								{ name: "BTC/USD", id: 1 },
+								{ name: "ETH/USD", id: 2 },
+							],
+						}),
+						() => Effect.succeed(fake.client),
+					);
+					yield* module.start();
+					yield* TestClock.adjust(Duration.millis(0));
+
+					expect(fake.subscribeCalls).toHaveLength(2);
+					const sideIds = fake.subscribeCalls.map((c) => c.subscriptionId);
+
+					// One compaction interval plus the make-before-break overlap
+					yield* TestClock.adjust(Duration.seconds(62));
+
+					expect(fake.subscribeCalls).toHaveLength(3);
+					const bulk = fake.subscribeCalls[2];
+					expect([...bulk.priceFeedIds].sort()).toEqual([1, 2]);
+					expect(fake.unsubscribeCalls.sort()).toEqual(sideIds.sort());
+				}),
+			);
+		});
+
+		it("never absorbs a feed that has not delivered an update", async () => {
+			const fake = makeFakeLazerClient({ autoDeliver: false });
+
+			await runWithTestClock(
+				Effect.gen(function* () {
+					const module = yield* makePythLazerModule(
+						makeConfig({
+							priceFeedIds: [
+								{ name: "GOOD/USD", id: 1 },
+								{ name: "BAD/USD", id: 2 },
+							],
+						}),
+						() => Effect.succeed(fake.client),
+					);
+					yield* module.start();
+					yield* TestClock.adjust(Duration.millis(0));
+					expect(fake.subscribeCalls).toHaveLength(2);
+
+					// Only feed 1 ever delivers
+					fake.deliverPrice([1]);
+
+					yield* TestClock.adjust(Duration.seconds(62));
+
+					expect(fake.subscribeCalls).toHaveLength(3);
+					expect(fake.subscribeCalls[2].priceFeedIds).toEqual([1]);
+
+					const badSideId = fake.subscribeCalls.find((c) =>
+						c.priceFeedIds.includes(2),
+					)?.subscriptionId;
+					expect(badSideId).toBeDefined();
+					expect(fake.unsubscribeCalls).not.toContain(badSideId);
+				}),
+			);
+		});
+
+		it("drops an idle feed from the bulk subscription without tearing the bulk down", async () => {
+			const fake = makeFakeLazerClient({ autoDeliver: true });
+
+			await runWithTestClock(
+				Effect.gen(function* () {
+					const module = yield* makePythLazerModule(
+						makeConfig({
+							priceFeedIds: [
+								{ name: "FRESH/USD", id: 1 },
+								{ name: "IDLE/USD", id: 2 },
+							],
+							priceFeedsCleanupTtl: "2 minutes",
+							priceFeedsCleanupInterval: "30 seconds",
+						}),
+						() => Effect.succeed(fake.client),
+					);
+					yield* module.start();
+					yield* TestClock.adjust(Duration.millis(0));
+
+					// First compaction folds both feeds into the bulk subscription
+					yield* TestClock.adjust(Duration.seconds(62));
+					expect(fake.subscribeCalls).toHaveLength(3);
+					const firstBulkId = fake.subscribeCalls[2].subscriptionId;
+
+					// Keep feed 1 fresh, let feed 2 idle past the 2 minute TTL
+					yield* TestClock.adjust(Duration.seconds(28));
+					yield* module.handleRequest(...requestSymbols("1"));
+					yield* TestClock.adjust(Duration.seconds(95));
+
+					// The cleanup must not unsubscribe the shared bulk subscription
+					// while it carries other feeds; the next compaction rebuilds it
+					const rebuilt = fake.subscribeCalls.at(-1);
+					expect(rebuilt).toBeDefined();
+					expect(rebuilt?.priceFeedIds).toEqual([1]);
+					expect(fake.unsubscribeCalls).toContain(firstBulkId);
+
+					const unsubscribedBeforeRebuild = fake.unsubscribeCalls.slice(
+						0,
+						fake.unsubscribeCalls.indexOf(firstBulkId),
+					);
+					expect(unsubscribedBeforeRebuild).not.toContain(firstBulkId);
+				}),
+			);
+		});
+	});
+});

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
@@ -340,6 +340,56 @@ describe("makePythLazerModule", () => {
 			);
 		});
 
+		it("unsubscribes an individual subscription re-created during the make-before-break overlap", async () => {
+			const fake = makeFakeLazerClient({ autoDeliver: true });
+
+			await runWithTestClock(
+				Effect.gen(function* () {
+					const module = yield* makePythLazerModule(
+						makeConfig({
+							priceFeedIds: [
+								{ name: "FRESH/USD", id: 1 },
+								{ name: "CHURN/USD", id: 2 },
+							],
+							bulkCompactInterval: "60 seconds",
+							bulkOverlap: "20 seconds",
+							priceFeedsCleanupTtl: "62 seconds",
+							priceFeedsCleanupInterval: "5 seconds",
+						}),
+						() => Effect.succeed(fake.client),
+					);
+					yield* module.start();
+					yield* TestClock.adjust(Duration.millis(0));
+					expect(fake.subscribeCalls).toHaveLength(2);
+
+					// Keep feed 1 fresh so only feed 2 churns during the overlap
+					yield* TestClock.adjust(Duration.seconds(55));
+					yield* module.handleRequest(...requestSymbols("1"));
+
+					// Compaction fires at 60s and parks on the 20s overlap with both
+					// feeds folded into the bulk subscription
+					yield* TestClock.adjust(Duration.seconds(5));
+					expect(fake.subscribeCalls).toHaveLength(3);
+					expect([...fake.subscribeCalls[2].priceFeedIds].sort()).toEqual([
+						1, 2,
+					]);
+
+					// Inside the overlap: feed 2 idles out (cleanup unsubscribes its
+					// individual sub), then a new request re-subscribes it fresh
+					yield* TestClock.adjust(Duration.seconds(6));
+					yield* module.handleRequest(...requestSymbols("2"));
+					expect(fake.subscribeCalls).toHaveLength(4);
+					const reCreatedId = fake.subscribeCalls[3].subscriptionId;
+					expect(fake.subscribeCalls[3].priceFeedIds).toEqual([2]);
+
+					// Overlap ends: the bulk now supersedes the re-created individual
+					// sub, which must be unsubscribed rather than orphaned
+					yield* TestClock.adjust(Duration.seconds(14));
+					expect(fake.unsubscribeCalls).toContain(reCreatedId);
+				}),
+			);
+		});
+
 		it("drops an idle feed from the bulk subscription without tearing the bulk down", async () => {
 			const fake = makeFakeLazerClient({ autoDeliver: true });
 

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -10,7 +10,6 @@ import {
 import {
 	Clock,
 	Data,
-	Duration,
 	Effect,
 	Either,
 	Layer,
@@ -42,10 +41,7 @@ import { getPriceIdBySymbol } from "./get-symbol-price-id";
 // upstream then sends one frame per channel tick carrying all feeds instead of
 // one frame per feed, which keeps the standing WebSocket load (and the price
 // staleness caused by thousands of per-feed frames) flat as feeds grow.
-const BULK_COMPACT_MS = Number(
-	process.env.PYTH_LAZER_BULK_COMPACT_MS ?? 60_000,
-);
-const BULK_OVERLAP_MS = Number(process.env.PYTH_LAZER_BULK_OVERLAP_MS ?? 1_000);
+// Cadence is configured per module via bulkCompactInterval and bulkOverlap.
 
 export class FailedToCreateLazerClientError extends Data.TaggedError(
 	"FailedToCreateLazerClientError",
@@ -55,6 +51,7 @@ export class FailedToCreateLazerClientError extends Data.TaggedError(
 
 type PriceFeedId = number;
 type PriceFeedSymbol = string;
+type SubscriptionId = number;
 
 interface PriceFeedWithSymbol extends ParsedFeedPayload {
 	symbol?: string;
@@ -117,11 +114,11 @@ export const makePythLazerModule = (
 		const lastRequestToPriceFeed = MutableHashMap.empty<PriceFeedId, number>();
 		const newPriceFeedRequests = yield* Queue.unbounded<PriceFeedId>();
 		// price feed id -> subscription id
-		const subscriptions = MutableHashMap.empty<PriceFeedId, number>();
+		const subscriptions = MutableHashMap.empty<PriceFeedId, SubscriptionId>();
 		const symbolsToId = MutableHashMap.empty<PriceFeedSymbol, PriceFeedId>();
 
 		const getSymbolByPriceFeedId = (priceFeedId: PriceFeedId) => {
-			for (const [symbol, id] of MutableHashMap.fromIterable(symbolsToId)) {
+			for (const [symbol, id] of symbolsToId) {
 				if (id === priceFeedId) {
 					return Option.some(symbol);
 				}
@@ -130,15 +127,15 @@ export const makePythLazerModule = (
 			return Option.none();
 		};
 
-		let subscriptionId = 0;
+		let subscriptionId: SubscriptionId = 0;
 
 		// Bulk-subscribe bookkeeping: which subscription ids are individual
-		// (side) subscriptions, which feeds the current bulk subscription
-		// carries, and which feeds have delivered at least one update. Feeds
-		// that never deliver (e.g. entitlement failures) are never absorbed
-		// into the bulk subscription, so one bad feed cannot poison it.
-		const sideSubscriptionIds = new Set<number>();
-		let bulkSubscriptionId: number | undefined;
+		// subscriptions, which feeds the current bulk subscription carries, and
+		// which feeds have delivered at least one update. Feeds that never
+		// deliver (e.g. entitlement failures) are never absorbed into the bulk
+		// subscription, so one bad feed cannot poison it.
+		const individualSubscriptionIds = new Set<SubscriptionId>();
+		let bulkSubscriptionId: SubscriptionId | undefined;
 		let bulkFeedIds = new Set<PriceFeedId>();
 		const deliveredFeedIds = new Set<PriceFeedId>();
 
@@ -229,8 +226,8 @@ export const makePythLazerModule = (
 		});
 
 		const sendSubscribe = (
-			newSubscriptionId: number,
-			priceFeedIds: number[],
+			newSubscriptionId: SubscriptionId,
+			priceFeedIds: PriceFeedId[],
 		) => {
 			lazerClient.subscribe({
 				type: "subscribe",
@@ -258,16 +255,19 @@ export const makePythLazerModule = (
 			});
 		};
 
-		// Unifies side subscriptions that have proven they deliver into a single
-		// bulk subscription, and drops feeds that idled out of the bulk set.
-		// Make-before-break: the replacement subscription overlaps the old ones
-		// before they are unsubscribed, so duplicate frames during the overlap
-		// are the only cost (cache writes are latest-wins). Side subscriptions
-		// created during the overlap are absorbed on the next pass.
+		// Unifies individual subscriptions that have proven they deliver into a
+		// single bulk subscription, and drops feeds that idled out of the bulk
+		// set. Make-before-break: the replacement subscription overlaps the old
+		// ones before they are unsubscribed, so duplicate frames during the
+		// overlap are the only cost (cache writes are latest-wins). Individual
+		// subscriptions created during the overlap are absorbed on the next pass.
 		const compactSubscriptions = Effect.gen(function* () {
-			const absorbable = new Map<PriceFeedId, number>();
+			const absorbable = new Map<PriceFeedId, SubscriptionId>();
 			for (const [feedId, subId] of subscriptions) {
-				if (sideSubscriptionIds.has(subId) && deliveredFeedIds.has(feedId)) {
+				if (
+					individualSubscriptionIds.has(subId) &&
+					deliveredFeedIds.has(feedId)
+				) {
 					absorbable.set(feedId, subId);
 				}
 			}
@@ -300,27 +300,39 @@ export const makePythLazerModule = (
 
 			const newBulkSubscriptionId = subscriptionId++;
 			yield* Effect.logInfo(
-				`Compacting subscriptions: ${absorbable.size} side subscription(s) absorbed, ` +
+				`Compacting subscriptions: ${absorbable.size} individual subscription(s) absorbed, ` +
 					`${droppedFromBulk} idle feed(s) dropped, bulk subscription ${newBulkSubscriptionId} ` +
 					`now carries ${newFeedIds.size} feed(s)`,
 			);
 
 			sendSubscribe(newBulkSubscriptionId, [...newFeedIds]);
-			yield* Effect.sleep(Duration.millis(BULK_OVERLAP_MS));
+			yield* Effect.sleep(config.bulkOverlap);
 
 			if (oldBulkSubscriptionId !== undefined) {
 				lazerClient.unsubscribe(oldBulkSubscriptionId);
 			}
 			for (const subId of absorbable.values()) {
 				lazerClient.unsubscribe(subId);
-				sideSubscriptionIds.delete(subId);
+				individualSubscriptionIds.delete(subId);
 			}
 			for (const feedId of newFeedIds) {
 				// Skip feeds that idled out during the overlap; the next pass
 				// drops them from the bulk subscription.
-				if (MutableHashMap.has(subscriptions, feedId)) {
-					MutableHashMap.set(subscriptions, feedId, newBulkSubscriptionId);
+				const current = MutableHashMap.get(subscriptions, feedId);
+				if (Option.isNone(current)) {
+					continue;
 				}
+				// A feed re-subscribed during the overlap holds a fresh individual
+				// subscription that the bulk now supersedes; drop it so it is not
+				// orphaned (no feed would map to it, so no later pass could).
+				if (
+					current.value !== newBulkSubscriptionId &&
+					individualSubscriptionIds.has(current.value)
+				) {
+					lazerClient.unsubscribe(current.value);
+					individualSubscriptionIds.delete(current.value);
+				}
+				MutableHashMap.set(subscriptions, feedId, newBulkSubscriptionId);
 			}
 
 			bulkSubscriptionId = newBulkSubscriptionId;
@@ -363,7 +375,7 @@ export const makePythLazerModule = (
 							newSubscriptionId,
 						);
 
-						sideSubscriptionIds.add(newSubscriptionId);
+						individualSubscriptionIds.add(newSubscriptionId);
 
 						sendSubscribe(newSubscriptionId, [newPriceFeedId]);
 					}).pipe(Effect.forever),
@@ -376,7 +388,7 @@ export const makePythLazerModule = (
 						),
 						// Effect.schedule waits one full interval before the first pass,
 						// so compaction never races the initial config-seeded subscribes.
-						Effect.schedule(Schedule.spaced(Duration.millis(BULK_COMPACT_MS))),
+						Effect.schedule(Schedule.spaced(config.bulkCompactInterval)),
 					),
 				);
 
@@ -401,7 +413,7 @@ export const makePythLazerModule = (
 								// compaction pass rebuilds the bulk subscription without it.
 								if (subscriptionId.value !== bulkSubscriptionId) {
 									lazerClient.unsubscribe(subscriptionId.value);
-									sideSubscriptionIds.delete(subscriptionId.value);
+									individualSubscriptionIds.delete(subscriptionId.value);
 								}
 								MutableHashMap.remove(subscriptions, priceFeedId);
 

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -1,11 +1,16 @@
 import {
+	type JsonOrBinaryResponse,
+	type Request as LazerSubscriptionRequest,
 	type ParsedFeedPayload,
 	type ParsedPayload,
 	PythLazerClient,
+	type SymbolResponse,
+	type SymbolsQueryParams,
 } from "@pythnetwork/pyth-lazer-sdk";
 import {
 	Clock,
 	Data,
+	Duration,
 	Effect,
 	Either,
 	Layer,
@@ -13,6 +18,7 @@ import {
 	Option,
 	Queue,
 	Runtime,
+	Schedule,
 } from "effect";
 import type { Route } from "../../config/config-parser";
 import type { PythLazerModuleConfig } from "../../config/pyth-lazer-module-config";
@@ -28,6 +34,19 @@ import {
 } from "./errors";
 import { getPriceIdBySymbol } from "./get-symbol-price-id";
 
+// Newly requested feeds get an immediate individual subscription, and a
+// periodic compaction pass unifies every individual subscription that proved
+// it delivers into one bulk subscription (make-before-break: subscribe the new
+// set, overlap briefly, then drop the old bulk and the absorbed individual
+// subscriptions). Idle feeds fall out of the bulk set at the same time. The
+// upstream then sends one frame per channel tick carrying all feeds instead of
+// one frame per feed, which keeps the standing WebSocket load (and the price
+// staleness caused by thousands of per-feed frames) flat as feeds grow.
+const BULK_COMPACT_MS = Number(
+	process.env.PYTH_LAZER_BULK_COMPACT_MS ?? 60_000,
+);
+const BULK_OVERLAP_MS = Number(process.env.PYTH_LAZER_BULK_OVERLAP_MS ?? 1_000);
+
 export class FailedToCreateLazerClientError extends Data.TaggedError(
 	"FailedToCreateLazerClientError",
 )<{ error: string | unknown }> {
@@ -42,39 +61,26 @@ interface PriceFeedWithSymbol extends ParsedFeedPayload {
 	[HAS_PRICE_KEY]: boolean;
 }
 
+/** The subset of PythLazerClient the module talks to. */
+export interface LazerClient {
+	subscribe(request: LazerSubscriptionRequest): void;
+	unsubscribe(subscriptionId: number): void;
+	addMessageListener(handler: (event: JsonOrBinaryResponse) => void): void;
+	addAllConnectionsDownListener(handler: () => void): void;
+	getSymbols(params?: SymbolsQueryParams): Promise<SymbolResponse[]>;
+}
+
+/** Error callbacks the module wires into the client's WebSocket pool. */
+export interface LazerClientHooks {
+	onPoolError: (error: unknown) => void;
+	onSocketError: (error: unknown) => void;
+}
+
 export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 	Layer.effect(
 		ModuleService,
-		Effect.gen(function* () {
-			yield* Effect.logInfo("Initializing Pyth Lazer module");
-			const runtime = yield* Effect.runtime();
-			const priceCache = yield* createPriceCache<
-				PriceFeedId,
-				ParsedFeedPayload
-			>();
-			// The timestamp of the last request to the price feed
-			const lastRequestToPriceFeed = MutableHashMap.empty<
-				PriceFeedId,
-				number
-			>();
-			const newPriceFeedRequests = yield* Queue.unbounded<PriceFeedId>();
-			// price feed id -> subscription id
-			const subscriptions = MutableHashMap.empty<PriceFeedId, number>();
-			const symbolsToId = MutableHashMap.empty<PriceFeedSymbol, PriceFeedId>();
-
-			const getSymbolByPriceFeedId = (priceFeedId: PriceFeedId) => {
-				for (const [symbol, id] of MutableHashMap.fromIterable(symbolsToId)) {
-					if (id === priceFeedId) {
-						return Option.some(symbol);
-					}
-				}
-
-				return Option.none();
-			};
-
-			let subscriptionId = 0;
-
-			const lazerClient = yield* Effect.tryPromise({
+		makePythLazerModule(config, (hooks) =>
+			Effect.tryPromise({
 				try: () =>
 					PythLazerClient.create({
 						token: config.pythLazerApiKey,
@@ -85,221 +91,374 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 								"wss://pyth-lazer-1.dourolabs.app/v1/stream",
 								"wss://pyth-lazer-2.dourolabs.app/v1/stream",
 							],
-							onWebSocketPoolError: (error) => {
-								Runtime.runSync(
-									runtime,
-									Effect.logError("Error in Pyth Lazer client web socket pool"),
-								);
-
-								const priceFeedId = extractPriceFeedIdFromErrorMessage(
-									`${error}`,
-								);
-
-								if (Option.isSome(priceFeedId)) {
-									const symbol = getSymbolByPriceFeedId(priceFeedId.value);
-
-									Runtime.runSync(
-										runtime,
-										priceCache.setPriceToError(
-											priceFeedId.value,
-											`(${Option.getOrElse(symbol, () => "Unknown/Symbol")}) ${error}`,
-										),
-									);
-								}
-
-								// For some reason the error is encoded to an empty object, the regular console.error does show the actual error
-								console.error(error);
-							},
-							onWebSocketError: (error) => {
-								Runtime.runSync(
-									runtime,
-									Effect.logError("Error in Pyth Lazer client web socket", {
-										error,
-									}),
-								);
-
-								console.error(error);
-							},
+							onWebSocketPoolError: hooks.onPoolError,
+							onWebSocketError: hooks.onSocketError,
 						},
 					}),
 				catch: (error) => new FailedToCreateLazerClientError({ error }),
+			}),
+		),
+	);
+
+export const makePythLazerModule = (
+	config: PythLazerModuleConfig,
+	acquireClient: (
+		hooks: LazerClientHooks,
+	) => Effect.Effect<LazerClient, FailedToCreateLazerClientError>,
+) =>
+	Effect.gen(function* () {
+		yield* Effect.logInfo("Initializing Pyth Lazer module");
+		const runtime = yield* Effect.runtime();
+		const priceCache = yield* createPriceCache<
+			PriceFeedId,
+			ParsedFeedPayload
+		>();
+		// The timestamp of the last request to the price feed
+		const lastRequestToPriceFeed = MutableHashMap.empty<PriceFeedId, number>();
+		const newPriceFeedRequests = yield* Queue.unbounded<PriceFeedId>();
+		// price feed id -> subscription id
+		const subscriptions = MutableHashMap.empty<PriceFeedId, number>();
+		const symbolsToId = MutableHashMap.empty<PriceFeedSymbol, PriceFeedId>();
+
+		const getSymbolByPriceFeedId = (priceFeedId: PriceFeedId) => {
+			for (const [symbol, id] of MutableHashMap.fromIterable(symbolsToId)) {
+				if (id === priceFeedId) {
+					return Option.some(symbol);
+				}
+			}
+
+			return Option.none();
+		};
+
+		let subscriptionId = 0;
+
+		// Bulk-subscribe bookkeeping: which subscription ids are individual
+		// (side) subscriptions, which feeds the current bulk subscription
+		// carries, and which feeds have delivered at least one update. Feeds
+		// that never deliver (e.g. entitlement failures) are never absorbed
+		// into the bulk subscription, so one bad feed cannot poison it.
+		const sideSubscriptionIds = new Set<number>();
+		let bulkSubscriptionId: number | undefined;
+		let bulkFeedIds = new Set<PriceFeedId>();
+		const deliveredFeedIds = new Set<PriceFeedId>();
+
+		const handleStreamUpdatedMessage = (message: ParsedPayload) =>
+			Effect.gen(function* () {
+				yield* Effect.logTrace(
+					"Received stream updated message from Pyth Lazer client",
+					message,
+				);
+
+				for (const priceFeed of message.priceFeeds) {
+					// To make sure that we don't set the price for a price feed that we are not subscribed to
+					// otherwise requests may get an outdated price
+					if (!MutableHashMap.has(subscriptions, priceFeed.priceFeedId)) {
+						continue;
+					}
+
+					deliveredFeedIds.add(priceFeed.priceFeedId);
+					yield* priceCache.setPrice(priceFeed.priceFeedId, priceFeed);
+				}
 			});
 
-			lazerClient.addAllConnectionsDownListener(() =>
+		const lazerClient = yield* acquireClient({
+			onPoolError: (error) => {
 				Runtime.runSync(
 					runtime,
-					Effect.logFatal("All connections are down for Pyth Lazer client"),
-				),
-			);
+					Effect.logError("Error in Pyth Lazer client web socket pool"),
+				);
 
-			lazerClient.addMessageListener((message) => {
+				const priceFeedId = extractPriceFeedIdFromErrorMessage(`${error}`);
+
+				if (Option.isSome(priceFeedId)) {
+					const symbol = getSymbolByPriceFeedId(priceFeedId.value);
+
+					Runtime.runSync(
+						runtime,
+						priceCache.setPriceToError(
+							priceFeedId.value,
+							`(${Option.getOrElse(symbol, () => "Unknown/Symbol")}) ${error}`,
+						),
+					);
+				}
+
+				// For some reason the error is encoded to an empty object, the regular console.error does show the actual error
+				console.error(error);
+			},
+			onSocketError: (error) => {
 				Runtime.runSync(
 					runtime,
-					Effect.gen(function* () {
-						yield* Effect.logTrace(
-							"Received message from Pyth Lazer client",
-							message,
-						);
-
-						if (message.type === "json") {
-							if (message.value.type === "streamUpdated") {
-								if (!message.value.parsed) {
-									return yield* Effect.logWarning("No parsed message found", {
-										message,
-									});
-								}
-
-								yield* handleStreamUpdatedMessage(message.value.parsed);
-							}
-						}
+					Effect.logError("Error in Pyth Lazer client web socket", {
+						error,
 					}),
 				);
-			});
 
-			const handleStreamUpdatedMessage = (message: ParsedPayload) =>
+				console.error(error);
+			},
+		});
+
+		lazerClient.addAllConnectionsDownListener(() =>
+			Runtime.runSync(
+				runtime,
+				Effect.logFatal("All connections are down for Pyth Lazer client"),
+			),
+		);
+
+		lazerClient.addMessageListener((message) => {
+			Runtime.runSync(
+				runtime,
 				Effect.gen(function* () {
 					yield* Effect.logTrace(
-						"Received stream updated message from Pyth Lazer client",
+						"Received message from Pyth Lazer client",
 						message,
 					);
 
-					for (const priceFeed of message.priceFeeds) {
-						// To make sure that we don't set the price for a price feed that we are not subscribed to
-						// otherwise requests may get an outdated price
-						if (!MutableHashMap.has(subscriptions, priceFeed.priceFeedId)) {
-							continue;
-						}
-
-						yield* priceCache.setPrice(priceFeed.priceFeedId, priceFeed);
-					}
-				});
-
-			const start = () =>
-				Effect.gen(function* () {
-					yield* Effect.logInfo("Starting Pyth Lazer module");
-
-					const now = yield* Clock.currentTimeMillis;
-					for (const priceFeed of config.priceFeedIds) {
-						yield* newPriceFeedRequests.offer(priceFeed.id);
-						// Add a request timestamp so it is tracked in the cleanup interval
-						MutableHashMap.set(lastRequestToPriceFeed, priceFeed.id, now);
-					}
-
-					yield* Effect.forkDaemon(
-						Effect.gen(function* () {
-							const newPriceFeedId = yield* newPriceFeedRequests.take;
-
-							if (MutableHashMap.has(subscriptions, newPriceFeedId)) {
-								yield* Effect.logDebug(
-									`Price feed ${newPriceFeedId} is already subscribed`,
-								);
-								return;
+					if (message.type === "json") {
+						if (message.value.type === "streamUpdated") {
+							if (!message.value.parsed) {
+								return yield* Effect.logWarning("No parsed message found", {
+									message,
+								});
 							}
 
-							yield* Effect.logInfo(
-								`Subscribing to price feed ${newPriceFeedId}`,
+							yield* handleStreamUpdatedMessage(message.value.parsed);
+						}
+					}
+				}),
+			);
+		});
+
+		const sendSubscribe = (
+			newSubscriptionId: number,
+			priceFeedIds: number[],
+		) => {
+			lazerClient.subscribe({
+				type: "subscribe",
+				channel: config.channel,
+				formats: ["solana"],
+				properties: [
+					"bestAskPrice",
+					"bestBidPrice",
+					"confidence",
+					"emaConfidence",
+					"emaPrice",
+					"exponent",
+					"feedUpdateTimestamp",
+					"fundingRate",
+					"fundingRateInterval",
+					"fundingTimestamp",
+					"marketSession",
+					"price",
+					"publisherCount",
+				],
+				subscriptionId: newSubscriptionId,
+				priceFeedIds,
+				// Recommended by Pyth case a previously valid feed id becomes invalid (delisting, id changed, etc.)
+				ignoreInvalidFeedIds: true,
+			});
+		};
+
+		// Unifies side subscriptions that have proven they deliver into a single
+		// bulk subscription, and drops feeds that idled out of the bulk set.
+		// Make-before-break: the replacement subscription overlaps the old ones
+		// before they are unsubscribed, so duplicate frames during the overlap
+		// are the only cost (cache writes are latest-wins). Side subscriptions
+		// created during the overlap are absorbed on the next pass.
+		const compactSubscriptions = Effect.gen(function* () {
+			const absorbable = new Map<PriceFeedId, number>();
+			for (const [feedId, subId] of subscriptions) {
+				if (sideSubscriptionIds.has(subId) && deliveredFeedIds.has(feedId)) {
+					absorbable.set(feedId, subId);
+				}
+			}
+
+			const carriedOver = new Set<PriceFeedId>();
+			let droppedFromBulk = 0;
+			for (const feedId of bulkFeedIds) {
+				if (MutableHashMap.has(subscriptions, feedId)) {
+					carriedOver.add(feedId);
+				} else {
+					droppedFromBulk++;
+				}
+			}
+
+			if (absorbable.size === 0 && droppedFromBulk === 0) {
+				return;
+			}
+
+			const newFeedIds = new Set([...carriedOver, ...absorbable.keys()]);
+			const oldBulkSubscriptionId = bulkSubscriptionId;
+
+			if (newFeedIds.size === 0) {
+				if (oldBulkSubscriptionId !== undefined) {
+					lazerClient.unsubscribe(oldBulkSubscriptionId);
+					bulkSubscriptionId = undefined;
+					bulkFeedIds = new Set();
+				}
+				return;
+			}
+
+			const newBulkSubscriptionId = subscriptionId++;
+			yield* Effect.logInfo(
+				`Compacting subscriptions: ${absorbable.size} side subscription(s) absorbed, ` +
+					`${droppedFromBulk} idle feed(s) dropped, bulk subscription ${newBulkSubscriptionId} ` +
+					`now carries ${newFeedIds.size} feed(s)`,
+			);
+
+			sendSubscribe(newBulkSubscriptionId, [...newFeedIds]);
+			yield* Effect.sleep(Duration.millis(BULK_OVERLAP_MS));
+
+			if (oldBulkSubscriptionId !== undefined) {
+				lazerClient.unsubscribe(oldBulkSubscriptionId);
+			}
+			for (const subId of absorbable.values()) {
+				lazerClient.unsubscribe(subId);
+				sideSubscriptionIds.delete(subId);
+			}
+			for (const feedId of newFeedIds) {
+				// Skip feeds that idled out during the overlap; the next pass
+				// drops them from the bulk subscription.
+				if (MutableHashMap.has(subscriptions, feedId)) {
+					MutableHashMap.set(subscriptions, feedId, newBulkSubscriptionId);
+				}
+			}
+
+			bulkSubscriptionId = newBulkSubscriptionId;
+			bulkFeedIds = newFeedIds;
+		});
+
+		const start = () =>
+			Effect.gen(function* () {
+				yield* Effect.logInfo("Starting Pyth Lazer module");
+
+				const now = yield* Clock.currentTimeMillis;
+				for (const priceFeed of config.priceFeedIds) {
+					yield* newPriceFeedRequests.offer(priceFeed.id);
+					// Add a request timestamp so it is tracked in the cleanup interval
+					MutableHashMap.set(lastRequestToPriceFeed, priceFeed.id, now);
+					// Seed the symbol lookup so requests by symbol skip the metadata service
+					MutableHashMap.set(symbolsToId, priceFeed.name, priceFeed.id);
+				}
+
+				yield* Effect.forkDaemon(
+					Effect.gen(function* () {
+						const newPriceFeedId = yield* newPriceFeedRequests.take;
+
+						if (MutableHashMap.has(subscriptions, newPriceFeedId)) {
+							yield* Effect.logDebug(
+								`Price feed ${newPriceFeedId} is already subscribed`,
 							);
+							return;
+						}
 
-							const newSubscriptionId = subscriptionId++;
+						yield* Effect.logInfo(
+							`Subscribing to price feed ${newPriceFeedId}`,
+						);
 
-							MutableHashMap.set(
+						const newSubscriptionId = subscriptionId++;
+
+						MutableHashMap.set(
+							subscriptions,
+							newPriceFeedId,
+							newSubscriptionId,
+						);
+
+						sideSubscriptionIds.add(newSubscriptionId);
+
+						sendSubscribe(newSubscriptionId, [newPriceFeedId]);
+					}).pipe(Effect.forever),
+				);
+
+				yield* Effect.forkDaemon(
+					compactSubscriptions.pipe(
+						Effect.catchAllCause((cause) =>
+							Effect.logError("Bulk subscription compaction failed", cause),
+						),
+						// Effect.schedule waits one full interval before the first pass,
+						// so compaction never races the initial config-seeded subscribes.
+						Effect.schedule(Schedule.spaced(Duration.millis(BULK_COMPACT_MS))),
+					),
+				);
+
+				yield* forkIdleCleanup({
+					lastRequest: lastRequestToPriceFeed,
+					ttl: config.priceFeedsCleanupTtl,
+					interval: config.priceFeedsCleanupInterval,
+					onExpire: (priceFeedId) =>
+						Effect.gen(function* () {
+							yield* Effect.logInfo(`Cleaning up price feed ${priceFeedId}`);
+							yield* priceCache.deletePrice(priceFeedId);
+							deliveredFeedIds.delete(priceFeedId);
+
+							const subscriptionId = MutableHashMap.get(
 								subscriptions,
-								newPriceFeedId,
-								newSubscriptionId,
+								priceFeedId,
 							);
-
-							lazerClient.subscribe({
-								type: "subscribe",
-								channel: config.channel,
-								formats: ["solana"],
-								properties: [
-									"bestAskPrice",
-									"bestBidPrice",
-									"confidence",
-									"emaConfidence",
-									"emaPrice",
-									"exponent",
-									"feedUpdateTimestamp",
-									"fundingRate",
-									"fundingRateInterval",
-									"fundingTimestamp",
-									"marketSession",
-									"price",
-									"publisherCount",
-								],
-								subscriptionId: newSubscriptionId,
-								priceFeedIds: [newPriceFeedId],
-								// Recommended by Pyth case a previously valid feed id becomes invalid (delisting, id changed, etc.)
-								ignoreInvalidFeedIds: true,
-							});
-						}).pipe(Effect.forever),
-					);
-
-					yield* forkIdleCleanup({
-						lastRequest: lastRequestToPriceFeed,
-						ttl: config.priceFeedsCleanupTtl,
-						interval: config.priceFeedsCleanupInterval,
-						onExpire: (priceFeedId) =>
-							Effect.gen(function* () {
-								yield* Effect.logInfo(`Cleaning up price feed ${priceFeedId}`);
-								yield* priceCache.deletePrice(priceFeedId);
-
-								const subscriptionId = MutableHashMap.get(
-									subscriptions,
-									priceFeedId,
-								);
-								if (Option.isSome(subscriptionId)) {
+							if (Option.isSome(subscriptionId)) {
+								// A feed carried by the bulk subscription must not
+								// unsubscribe it: that would drop every other feed. Removing
+								// it from the map stops cache writes immediately; the next
+								// compaction pass rebuilds the bulk subscription without it.
+								if (subscriptionId.value !== bulkSubscriptionId) {
 									lazerClient.unsubscribe(subscriptionId.value);
-									MutableHashMap.remove(subscriptions, priceFeedId);
-
-									const symbol = getSymbolByPriceFeedId(priceFeedId);
-									if (Option.isSome(symbol)) {
-										MutableHashMap.remove(symbolsToId, symbol.value);
-									}
-
-									yield* Effect.logInfo(
-										`Unsubscribed from price feed ${priceFeedId}`,
-									);
+									sideSubscriptionIds.delete(subscriptionId.value);
 								}
+								MutableHashMap.remove(subscriptions, priceFeedId);
+
+								const symbol = getSymbolByPriceFeedId(priceFeedId);
+								if (Option.isSome(symbol)) {
+									MutableHashMap.remove(symbolsToId, symbol.value);
+								}
+
+								yield* Effect.logInfo(
+									`Unsubscribed from price feed ${priceFeedId}`,
+								);
+							}
+						}),
+				});
+			}).pipe(Effect.annotateLogs("_name", "pyth-lazer"));
+
+		const handleRequest = (
+			route: Route,
+			params: Record<string, string>,
+			request: Request,
+		) =>
+			Effect.gen(function* () {
+				if (route.type !== "pyth-lazer") {
+					return yield* Effect.fail(
+						new FailedToHandleRequest({
+							msg: "Route is not a Pyth Lazer module",
+						}),
+					);
+				}
+
+				const priceFeedIdsRaw = replaceParams(
+					route.fetchFromModule,
+					params,
+				).split(",");
+
+				if (priceFeedIdsRaw.length > config.maxFeedsPerRequest) {
+					return yield* Effect.succeed(
+						createErrorResponse(
+							new FailedToHandlePythLazerRequestError({
+								error: `Too many price feed IDs, max is ${config.maxFeedsPerRequest} but got ${priceFeedIdsRaw.length}`,
 							}),
-					});
-				}).pipe(Effect.annotateLogs("_name", "pyth-lazer"));
+							400,
+						),
+					);
+				}
 
-			const handleRequest = (
-				route: Route,
-				params: Record<string, string>,
-				request: Request,
-			) =>
-				Effect.gen(function* () {
-					if (route.type !== "pyth-lazer") {
-						return yield* Effect.fail(
-							new FailedToHandleRequest({
-								msg: "Route is not a Pyth Lazer module",
-							}),
-						);
-					}
+				// Normalize the ids or symbols to price feed ids. Unknown symbols hit
+				// the metadata service, so they are resolved concurrently instead of
+				// serializing one round trip per symbol.
+				const priceFeedIds = yield* Effect.forEach(
+					priceFeedIdsRaw,
+					(symbolOrId) =>
+						Effect.gen(function* () {
+							if (!Number.isNaN(Number(symbolOrId))) {
+								return Number(symbolOrId);
+							}
 
-					const priceFeedIdsRaw = replaceParams(
-						route.fetchFromModule,
-						params,
-					).split(",");
-
-					if (priceFeedIdsRaw.length > config.maxFeedsPerRequest) {
-						return yield* Effect.succeed(
-							createErrorResponse(
-								new FailedToHandlePythLazerRequestError({
-									error: `Too many price feed IDs, max is ${config.maxFeedsPerRequest} but got ${priceFeedIdsRaw.length}`,
-								}),
-								400,
-							),
-						);
-					}
-
-					const priceFeedIds: number[] = [];
-
-					// Normalize the ids or symbols to price feed ids
-					for (const symbolOrId of priceFeedIdsRaw) {
-						if (Number.isNaN(Number(symbolOrId))) {
 							// Let's check if the symbol exists otherwise
 							const cachedSymbolToPriceFeedId = MutableHashMap.get(
 								symbolsToId,
@@ -307,8 +466,7 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 							);
 
 							if (Option.isSome(cachedSymbolToPriceFeedId)) {
-								priceFeedIds.push(cachedSymbolToPriceFeedId.value);
-								continue;
+								return cachedSymbolToPriceFeedId.value;
 							}
 
 							const priceFeedId = yield* getPriceIdBySymbol(
@@ -317,64 +475,65 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 							);
 
 							MutableHashMap.set(symbolsToId, symbolOrId, priceFeedId);
-							priceFeedIds.push(priceFeedId);
-						} else {
-							priceFeedIds.push(Number(symbolOrId));
-						}
-					}
-
-					const prices: PriceFeedWithSymbol[] = [];
-					const now = yield* Clock.currentTimeMillis;
-
-					// First subscribe to all the symbols that we have not subscribed to yet
-					for (const priceFeedId of priceFeedIds) {
-						if (!MutableHashMap.has(lastRequestToPriceFeed, priceFeedId)) {
-							yield* newPriceFeedRequests.offer(priceFeedId);
-						}
-
-						MutableHashMap.set(lastRequestToPriceFeed, priceFeedId, now);
-					}
-
-					// Now since the subscriptions are in-flight, we can fetch the prices concurrently.
-					const results = yield* Effect.forEach(
-						priceFeedIds,
-						(priceFeedId) =>
-							Effect.either(priceCache.getOrWaitPrice(priceFeedId)),
-						{ concurrency: "unbounded" },
-					);
-
-					for (let i = 0; i < priceFeedIds.length; i++) {
-						const priceFeedId = priceFeedIds[i];
-						const price = results[i];
-
-						if (Either.isLeft(price)) {
-							prices.push({
-								priceFeedId,
-								symbol: priceFeedIdsRaw.at(i),
-								[HAS_PRICE_KEY]: false,
-							});
-						} else {
-							prices.push({
-								...price.right,
-								symbol: priceFeedIdsRaw.at(i),
-								[HAS_PRICE_KEY]: true,
-							});
-						}
-					}
-
-					return yield* Effect.succeed(
-						new Response(JSON.stringify(prices), { status: 200 }),
-					);
-				}).pipe(
-					Effect.withSpan("handlePythLazerRequest"),
-					Effect.catchAll((error) => {
-						return Effect.succeed(createErrorResponse(error, error.status));
-					}),
+							return priceFeedId;
+						}),
+					{ concurrency: "unbounded" },
 				);
 
-			return {
-				start,
-				handleRequest,
-			};
-		}),
-	);
+				const prices: PriceFeedWithSymbol[] = [];
+				const now = yield* Clock.currentTimeMillis;
+
+				// First subscribe to all the symbols that we have not subscribed to yet.
+				// The subscriptions map is the source of truth: a lastRequest entry can
+				// outlive its subscription when a request races the idle cleanup, and
+				// the subscribe daemon dedupes any double offer.
+				for (const priceFeedId of priceFeedIds) {
+					if (!MutableHashMap.has(subscriptions, priceFeedId)) {
+						yield* newPriceFeedRequests.offer(priceFeedId);
+					}
+
+					MutableHashMap.set(lastRequestToPriceFeed, priceFeedId, now);
+				}
+
+				// Now since the subscriptions are in-flight, we can fetch the prices concurrently.
+				const results = yield* Effect.forEach(
+					priceFeedIds,
+					(priceFeedId) =>
+						Effect.either(priceCache.getOrWaitPrice(priceFeedId)),
+					{ concurrency: "unbounded" },
+				);
+
+				for (let i = 0; i < priceFeedIds.length; i++) {
+					const priceFeedId = priceFeedIds[i];
+					const price = results[i];
+
+					if (Either.isLeft(price)) {
+						prices.push({
+							priceFeedId,
+							symbol: priceFeedIdsRaw.at(i),
+							[HAS_PRICE_KEY]: false,
+						});
+					} else {
+						prices.push({
+							...price.right,
+							symbol: priceFeedIdsRaw.at(i),
+							[HAS_PRICE_KEY]: true,
+						});
+					}
+				}
+
+				return yield* Effect.succeed(
+					new Response(JSON.stringify(prices), { status: 200 }),
+				);
+			}).pipe(
+				Effect.withSpan("handlePythLazerRequest"),
+				Effect.catchAll((error) => {
+					return Effect.succeed(createErrorResponse(error, error.status));
+				}),
+			);
+
+		return {
+			start,
+			handleRequest,
+		};
+	});


### PR DESCRIPTION
Per-feed Pyth Lazer subscriptions make the upstream send one WS frame per feed per channel tick, which saturates the single event loop: request latency tails and price staleness both balloon, and the congestion spills onto unrelated routes that share the proxy process.