### PR TITLE
feat(multi): add a multi route that fans out to several modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,136 @@ The JSON Path also supports path parameters using the `{:PARAM}` syntax:
 }
 ```
 
+### Module routes
+
+In addition to forwarding HTTP requests to an upstream URL, routes can call **modules** — long-lived integrations that subscribe to live feeds (WebSocket or similar) and serve prices from an in-memory cache.
+
+Module routes are declared in two places:
+
+1. **`modules`** — one entry per integration (connection settings, credentials, and so on).
+2. **`routes`** — a route with a module `type` (for example `binance`, `lighter`, or `multi`) that points at a module by `moduleName`.
+
+Supported module types include `pyth-lazer`, `chainlink-streams`, `dxfeed`, `hydromancer`, `lo-tech`, `pm-insights`, `binance`, and `lighter`. Each module has its own config fields; see the example configs under `configs/` for full options.
+
+#### Single module route
+
+A module route uses `fetchFromModule` (and sometimes `body`) as a template. Path parameters from the inbound request are substituted with the `{:param}` syntax, same as upstream URLs.
+
+Binance example — comma-separated symbols, resolved from the path:
+
+```jsonc
+{
+  "routeGroup": "proxy",
+  "modules": [{ "name": "bin", "type": "binance" }],
+  "routes": [
+    {
+      "type": "binance",
+      "moduleName": "bin",
+      "path": "/binance/:symbols",
+      "method": ["GET"],
+      "fetchFromModule": "{:symbols}"
+    }
+  ]
+}
+```
+
+```bash
+curl "http://127.0.0.1:5384/proxy/binance/BTCUSDT,ETHUSDT"
+```
+
+Lighter example — numeric market ids (for example `1` for BTC on mainnet):
+
+```jsonc
+{
+  "modules": [{ "name": "lig", "type": "lighter" }],
+  "routes": [
+    {
+      "type": "lighter",
+      "moduleName": "lig",
+      "path": "/lighter/:markets",
+      "method": ["GET"],
+      "fetchFromModule": "{:markets}"
+    }
+  ]
+}
+```
+
+Module responses include a per-item `__sedaHasPrice` flag (`true` when a price was resolved, `false` on timeout or invalid input). The first request for a new symbol may need a retry while the WebSocket subscription warms up.
+
+#### Multi routes
+
+A **multi** route fans out to several module handlers in one request. Each entry in `fetches` runs concurrently; results are merged into a single JSON object keyed by fetch `name`.
+
+- **`fetchFromModule`** — forwarded to modules that read symbols or ids from a template (Binance, Lighter, Pyth, and so on).
+- **`body`** — forwarded to modules that expect a request body (for example Hydromancer `assetContext`).
+- Sub-fetch failures are **non-fatal**: the failing source appears as an `{ "error": "...", "status": ... }` entry; other sources still resolve. The multi route itself returns HTTP `200`.
+- Fetch `name` values must be **unique** within a route (validated at startup).
+
+Example — Binance spot, Lighter perp ticker, and Hydromancer asset context in one call (see also `configs/config-multi-fetcher.jsonc`):
+
+```jsonc
+{
+  "routeGroup": "proxy",
+  "modules": [
+    { "name": "bin", "type": "binance" },
+    { "name": "lig", "type": "lighter" },
+    {
+      "name": "hydro",
+      "type": "hydromancer",
+      "wsUrl": "wss://api.hydromancer.xyz/ws",
+      "restBaseUrl": "https://api.hydromancer.xyz",
+      "hydromancerApiKeyEnvKey": "HYDROMANCER_API_KEY_MAINNET"
+    }
+  ],
+  "routes": [
+    {
+      "type": "multi",
+      "path": "/multi/:symbol/:market/:hydroTicker",
+      "method": ["GET"],
+      "fetches": [
+        {
+          "name": "binance",
+          "moduleName": "bin",
+          "type": "binance",
+          "fetchFromModule": "{:symbol}USDT"
+        },
+        {
+          "name": "lighter",
+          "moduleName": "lig",
+          "type": "lighter",
+          "fetchFromModule": "{:market}"
+        },
+        {
+          "name": "hydromancer",
+          "moduleName": "hydro",
+          "type": "hydromancer",
+          "body": "{\"type\":\"assetContext\",\"coin\":\"{:hydroTicker}\"}"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Test locally (disable proof verification for easier debugging):
+
+```bash
+curl -s "http://127.0.0.1:5384/proxy/multi/BTC/1/BTC" | jq .
+```
+
+Example response shape:
+
+```jsonc
+{
+  "binance": [{ "symbol": "BTC", "__sedaHasPrice": true, "s": "BTCUSDT", "b": "...", "a": "..." }],
+  "lighter": [{ "marketId": "1", "__sedaHasPrice": true, "s": "BTC", "b": { "price": "..." } }],
+  "hydromancer": { "coin": "BTC", "markPx": "...", "..." }
+}
+```
+
+> [!NOTE]
+> Multi routes skip the global `__sedaHasPrice` gate used on single-source routes, because a partial miss on one source is expected and reported inside the combined payload.
+
 ### Status Endpoint
 
 The Data Proxy node has support for exposing status information through some endpoints. This can be used to monitor the health of the node and the number of requests it has processed.

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -766,4 +766,110 @@ describe("parseConfig", () => {
 			);
 		});
 	});
+
+	describe("multi route", () => {
+		const baseModules = [{ name: "bin", type: "binance" }];
+
+		it("accepts a multi route whose fetches reference configured modules", async () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					modules: baseModules,
+					routes: [
+						{
+							type: "multi",
+							path: "/multi/:symbol",
+							fetches: [
+								{
+									name: "binance",
+									moduleName: "bin",
+									type: "binance",
+									fetchFromModule: "{:symbol}USDT",
+								},
+							],
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeOkResult();
+		});
+
+		it("rejects a fetch referencing an unknown module", async () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					modules: baseModules,
+					routes: [
+						{
+							type: "multi",
+							path: "/multi/:symbol",
+							fetches: [
+								{
+									name: "ghost",
+									moduleName: "nope",
+									type: "binance",
+									fetchFromModule: "{:symbol}",
+								},
+							],
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				'Multi route fetch "ghost" references unknown module "nope"',
+			);
+		});
+
+		it("rejects a fetch whose type does not match the module", async () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					modules: baseModules,
+					routes: [
+						{
+							type: "multi",
+							path: "/multi/:symbol",
+							fetches: [
+								{
+									name: "mismatch",
+									moduleName: "bin",
+									type: "lighter",
+									fetchFromModule: "{:symbol}",
+								},
+							],
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				'Multi route fetch "mismatch" has type "lighter" but module "bin" is "binance"',
+			);
+		});
+
+		it("rejects a fetch template var that the path does not provide", async () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					modules: baseModules,
+					routes: [
+						{
+							type: "multi",
+							path: "/multi/:symbol",
+							fetches: [
+								{
+									name: "binance",
+									moduleName: "bin",
+									type: "binance",
+									fetchFromModule: "{:missing}",
+								},
+							],
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				'Multi route fetch "binance" requires :missing, but it is not given in route /multi/:symbol',
+			);
+		});
+	});
 });

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -871,5 +871,37 @@ describe("parseConfig", () => {
 				'Multi route fetch "binance" requires :missing, but it is not given in route /multi/:symbol',
 			);
 		});
+
+		it("rejects duplicate fetch names", async () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					modules: baseModules,
+					routes: [
+						{
+							type: "multi",
+							path: "/multi/:symbol",
+							fetches: [
+								{
+									name: "dup",
+									moduleName: "bin",
+									type: "binance",
+									fetchFromModule: "{:symbol}USDT",
+								},
+								{
+									name: "dup",
+									moduleName: "bin",
+									type: "binance",
+									fetchFromModule: "{:symbol}USD",
+								},
+							],
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				'Multi route /multi/:symbol has a duplicate fetch name "dup"; fetch names must be unique',
+			);
+		});
 	});
 });

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -45,6 +45,10 @@ import {
 } from "./lo-tech-module-config";
 import { type Modules, ModulesSchema } from "./module-config";
 import {
+	type MultiModuleRoute,
+	MultiModuleRouteSchema,
+} from "./multi-module-config";
+import {
 	type PmInsightsModuleRoute,
 	PmInsightsModuleRouteSchema,
 	validatePmInsightsModuleRoute,
@@ -142,6 +146,7 @@ const ConfigSchema = v.strictObject(
 				PmInsightsModuleRouteSchema,
 				BinanceModuleRouteSchema,
 				LighterModuleRouteSchema,
+				MultiModuleRouteSchema,
 			]),
 		),
 		baseURL: maybe(v.string()),
@@ -179,7 +184,8 @@ export type Route =
 	| LoTechModuleRoute
 	| PmInsightsModuleRoute
 	| BinanceModuleRoute
-	| LighterModuleRoute;
+	| LighterModuleRoute
+	| MultiModuleRoute;
 
 export interface Config extends v.InferOutput<typeof ConfigSchema> {
 	modules: Modules[];
@@ -303,6 +309,45 @@ export const parseConfig = (
 
 			if (route.type === "lighter") {
 				yield* validateLighterModuleRoute(route);
+				continue;
+			}
+
+			if (route.type === "multi") {
+				for (const fetch of route.fetches) {
+					const target = config.modules.find(
+						(m) => m.name === fetch.moduleName,
+					);
+					if (!target) {
+						return [
+							Result.err(
+								`Multi route fetch "${fetch.name}" references unknown module "${fetch.moduleName}"`,
+							),
+							hasWarnings,
+						];
+					}
+					if (target.type !== fetch.type) {
+						return [
+							Result.err(
+								`Multi route fetch "${fetch.name}" has type "${fetch.type}" but module "${fetch.moduleName}" is "${target.type}"`,
+							),
+							hasWarnings,
+						];
+					}
+					// Every {:var} used by a fetch template must be provided by the path.
+					for (const template of [fetch.fetchFromModule, fetch.body]) {
+						if (!template) continue;
+						for (const match of template.matchAll(varRegex)) {
+							if (!route.path.includes(match[1])) {
+								return [
+									Result.err(
+										`Multi route fetch "${fetch.name}" requires ${match[1]}, but it is not given in route ${route.path}`,
+									),
+									hasWarnings,
+								];
+							}
+						}
+					}
+				}
 				continue;
 			}
 

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -313,7 +313,19 @@ export const parseConfig = (
 			}
 
 			if (route.type === "multi") {
+				const seenFetchNames = new Set<string>();
 				for (const fetch of route.fetches) {
+					// Fetch names key the combined response, so a duplicate silently overwrites an earlier fetch.
+					if (seenFetchNames.has(fetch.name)) {
+						return [
+							Result.err(
+								`Multi route ${route.path} has a duplicate fetch name "${fetch.name}"; fetch names must be unique`,
+							),
+							hasWarnings,
+						];
+					}
+					seenFetchNames.add(fetch.name);
+
 					const target = config.modules.find(
 						(m) => m.name === fetch.moduleName,
 					);

--- a/workspace/data-proxy/src/config/multi-module-config.ts
+++ b/workspace/data-proxy/src/config/multi-module-config.ts
@@ -1,0 +1,44 @@
+import * as v from "valibot";
+import { RouteSchema } from "./route-config";
+
+// Module types a multi fetch can target. These are the modules backed by a
+// ModuleService handler (upstream is excluded: it is handled inline by the
+// proxy controller, not through a module handler).
+export const MULTI_FETCH_TYPES = [
+	"pyth-lazer",
+	"chainlink-streams",
+	"dxfeed",
+	"hydromancer",
+	"lo-tech",
+	"pm-insights",
+	"binance",
+	"lighter",
+] as const;
+
+// A single sub-request inside a multi route. `fetchFromModule` and `body` are
+// templates filled from the inbound request path params via replaceParams; the
+// resolved value is forwarded to the target module's own handler.
+export const MultiFetchSchema = v.strictObject({
+	name: v.string(),
+	moduleName: v.string(),
+	type: v.picklist(MULTI_FETCH_TYPES),
+	fetchFromModule: v.optional(v.string()),
+	body: v.optional(v.string()),
+	allowedQueryParams: v.optional(v.array(v.string())),
+});
+
+export type MultiFetch = v.InferOutput<typeof MultiFetchSchema>;
+
+export const MultiModuleRouteSchema = v.strictObject({
+	...RouteSchema.entries,
+	type: v.literal("multi"),
+	// Unused by multi routes (which dispatch via `fetches`), but kept so the
+	// route union exposes a uniform `moduleName`, matching the other routes.
+	moduleName: v.optional(v.string(), "default"),
+	fetches: v.pipe(
+		v.array(MultiFetchSchema),
+		v.minLength(1, "A multi route needs at least one fetch"),
+	),
+});
+
+export type MultiModuleRoute = v.InferOutput<typeof MultiModuleRouteSchema>;

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import type { MultiModuleRoute } from "../../config/multi-module-config";
+import {
+	FailedToHandleRequest,
+	type ModuleHandlers,
+} from "../../modules/module";
+import { handleMultiRequest } from "./handle-multi-request";
+
+const handlers = (
+	handleRequest: ModuleHandlers["handleRequest"],
+): ModuleHandlers => ({
+	start: () => Effect.succeed(undefined),
+	handleRequest,
+});
+
+// Echoes back what the synthetic route/body carried so tests can assert the
+// templates were filled and forwarded.
+const echoHandlers = handlers((route, _params, _request, body) =>
+	Effect.succeed(
+		new Response(
+			JSON.stringify({ fetchFromModule: route.fetchFromModule, body }),
+			{ status: 200 },
+		),
+	),
+);
+
+const makeRoute = (fetches: MultiModuleRoute["fetches"]): MultiModuleRoute =>
+	({
+		type: "multi",
+		moduleName: "default",
+		path: "/multi/:symbol/:index",
+		method: ["GET"],
+		fetches,
+		headers: {},
+		useLegacyJsonPath: true,
+		forwardResponseHeaders: new Set<string>(),
+	}) as unknown as MultiModuleRoute;
+
+const run = (route: MultiModuleRoute, map: Map<string, ModuleHandlers>) =>
+	Effect.runPromise(
+		handleMultiRequest(
+			route,
+			{ symbol: "BTC", index: "1" },
+			new Request("http://localhost/multi/BTC/1"),
+			map,
+		).pipe(Effect.flatMap((res) => Effect.promise(() => res.json()))),
+	);
+
+describe("handleMultiRequest", () => {
+	it("fills each fetch template from the request params and keys results by name", async () => {
+		const route = makeRoute([
+			{
+				name: "binance",
+				moduleName: "bin",
+				type: "binance",
+				fetchFromModule: "{:symbol}USDT",
+			},
+			{
+				name: "lighter",
+				moduleName: "lig",
+				type: "lighter",
+				fetchFromModule: "{:index}",
+			},
+		]);
+		const map = new Map<string, ModuleHandlers>([
+			["bin", echoHandlers],
+			["lig", echoHandlers],
+		]);
+
+		const body = await run(route, map);
+		expect(body).toEqual({
+			binance: { fetchFromModule: "BTCUSDT" },
+			lighter: { fetchFromModule: "1" },
+		});
+	});
+
+	it("fills a body template and forwards it to the target module", async () => {
+		const route = makeRoute([
+			{
+				name: "hydro",
+				moduleName: "hydro",
+				type: "hydromancer",
+				body: '{"type":"assetContext","coins":["{:symbol}"]}',
+			},
+		]);
+		const map = new Map<string, ModuleHandlers>([["hydro", echoHandlers]]);
+
+		const body = await run(route, map);
+		expect(body).toEqual({
+			hydro: {
+				fetchFromModule: "",
+				body: '{"type":"assetContext","coins":["BTC"]}',
+			},
+		});
+	});
+
+	it("records a per-fetch error for a missing module without failing the request", async () => {
+		const route = makeRoute([
+			{
+				name: "binance",
+				moduleName: "bin",
+				type: "binance",
+				fetchFromModule: "{:symbol}",
+			},
+			{
+				name: "ghost",
+				moduleName: "ghost",
+				type: "lighter",
+				fetchFromModule: "{:index}",
+			},
+		]);
+		const map = new Map<string, ModuleHandlers>([["bin", echoHandlers]]);
+
+		const body = (await run(route, map)) as Record<string, unknown>;
+		expect(body.binance).toEqual({ fetchFromModule: "BTC" });
+		expect(body.ghost).toEqual({
+			error: "Module ghost not found",
+			status: 500,
+		});
+	});
+
+	it("captures a sub-fetch handler failure as an error entry", async () => {
+		const failing = handlers(() =>
+			Effect.fail(new FailedToHandleRequest({ msg: "boom" })),
+		);
+		const route = makeRoute([
+			{
+				name: "binance",
+				moduleName: "bin",
+				type: "binance",
+				fetchFromModule: "{:symbol}",
+			},
+			{
+				name: "broken",
+				moduleName: "brk",
+				type: "lighter",
+				fetchFromModule: "{:index}",
+			},
+		]);
+		const map = new Map<string, ModuleHandlers>([
+			["bin", echoHandlers],
+			["brk", failing],
+		]);
+
+		const body = (await run(route, map)) as Record<string, unknown>;
+		expect(body.binance).toEqual({ fetchFromModule: "BTC" });
+		expect(body.broken).toEqual({
+			error: "Failed to handle request: boom",
+			status: 500,
+		});
+	});
+
+	it("captures a non-ok sub-fetch response", async () => {
+		const notOk = handlers(() =>
+			Effect.succeed(
+				new Response(JSON.stringify({ reason: "bad" }), { status: 502 }),
+			),
+		);
+		const route = makeRoute([
+			{
+				name: "x",
+				moduleName: "x",
+				type: "lighter",
+				fetchFromModule: "{:index}",
+			},
+		]);
+		const map = new Map<string, ModuleHandlers>([["x", notOk]]);
+
+		const body = (await run(route, map)) as Record<string, unknown>;
+		expect(body.x).toEqual({
+			error: "Sub-fetch returned a non-ok response",
+			status: 502,
+			body: { reason: "bad" },
+		});
+	});
+});

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
@@ -45,7 +45,7 @@ export const handleMultiRequest = (
 						headers: {},
 						useLegacyJsonPath: true,
 						forwardResponseHeaders: new Set<string>(),
-					} as unknown as Route;
+					} as Route;
 
 					const result = yield* Effect.either(
 						handlers.handleRequest(syntheticRoute, params, request, body),

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
@@ -1,0 +1,99 @@
+import { Effect, Either } from "effect";
+import type { Route } from "../../config/config-parser";
+import type { MultiModuleRoute } from "../../config/multi-module-config";
+import type { ModuleHandlers } from "../../modules/module";
+import { replaceParams } from "../../utils/replace-params";
+
+// Fans a multi route out to its configured sub-fetches concurrently, forwarding
+// each to its target module's own handler and collecting the raw responses
+// keyed by fetch name. Sub-fetch failures are non-fatal: the failing entry
+// carries an error and the rest still resolve. The combined object is returned
+// as one response for the proxy to sign.
+export const handleMultiRequest = (
+	route: MultiModuleRoute,
+	params: Record<string, string>,
+	request: Request,
+	moduleHandlers: ReadonlyMap<string, ModuleHandlers>,
+) =>
+	Effect.gen(function* () {
+		const entries = yield* Effect.forEach(
+			route.fetches,
+			(fetch) =>
+				Effect.gen(function* () {
+					const handlers = moduleHandlers.get(fetch.moduleName);
+					if (!handlers) {
+						return [
+							fetch.name,
+							{ error: `Module ${fetch.moduleName} not found`, status: 500 },
+						] as const;
+					}
+
+					const fetchFromModule = fetch.fetchFromModule
+						? replaceParams(fetch.fetchFromModule, params)
+						: "";
+					const body = fetch.body
+						? replaceParams(fetch.body, params)
+						: undefined;
+
+					const syntheticRoute = {
+						type: fetch.type,
+						moduleName: fetch.moduleName,
+						fetchFromModule,
+						path: route.path,
+						method: route.method,
+						allowedQueryParams: fetch.allowedQueryParams ?? [],
+						headers: {},
+						useLegacyJsonPath: true,
+						forwardResponseHeaders: new Set<string>(),
+					} as unknown as Route;
+
+					const result = yield* Effect.either(
+						handlers.handleRequest(syntheticRoute, params, request, body),
+					);
+
+					if (Either.isLeft(result)) {
+						return [
+							fetch.name,
+							{ error: result.left.message, status: result.left.status },
+						] as const;
+					}
+
+					const response = result.right;
+					const text = yield* Effect.tryPromise({
+						try: () => response.text(),
+						catch: (error) => new Error(`${error}`),
+					}).pipe(Effect.catchAll(() => Effect.succeed("")));
+
+					let parsed: unknown;
+					try {
+						parsed = text.length > 0 ? JSON.parse(text) : null;
+					} catch {
+						parsed = text;
+					}
+
+					if (!response.ok) {
+						return [
+							fetch.name,
+							{
+								error: "Sub-fetch returned a non-ok response",
+								status: response.status,
+								body: parsed,
+							},
+						] as const;
+					}
+
+					return [fetch.name, parsed] as const;
+				}),
+			{ concurrency: "unbounded" },
+		);
+
+		const combined: Record<string, unknown> = {};
+		for (const [name, value] of entries) {
+			combined[name] = value;
+		}
+
+		return new Response(JSON.stringify(combined), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	});

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -8,6 +8,7 @@ import {
 	QueryJsonError,
 	UpstreamRequestFailedError,
 } from "../../errors";
+import type { ModuleHandlers } from "../../modules/module";
 import { ModuleService } from "../../modules/module";
 import type { ProxyServerOptions } from "../../proxy-server";
 import { HttpClientService } from "../../services/http-client";
@@ -18,6 +19,7 @@ import { replaceParams } from "../../utils/replace-params";
 import { createUrlSearchParams } from "../../utils/search-params";
 import { injectSearchParamsInUrl } from "../../utils/url";
 import { createErrorResponse } from "../create-error-response";
+import { handleMultiRequest } from "./handle-multi-request";
 import { verifyProof } from "./verify-proof";
 
 export type HandleProxyRequestParams = {
@@ -31,6 +33,9 @@ export type HandleProxyRequestParams = {
 	config: Config;
 	request: Request;
 	route: Config["routes"][number];
+	// Resolved module handlers keyed by module name, used by multi routes to
+	// fan out to several modules in one request.
+	moduleHandlers: ReadonlyMap<string, ModuleHandlers>;
 };
 
 export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
@@ -48,6 +53,7 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 			request,
 			dataProxy,
 			route,
+			moduleHandlers,
 		} = inputParams;
 
 		if (!serverOptions.disableProof) {
@@ -144,6 +150,17 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 						lighterModuleRoute,
 						params,
 						request,
+					);
+				}),
+			),
+			Match.when({ type: "multi" }, (multiModuleRoute) =>
+				Effect.gen(function* () {
+					yield* Effect.logDebug("Handling multi request");
+					return yield* handleMultiRequest(
+						multiModuleRoute,
+						params,
+						request,
+						moduleHandlers,
 					);
 				}),
 			),
@@ -284,7 +301,9 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 
 		// TEMP: This is added for older ops who may not handle __sedaHasPrice key in the response.
 		// we should remove this once all ops have updated to the new response format.
-		if (!requestSearchParams.has("skipPriceErrors")) {
+		// Multi routes return arbitrary per-source payloads where a per-source miss
+		// is expected, so the price gate does not apply.
+		if (route.type !== "multi" && !requestSearchParams.has("skipPriceErrors")) {
 			if (upstreamTextResponse.includes(`"${HAS_PRICE_KEY}":false`)) {
 				return yield* Effect.fail(
 					new NotOkUpstreamResponseError({

--- a/workspace/data-proxy/src/modules/module.ts
+++ b/workspace/data-proxy/src/modules/module.ts
@@ -8,17 +8,19 @@ export class FailedToHandleRequest extends Data.TaggedError(
 	status = 500;
 }
 
+export interface ModuleHandlers {
+	start: () => Effect.Effect<void>;
+	handleRequest: (
+		route: Route,
+		params: Record<string, string>,
+		request: Request,
+		body?: string,
+	) => Effect.Effect<Response, FailedToHandleRequest>;
+}
+
 export class ModuleService extends Context.Tag("ModuleService")<
 	ModuleService,
-	{
-		start: () => Effect.Effect<void>;
-		handleRequest: (
-			route: Route,
-			params: Record<string, string>,
-			request: Request,
-			body?: string,
-		) => Effect.Effect<Response, FailedToHandleRequest>;
-	}
+	ModuleHandlers
 >() {}
 
 export const EmptyModuleService = Layer.effect(

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -14,7 +14,11 @@ import { DxFeedModuleService } from "./modules/dxfeed/dxfeed";
 import { HydromancerModuleService } from "./modules/hydromancer/hydromancer";
 import { LighterModuleService } from "./modules/lighter/lighter";
 import { LoTechModuleService } from "./modules/lo-tech/lo-tech";
-import { EmptyModuleService, ModuleService } from "./modules/module";
+import {
+	EmptyModuleService,
+	type ModuleHandlers,
+	ModuleService,
+} from "./modules/module";
 import { PmInsightsModuleService } from "./modules/pm-insights/pm-insights";
 import { PythLazerModuleService } from "./modules/pyth-lazer/pyth-lazer";
 import type { HttpClientService } from "./services/http-client";
@@ -38,6 +42,9 @@ export const startProxyServer = (
 			string,
 			Layer.Layer<ModuleService, unknown, never>
 		>();
+		// Resolved module handlers keyed by module name, so multi routes can fan
+		// out to several modules within a single request.
+		const moduleHandlers = new Map<string, ModuleHandlers>();
 
 		// Initialize the modules and start them
 		for (const moduleConfig of config.modules) {
@@ -72,6 +79,7 @@ export const startProxyServer = (
 			yield* Effect.gen(function* () {
 				const moduleService = yield* ModuleService;
 				yield* moduleService.start();
+				moduleHandlers.set(moduleConfig.name, moduleService);
 			}).pipe(Effect.provide(moduleLayer));
 
 			MutableHashMap.set(modules, moduleConfig.name, moduleLayer);
@@ -213,6 +221,7 @@ export const startProxyServer = (
 										route,
 										config,
 										dataProxy,
+										moduleHandlers,
 									}).pipe(Effect.provide(moduleLayer));
 								}).pipe(
 									withIncomingTrace,


### PR DESCRIPTION
Adds a generic `multi` route that forwards one inbound request to a configured list of named sub-fetches and returns each module's raw response side by side, so a single endpoint can pull from several modules (e.g. binance, lighter, hydromancer) at once. Each fetch targets any module by name with its own `fetchFromModule` path template and/or `body` template, filled from the inbound request via `replaceParams`; the proxy reuses each target module's own handler, so it stays type-agnostic and does no interpretation or blending. Fetches run concurrently, a per-fetch failure or miss becomes a non-fatal `{error, status}` entry rather than failing the request, and multi is exempt from the `__sedaHasPrice` gate since per-source misses are expected. The combined object is signed once like any other route.

Example: `GET /multi/:symbol/:market` with fetches `binance` (`{:symbol}USDT`) and `lighter` (`{:market}`) returns `{ "binance": {...}, "lighter": {...} }`. Startup validation rejects a fetch that references an unknown module, mismatches the module's type, or uses a template variable the path does not provide. Verified with unit tests for the fan-out and config validation, and a live smoke test (happy path, partial miss returning 200, and signature headers present).