### PR TITLE
Support Fast proof without chain ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This will generate two files:
 - `config.json`: Configure where routes are going to and what to inject (ex: headers)
 - `data-proxy-private-key.json`: Private key that signs the HTTP response. This key is registered on the SEDA chain (see below). If required you can also use the `SEDA_DATA_PROXY_PRIVATE_KEY` environment variable to expose the private key to the node.
 
+The private key file may optionally include a `network` field (`devnet`, `testnet`, or `mainnet`). If omitted, no network is configured until you pass `--network` on the CLI. On-chain commands such as `register` and the startup registration check in `run` require a network to be set via `--network` or in the private key file.
+
 Before running the node, the data proxy needs to be registered on-chain:
 
 ```sh
@@ -54,7 +56,7 @@ The registration will output a URL where you can submit your transaction to regi
 Now you can run the node:
 
 ```sh
-# Disables the proofing mechanism so it's easier to debug the proxy
+# Disables the proving mechanism so it's easier to debug the proxy
 bun start run --disable-proof
 
 # The console will output something similiar:

--- a/workspace/data-proxy-sdk/src/config.ts
+++ b/workspace/data-proxy-sdk/src/config.ts
@@ -5,7 +5,7 @@ export enum Environment {
 }
 
 export interface DataProxyOptions {
-	chainId: string;
+	chainId?: string;
 	rpcUrl: string;
 
 	fastAllowedClients: string[];

--- a/workspace/data-proxy-sdk/src/data-proxy.test.ts
+++ b/workspace/data-proxy-sdk/src/data-proxy.test.ts
@@ -1,14 +1,34 @@
 import { describe, expect, it } from "bun:test";
 import { Secp256k1 } from "@cosmjs/crypto";
-import { Effect, Either } from "effect";
+import { Effect, Either, Option } from "effect";
 import { Environment } from "./config";
 import { DataProxy } from "./data-proxy";
+
+type SedaFastProofTestVector = {
+	unixTimestampMs: bigint;
+	signature: string;
+	publicKey?: string;
+	chainId?: string;
+};
+
+function createSedaFastProof(testVector: SedaFastProofTestVector): string {
+	const payload = testVector.chainId
+		? `${testVector.unixTimestampMs}:${testVector.signature}:${testVector.chainId}`
+		: `${testVector.unixTimestampMs}:${testVector.signature}`;
+
+	return Buffer.from(payload, "utf-8").toString("base64");
+}
 
 describe("DataProxy", async () => {
 	const privateKeyBuff = Buffer.from(new Array(32).fill(1));
 	const keyPair = await Secp256k1.makeKeypair(privateKeyBuff);
 
 	const dataProxy = new DataProxy(Environment.Devnet, {
+		privateKey: Buffer.from(keyPair.privkey),
+	});
+
+	// Data proxy without chain ID configured
+	const dataProxyWithoutChainId = new DataProxy(null, {
 		privateKey: Buffer.from(keyPair.privkey),
 	});
 
@@ -64,11 +84,9 @@ describe("DataProxy", async () => {
 				Effect.either(dataProxy.decodeProof(proof.toString("base64"))),
 			);
 
-			if (Either.isLeft(decodedProof)) {
-				throw decodedProof.left.error;
-			}
+			expect(Either.isRight(decodedProof)).toBe(true);
 
-			const { publicKey, drId, signature } = decodedProof.right;
+			const { publicKey, drId, signature } = Either.getOrThrow(decodedProof);
 			expect(publicKey.toString("hex")).toBe(
 				"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
 			);
@@ -90,25 +108,21 @@ describe("DataProxy", async () => {
 				chainId: "seda-1-devnet",
 			};
 
-			const proof = Buffer.from(
-				`${testVector.unixTimestampMs}:${testVector.signature}:${testVector.chainId}`,
-				"utf-8",
-			);
 			const decodedProof = await Effect.runPromise(
-				Effect.either(dataProxy.decodeSedaFastProof(proof.toString("base64"))),
+				Effect.either(
+					dataProxy.decodeSedaFastProof(createSedaFastProof(testVector)),
+				),
 			);
 
-			if (Either.isLeft(decodedProof)) {
-				expect.unreachable("Failed to decode proof");
-			}
+			expect(Either.isRight(decodedProof)).toBe(true);
 
-			const { publicKey, unixTimestampMs, signature } = decodedProof.right;
-			expect(unixTimestampMs).toBe(testVector.unixTimestampMs);
-			expect(publicKey.toString("hex")).toBe(testVector.publicKey);
-			expect(signature.toString("hex")).toBe(testVector.signature);
+			const decoded = Either.getOrThrow(decodedProof);
+			expect(decoded.unixTimestampMs).toBe(testVector.unixTimestampMs);
+			expect(decoded.publicKey.toString("hex")).toBe(testVector.publicKey);
+			expect(decoded.signature.toString("hex")).toBe(testVector.signature);
 		});
 
-		it("should decode a valid SEDA Fast proof without chain id", async () => {
+		it("should accept a SEDA Fast proof without chain id even when chain id is configured", async () => {
 			const testVector = {
 				unixTimestampMs: 1782929240000n,
 				publicKey:
@@ -117,58 +131,113 @@ describe("DataProxy", async () => {
 					"dee3c4fa3bd7a3f88d32f5671cbeb8b7af3ddad6ed102f223859633fb1cf437201fbfbf4f47df7d53d842f9457299e4fbe595dc3791fb43a8331d2ca2c7e9de000",
 			};
 
-			const proof = Buffer.from(
-				`${testVector.unixTimestampMs}:${testVector.signature}`,
-				"utf-8",
+			const decodedProof = await Effect.runPromise(
+				Effect.either(
+					dataProxy.decodeSedaFastProof(createSedaFastProof(testVector)),
+				),
 			);
+
+			expect(Either.isRight(decodedProof)).toBe(true);
+
+			const decoded = Either.getOrThrow(decodedProof);
+			expect(decoded.publicKey.toString("hex")).toBe(testVector.publicKey);
+			expect(decoded.unixTimestampMs).toBe(testVector.unixTimestampMs);
+			expect(decoded.signature.toString("hex")).toBe(testVector.signature);
+		});
+
+		it("should decode a valid SEDA Fast proof without chain id when chain id is not configured", async () => {
+			const testVector = {
+				unixTimestampMs: 1782929240000n,
+				publicKey:
+					"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+				signature:
+					"dee3c4fa3bd7a3f88d32f5671cbeb8b7af3ddad6ed102f223859633fb1cf437201fbfbf4f47df7d53d842f9457299e4fbe595dc3791fb43a8331d2ca2c7e9de000",
+			};
 
 			const decodedProof = await Effect.runPromise(
-				Effect.either(dataProxy.decodeSedaFastProof(proof.toString("base64"))),
+				Effect.either(
+					dataProxyWithoutChainId.decodeSedaFastProof(
+						createSedaFastProof(testVector),
+					),
+				),
 			);
 
-			if (Either.isLeft(decodedProof)) {
-				expect.unreachable("Failed to decode proof");
-			}
+			expect(Either.isRight(decodedProof)).toBe(true);
 
-			const { publicKey, unixTimestampMs, signature } = decodedProof.right;
+			const { publicKey, unixTimestampMs, signature } =
+				Either.getOrThrow(decodedProof);
+			expect(unixTimestampMs).toBe(testVector.unixTimestampMs);
+			expect(publicKey.toString("hex")).toBe(testVector.publicKey);
+			expect(signature.toString("hex")).toBe(testVector.signature);
+		});
+
+		it("should decode a valid SEDA Fast proof with chain id when chain id is not configured", async () => {
+			const testVector = {
+				unixTimestampMs: 0n,
+				publicKey:
+					"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+				signature:
+					"3078599bcc106c0671fd5dbe1c6d1974c66e3efb83cd39e0dd3ab7ffe578777e3a865ef42bd9e9ac3659624ea47def412f2727a45857cca6902190b5afe2c73100",
+				chainId: "seda-1-devnet",
+			};
+
+			const decodedProof = await Effect.runPromise(
+				Effect.either(
+					dataProxyWithoutChainId.decodeSedaFastProof(
+						createSedaFastProof(testVector),
+					),
+				),
+			);
+
+			expect(Either.isRight(decodedProof)).toBe(true);
+
+			const { publicKey, unixTimestampMs, signature } =
+				Either.getOrThrow(decodedProof);
 			expect(unixTimestampMs).toBe(testVector.unixTimestampMs);
 			expect(publicKey.toString("hex")).toBe(testVector.publicKey);
 			expect(signature.toString("hex")).toBe(testVector.signature);
 		});
 
 		it("should not recover the expected public key from the proof if it was tampered with", async () => {
-			const proof = Buffer.from(
-				"1000:3078599bcc106c0671fd5dbe1c6d1974c66e3efb83cd39e0dd3ab7ffe578777e3a865ef42bd9e9ac3659624ea47def412f2727a45857cca6902190b5afe2c73100:seda-1-devnet",
-				"utf-8",
-			);
 			const decodedProof = await Effect.runPromise(
-				Effect.either(dataProxy.decodeSedaFastProof(proof.toString("base64"))),
+				Effect.either(
+					dataProxy.decodeSedaFastProof(
+						createSedaFastProof({
+							unixTimestampMs: 1000n,
+							signature:
+								"3078599bcc106c0671fd5dbe1c6d1974c66e3efb83cd39e0dd3ab7ffe578777e3a865ef42bd9e9ac3659624ea47def412f2727a45857cca6902190b5afe2c73100",
+							chainId: "seda-1-devnet",
+						}),
+					),
+				),
 			);
 
-			if (Either.isLeft(decodedProof)) {
-				expect.unreachable("Failed to decode proof");
-			}
+			expect(Either.isRight(decodedProof)).toBe(true);
 
-			const { publicKey } = decodedProof.right;
+			const { publicKey } = Either.getOrThrow(decodedProof);
 			expect(publicKey.toString("hex")).not.toBe(
 				"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
 			);
 		});
 
 		it("should return an error if the chain id is invalid", async () => {
-			const proof = Buffer.from(
-				"0:3078599bcc106c0671fd5dbe1c6d1974c66e3efb83cd39e0dd3ab7ffe578777e3a865ef42bd9e9ac3659624ea47def412f2727a45857cca6902190b5afe2c73100:seda-1-testnet",
-				"utf-8",
-			);
 			const decodedProof = await Effect.runPromise(
-				Effect.either(dataProxy.decodeSedaFastProof(proof.toString("base64"))),
+				Effect.either(
+					dataProxy.decodeSedaFastProof(
+						createSedaFastProof({
+							unixTimestampMs: 0n,
+							signature:
+								"3078599bcc106c0671fd5dbe1c6d1974c66e3efb83cd39e0dd3ab7ffe578777e3a865ef42bd9e9ac3659624ea47def412f2727a45857cca6902190b5afe2c73100",
+							chainId: "seda-1-testnet",
+						}),
+					),
+				),
 			);
 
-			if (Either.isRight(decodedProof)) {
-				expect.unreachable("Should not be able to decode proof");
-			}
+			expect(Either.isLeft(decodedProof)).toBe(true);
 
-			expect(decodedProof.left.error).toContain("Invalid client chain id");
+			const error = Option.getOrThrow(Either.getLeft(decodedProof));
+			expect(error.error).toContain("Invalid client chain id");
 		});
 	});
 });

--- a/workspace/data-proxy-sdk/src/data-proxy.test.ts
+++ b/workspace/data-proxy-sdk/src/data-proxy.test.ts
@@ -80,9 +80,18 @@ describe("DataProxy", async () => {
 	});
 
 	describe("decodeFastProof", () => {
-		it("should decode a valid SEDA Fast proof", async () => {
+		it("should decode a valid SEDA Fast proof with chain id", async () => {
+			const testVector = {
+				unixTimestampMs: 0n,
+				publicKey:
+					"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+				signature:
+					"3078599bcc106c0671fd5dbe1c6d1974c66e3efb83cd39e0dd3ab7ffe578777e3a865ef42bd9e9ac3659624ea47def412f2727a45857cca6902190b5afe2c73100",
+				chainId: "seda-1-devnet",
+			};
+
 			const proof = Buffer.from(
-				"0:3078599bcc106c0671fd5dbe1c6d1974c66e3efb83cd39e0dd3ab7ffe578777e3a865ef42bd9e9ac3659624ea47def412f2727a45857cca6902190b5afe2c73100:seda-1-devnet",
+				`${testVector.unixTimestampMs}:${testVector.signature}:${testVector.chainId}`,
 				"utf-8",
 			);
 			const decodedProof = await Effect.runPromise(
@@ -93,14 +102,38 @@ describe("DataProxy", async () => {
 				expect.unreachable("Failed to decode proof");
 			}
 
-			const { publicKey, unixTimestamp, signature } = decodedProof.right;
-			expect(unixTimestamp).toBe(0n);
-			expect(publicKey.toString("hex")).toBe(
-				"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+			const { publicKey, unixTimestampMs, signature } = decodedProof.right;
+			expect(unixTimestampMs).toBe(testVector.unixTimestampMs);
+			expect(publicKey.toString("hex")).toBe(testVector.publicKey);
+			expect(signature.toString("hex")).toBe(testVector.signature);
+		});
+
+		it("should decode a valid SEDA Fast proof without chain id", async () => {
+			const testVector = {
+				unixTimestampMs: 1782929240000n,
+				publicKey:
+					"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+				signature:
+					"dee3c4fa3bd7a3f88d32f5671cbeb8b7af3ddad6ed102f223859633fb1cf437201fbfbf4f47df7d53d842f9457299e4fbe595dc3791fb43a8331d2ca2c7e9de000",
+			};
+
+			const proof = Buffer.from(
+				`${testVector.unixTimestampMs}:${testVector.signature}`,
+				"utf-8",
 			);
-			expect(signature.toString("hex")).toBe(
-				"3078599bcc106c0671fd5dbe1c6d1974c66e3efb83cd39e0dd3ab7ffe578777e3a865ef42bd9e9ac3659624ea47def412f2727a45857cca6902190b5afe2c73100",
+
+			const decodedProof = await Effect.runPromise(
+				Effect.either(dataProxy.decodeSedaFastProof(proof.toString("base64"))),
 			);
+
+			if (Either.isLeft(decodedProof)) {
+				expect.unreachable("Failed to decode proof");
+			}
+
+			const { publicKey, unixTimestampMs, signature } = decodedProof.right;
+			expect(unixTimestampMs).toBe(testVector.unixTimestampMs);
+			expect(publicKey.toString("hex")).toBe(testVector.publicKey);
+			expect(signature.toString("hex")).toBe(testVector.signature);
 		});
 
 		it("should not recover the expected public key from the proof if it was tampered with", async () => {

--- a/workspace/data-proxy-sdk/src/data-proxy.ts
+++ b/workspace/data-proxy-sdk/src/data-proxy.ts
@@ -1,9 +1,5 @@
 import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
-import {
-	ExtendedSecp256k1Signature,
-	Secp256k1,
-	keccak256,
-} from "@cosmjs/crypto";
+import { keccak256 } from "@cosmjs/crypto";
 import {
 	type ProtobufRpcClient,
 	QueryClient,
@@ -58,7 +54,7 @@ export class DataProxy {
 	private coreContractAddress: Option.Option<string> = Option.none();
 
 	constructor(
-		public environment: Environment,
+		public environment: Environment | null,
 		optionsOverride: Partial<DataProxyOptions> = {},
 	) {
 		// Remove undefined variables, so that the default config can override them
@@ -70,8 +66,19 @@ export class DataProxy {
 			}
 		}
 
+		const baseConfig =
+			environment !== null
+				? defaultConfig[environment]
+				: {
+						rpcUrl: "",
+						explorerUrl: "",
+						privateKey: Buffer.from([]),
+						fastMaxProofAgeMs: 1000 * 60 * 5,
+						fastAllowedClients: [],
+					};
+
 		this.options = {
-			...defaultConfig[environment],
+			...baseConfig,
 			...optionsOverride,
 		};
 
@@ -82,9 +89,11 @@ export class DataProxy {
 			this.coreContractAddress = Option.some(this.options.coreContract);
 		}
 
-		// Trigger fetching of clients and address
-		this.getCosmWasmClient();
-		this.getCoreContractAddress();
+		if (this.options.rpcUrl) {
+			// Trigger fetching of clients and address
+			this.getCosmWasmClient();
+			this.getCoreContractAddress();
+		}
 	}
 
 	private getCometClient = () =>

--- a/workspace/data-proxy-sdk/src/data-proxy.ts
+++ b/workspace/data-proxy-sdk/src/data-proxy.ts
@@ -277,7 +277,7 @@ export class DataProxy {
 	};
 
 	/**
-	 * Decodes a seda fast proof string into a public key, drId and signature
+	 * Decodes a seda fast proof string into a public key, unix timestamp and signature.
 	 * This is usually in the header x-seda-fast-proof
 	 *
 	 * @param proof
@@ -295,7 +295,7 @@ export class DataProxy {
 	 * @returns
 	 */
 	verifyFastProof(proof: {
-		unixTimestamp: bigint;
+		unixTimestampMs: bigint;
 		signature: Buffer;
 		publicKey: Buffer;
 	}) {

--- a/workspace/data-proxy-sdk/src/services/decode-seda-fast-proof.ts
+++ b/workspace/data-proxy-sdk/src/services/decode-seda-fast-proof.ts
@@ -9,7 +9,7 @@ import { FailedToDecodeSedaFastProofError } from "../errors";
 // "{unixTimestampMs}:{signatureAsHexString}" — signed over keccak256(timestamp)
 // or:
 // "{unixTimestampMs}:{signatureAsHexString}:{clientChainId}" — signed over keccak256(timestamp || chainId)
-export const decodeSedaFastProof = (proof: string, chainId: string) => {
+export const decodeSedaFastProof = (proof: string, chainId?: string) => {
 	return Effect.gen(function* () {
 		try {
 			const decoded = Buffer.from(proof, "base64");
@@ -24,22 +24,27 @@ export const decodeSedaFastProof = (proof: string, chainId: string) => {
 			}
 
 			const [unixTimestampMs, signature, clientChainId] = parts;
+			const hasProofChainId = parts.length === 3;
 
-			if (clientChainId !== undefined && clientChainId !== chainId) {
-				return yield* Effect.fail(
-					new FailedToDecodeSedaFastProofError({
-						error: `Invalid client chain id: ${clientChainId}, wanted: ${chainId}`,
-					}),
-				);
+			// Check proof's chain ID only if it is present and a chain ID is configured.
+			if (hasProofChainId) {
+				if (chainId !== undefined && clientChainId !== chainId) {
+					return yield* Effect.fail(
+						new FailedToDecodeSedaFastProofError({
+							error: `Invalid client chain id: ${clientChainId}, wanted: ${chainId}`,
+						}),
+					);
+				}
 			}
 
 			const timestampBuffer = Buffer.alloc(8); // 64-bit = 8 bytes
 			timestampBuffer.writeBigUInt64BE(BigInt(unixTimestampMs));
 
-			const messageHash =
-				parts.length === 2
-					? keccak256(timestampBuffer)
-					: keccak256(Buffer.concat([timestampBuffer, Buffer.from(chainId)]));
+			const messageHash = hasProofChainId
+				? keccak256(
+						Buffer.concat([timestampBuffer, Buffer.from(clientChainId)]),
+					)
+				: keccak256(timestampBuffer);
 
 			const extendSignatures = ExtendedSecp256k1Signature.fromFixedLength(
 				Buffer.from(signature, "hex"),

--- a/workspace/data-proxy-sdk/src/services/decode-seda-fast-proof.ts
+++ b/workspace/data-proxy-sdk/src/services/decode-seda-fast-proof.ts
@@ -6,16 +6,26 @@ import {
 import { Effect } from "effect";
 import { FailedToDecodeSedaFastProofError } from "../errors";
 
+// "{unixTimestampMs}:{signatureAsHexString}" — signed over keccak256(timestamp)
+// or:
+// "{unixTimestampMs}:{signatureAsHexString}:{clientChainId}" — signed over keccak256(timestamp || chainId)
 export const decodeSedaFastProof = (proof: string, chainId: string) => {
 	return Effect.gen(function* () {
 		try {
-			// The format is "{unixTimestampMs}:{signatureAsHexString}:{clientChainId}"
 			const decoded = Buffer.from(proof, "base64");
-			const [unixTimestampMs, signature, clientChainId] = decoded
-				.toString("utf-8")
-				.split(":");
+			const parts = decoded.toString("utf-8").split(":");
 
-			if (clientChainId !== chainId) {
+			if (parts.length !== 2 && parts.length !== 3) {
+				return yield* Effect.fail(
+					new FailedToDecodeSedaFastProofError({
+						error: `Invalid proof format: expected 2 or 3 colon-separated fields, got ${parts.length}`,
+					}),
+				);
+			}
+
+			const [unixTimestampMs, signature, clientChainId] = parts;
+
+			if (clientChainId !== undefined && clientChainId !== chainId) {
 				return yield* Effect.fail(
 					new FailedToDecodeSedaFastProofError({
 						error: `Invalid client chain id: ${clientChainId}, wanted: ${chainId}`,
@@ -23,13 +33,13 @@ export const decodeSedaFastProof = (proof: string, chainId: string) => {
 				);
 			}
 
-			const unixTimestampBuffer = Buffer.alloc(8); // 64-bit = 8 bytes
-			unixTimestampBuffer.writeBigUInt64BE(BigInt(unixTimestampMs));
-			const chainIdBytes = Buffer.from(chainId);
+			const timestampBuffer = Buffer.alloc(8); // 64-bit = 8 bytes
+			timestampBuffer.writeBigUInt64BE(BigInt(unixTimestampMs));
 
-			const messageHash = keccak256(
-				Buffer.concat([unixTimestampBuffer, chainIdBytes]),
-			);
+			const messageHash =
+				parts.length === 2
+					? keccak256(timestampBuffer)
+					: keccak256(Buffer.concat([timestampBuffer, Buffer.from(chainId)]));
 
 			const extendSignatures = ExtendedSecp256k1Signature.fromFixedLength(
 				Buffer.from(signature, "hex"),
@@ -39,7 +49,7 @@ export const decodeSedaFastProof = (proof: string, chainId: string) => {
 
 			return yield* Effect.succeed({
 				publicKey: Buffer.from(compressedPubKey),
-				unixTimestamp: BigInt(unixTimestampMs),
+				unixTimestampMs: BigInt(unixTimestampMs),
 				signature: Buffer.from(signature, "hex"),
 			});
 		} catch (error) {

--- a/workspace/data-proxy-sdk/src/services/verify-fast-proof.ts
+++ b/workspace/data-proxy-sdk/src/services/verify-fast-proof.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect";
 
 export const verifyFastProof = (
 	proof: {
-		unixTimestamp: bigint;
+		unixTimestampMs: bigint;
 		signature: Buffer;
 		publicKey: Buffer;
 	},
@@ -11,7 +11,7 @@ export const verifyFastProof = (
 ) => {
 	return Effect.gen(function* () {
 		const now = BigInt(Date.now());
-		const delta = now - proof.unixTimestamp;
+		const delta = now - proof.unixTimestampMs;
 
 		if (delta > fastMaxProofAgeMs) {
 			return yield* Effect.succeed({

--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",

--- a/workspace/data-proxy/src/cli/init.ts
+++ b/workspace/data-proxy/src/cli/init.ts
@@ -38,14 +38,13 @@ export const initCmd = new Command("init")
 		DEFAULT_PRIVATE_KEY_JSON_FILE_NAME,
 	)
 	.option("-c, --config <string>", "Path to config.json", "./config.json")
-	.option(
-		"-n, --network <string>",
-		"The SEDA network to chose",
-		Environment.Testnet,
-	)
+	.option("-n, --network <string>", "The SEDA network to chose")
 	.option("--print", "Print the content instead of writing it")
 	.action(async (args) => {
-		if (!Object.values(Environment).includes(args.network as Environment)) {
+		if (
+			args.network &&
+			!Object.values(Environment).includes(args.network as Environment)
+		) {
 			const networkList = Object.values(Environment).join(", ");
 			console.error(
 				`Invalid network '${args.network}'. Valid options: ${networkList}`,
@@ -57,7 +56,7 @@ export const initCmd = new Command("init")
 			const privateKeyBuff = randomBytes(32);
 			const keyPair = await Secp256k1.makeKeypair(privateKeyBuff);
 			const keyPairJson: FileKeyPair = {
-				network: args.network as Environment,
+				...(args.network ? { network: args.network as Environment } : {}),
 				pubkey: Buffer.from(Secp256k1.compressPubkey(keyPair.pubkey)).toString(
 					"hex",
 				),

--- a/workspace/data-proxy/src/cli/register.ts
+++ b/workspace/data-proxy/src/cli/register.ts
@@ -7,7 +7,7 @@ import { trySync } from "@seda-protocol/utils";
 import { Effect, Either, LogLevel, Logger } from "effect";
 import { ecdsaSign, publicKeyCreate } from "secp256k1";
 import { Maybe } from "true-myth";
-import { DEFAULT_ENVIRONMENT, PRIVATE_KEY_ENV_KEY } from "../constants";
+import { PRIVATE_KEY_ENV_KEY } from "../constants";
 import { sedaToAseda } from "./utils/big";
 import { createHash } from "./utils/create-hash";
 import { loadNetworkFromKeyFile, loadPrivateKey } from "./utils/private-key";
@@ -34,9 +34,9 @@ export const registerCmd = new Command("register")
 	)
 	.action(async (adminAddress, fee, options) => {
 		const program = Effect.gen(function* () {
-			let networkEnv: Environment;
+			let networkEnv: Environment | null;
 			if (options.network) {
-				// Validate network option
+				// Load network from command line option.
 				const validNetworks = Object.values(Environment);
 				if (!validNetworks.includes(options.network as Environment)) {
 					const networkList = validNetworks.join(", ");
@@ -47,7 +47,7 @@ export const registerCmd = new Command("register")
 				}
 				networkEnv = options.network as Environment;
 			} else {
-				// Load network from private key file (defaults to Testnet if not provided)
+				// Load network from private key file.
 				const networkResult = yield* Effect.either(
 					loadNetworkFromKeyFile(options.privateKeyFile),
 				);
@@ -59,7 +59,21 @@ export const registerCmd = new Command("register")
 				}
 				networkEnv = networkResult.right;
 			}
+
+			if (networkEnv === null) {
+				yield* Effect.logError(
+					"Network is required for registration. Pass --network or set network in the private key file.",
+				);
+				process.exit(1);
+			}
+
 			const network = defaultConfig[networkEnv];
+			if (network?.chainId === undefined) {
+				yield* Effect.logError(
+					`Network '${networkEnv}' is not supported for registration: chain ID is missing from the default configuration.`,
+				);
+				process.exit(1);
+			}
 
 			const privateKey = yield* Effect.either(
 				loadPrivateKey(options.privateKeyFile),

--- a/workspace/data-proxy/src/cli/run.ts
+++ b/workspace/data-proxy/src/cli/run.ts
@@ -158,7 +158,7 @@ const configure = (
 	Effect.gen(function* () {
 		const fs = yield* FileSystem.FileSystem;
 
-		let networkEnv: Environment;
+		let networkEnv: Environment | null;
 		if (options.network) {
 			// Validate network option
 			const validNetworks = Object.values(Environment);
@@ -171,11 +171,9 @@ const configure = (
 			}
 			networkEnv = options.network as Environment;
 		} else {
-			// Load network from private key file (defaults to Testnet if not provided)
 			networkEnv = yield* loadNetworkFromKeyFile(options.privateKeyFile);
 		}
 
-		const network = defaultConfig[networkEnv];
 		const privateKey = yield* Effect.either(
 			loadPrivateKey(options.privateKeyFile),
 		);
@@ -236,7 +234,7 @@ const configure = (
 			process.exit(1);
 		}
 
-		yield* Effect.logInfo(`🌐 Network: ${networkEnv}\n`);
+		yield* Effect.logInfo(`🌐 Network: ${networkEnv ?? "agnostic"}\n`);
 
 		const dataProxy = new DataProxy(networkEnv, {
 			privateKey: privateKey.right,
@@ -248,9 +246,21 @@ const configure = (
 
 		const publicKey = dataProxy.publicKey.toString("hex");
 		yield* Effect.logInfo(`🔐 Using public key: ${publicKey}`);
+
 		if (options.skipRegistrationCheck) {
-			yield* Effect.logWarning("⚠️  Registration check was skipped\n");
+			yield* Effect.logWarning("⚠️ Registration check was skipped\n");
+		} else if (config.value.config.fastOnly) {
+			yield* Effect.logWarning(
+				"⚠️ Registration check was skipped because fastOnly mode is enabled\n",
+			);
 		} else {
+			if (networkEnv === null) {
+				yield* Effect.logError(
+					"Network is required unless fastOnly mode is enabled in config.json",
+				);
+				process.exit(1);
+			}
+
 			const dataProxyRegistration = yield* Effect.either(
 				dataProxy.getDataProxyRegistration(),
 			);
@@ -261,6 +271,7 @@ const configure = (
 				process.exit(1);
 			}
 
+			const network = defaultConfig[networkEnv];
 			const url = new URL(`/data-proxies/${publicKey}`, network.explorerUrl);
 			yield* Effect.logInfo(
 				`✅ Registration has been verified. Link to explorer page: ${url.toString()}\n`,

--- a/workspace/data-proxy/src/cli/utils/key-pair.ts
+++ b/workspace/data-proxy/src/cli/utils/key-pair.ts
@@ -2,10 +2,7 @@ import { Environment } from "@seda-protocol/data-proxy-sdk";
 import * as v from "valibot";
 
 export const FileKeyPairSchema = v.object({
-	network: v.optional(
-		v.picklist(Object.values(Environment)),
-		Environment.Testnet,
-	),
+	network: v.optional(v.picklist(Object.values(Environment))),
 	pubkey: v.optional(v.string()),
 	privkey: v.string(),
 });

--- a/workspace/data-proxy/src/cli/utils/private-key.ts
+++ b/workspace/data-proxy/src/cli/utils/private-key.ts
@@ -1,5 +1,4 @@
 import { readFile } from "node:fs/promises";
-import { Environment } from "@seda-protocol/data-proxy-sdk";
 import { tryParseSync } from "@seda-protocol/utils";
 import { Data, Effect } from "effect";
 import {
@@ -32,9 +31,8 @@ export class FailedToParsePrivateKeyFileError extends Data.TaggedError(
 
 export const loadNetworkFromKeyFile = (privateKeyFilePath?: string) =>
 	Effect.gen(function* () {
-		// If no private key file path is provided and private key env var is set, use default network Testnet
 		if (!privateKeyFilePath && getPrivateKey()) {
-			return yield* Effect.succeed(Environment.Testnet);
+			return yield* Effect.succeed(null);
 		}
 
 		const filePath = privateKeyFilePath ?? DEFAULT_PRIVATE_KEY_JSON_FILE_NAME;
@@ -67,7 +65,7 @@ export const loadNetworkFromKeyFile = (privateKeyFilePath?: string) =>
 			);
 		}
 
-		return yield* Effect.succeed(parsedPrivateKeyFile.value.network);
+		return yield* Effect.succeed(parsedPrivateKeyFile.value.network ?? null);
 	});
 
 export const loadPrivateKey = (privateKeyFilePath?: string) =>

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -904,4 +904,48 @@ describe("parseConfig", () => {
 			);
 		});
 	});
+
+	describe("fastOnly", () => {
+		it("rejects fastOnly when sedaFast is not enabled", () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					fastOnly: true,
+					routes: [
+						{
+							path: "/test",
+							upstreamUrl: "https://example.com/test",
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				"fastOnly requires sedaFast.enable to be true",
+			);
+		});
+
+		it("accepts fastOnly when sedaFast is enabled", () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					fastOnly: true,
+					sedaFast: {
+						enable: true,
+						allowedClients: [
+							"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+						],
+					},
+					routes: [
+						{
+							path: "/test",
+							upstreamUrl: "https://example.com/test",
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeOkResult();
+			assertIsOkResult(result);
+			expect(result.value.config.fastOnly).toBe(true);
+		});
+	});
 });

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -629,6 +629,13 @@ export const parseConfig = (
 			}
 		}
 
+		if (config.fastOnly && !config.sedaFast?.enable) {
+			return [
+				Result.err("fastOnly requires sedaFast.enable to be true"),
+				hasWarnings,
+			];
+		}
+
 		return [
 			Result.ok({ config: { ...config, modules }, envSecrets }),
 			hasWarnings,

--- a/workspace/data-proxy/src/controllers/proxy/verify-proof.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/verify-proof.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import type { DataProxy } from "@seda-protocol/data-proxy-sdk";
+import { constants } from "@seda-protocol/data-proxy-sdk";
+import { Effect, Either } from "effect";
+import { Maybe } from "true-myth";
+import type { Config } from "../../config/config-parser";
+import {
+	DEFAULT_PROXY_ROUTE_GROUP,
+	DEFAULT_VERIFICATION_MAX_RETRIES,
+	DEFAULT_VERIFICATION_RETRY_DELAY,
+} from "../../constants";
+import { VerifyProofError, verifyProof } from "./verify-proof";
+
+const fastOnlyConfig: Config = {
+	fastOnly: true,
+	sedaFast: {
+		enable: true,
+		allowedClients: [
+			"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+		],
+	},
+	modules: [],
+	routes: [],
+	verificationMaxRetries: DEFAULT_VERIFICATION_MAX_RETRIES,
+	verificationRetryDelay: DEFAULT_VERIFICATION_RETRY_DELAY,
+	routeGroup: DEFAULT_PROXY_ROUTE_GROUP,
+	baseURL: Maybe.nothing(),
+	statusEndpoints: { root: "status" },
+};
+
+describe("verifyProof", () => {
+	it("rejects SEDA Core proofs in fastOnly mode", async () => {
+		const result = await Effect.runPromise(
+			Effect.either(
+				verifyProof({
+					headers: {
+						[constants.PROOF_HEADER_KEY]: Buffer.from(
+							"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f:1:00",
+							"utf-8",
+						).toString("base64"),
+					},
+					config: fastOnlyConfig,
+					dataProxy: {} as DataProxy,
+				}),
+			),
+		);
+
+		if (Either.isRight(result)) {
+			expect.unreachable("Should reject core proof in fastOnly mode");
+		}
+
+		expect(result.left).toBeInstanceOf(VerifyProofError);
+		expect(result.left.message).toContain("not allowed in fastOnly mode");
+	});
+});

--- a/workspace/data-proxy/src/controllers/proxy/verify-proof.ts
+++ b/workspace/data-proxy/src/controllers/proxy/verify-proof.ts
@@ -128,6 +128,14 @@ export const verifyProof = (params: VerifyProofParams) =>
 			);
 		}
 
+		if (config.fastOnly && Option.isSome(proofHeader)) {
+			return yield* Effect.fail(
+				new VerifyProofError({
+					error: `Header "${constants.PROOF_HEADER_KEY}" is not allowed in fastOnly mode`,
+				}),
+			);
+		}
+
 		if (Option.isSome(sedaFastProofHeader)) {
 			return yield* handleSedaFastProof(sedaFastProofHeader.value, dataProxy);
 		}


### PR DESCRIPTION
## Explanation of Changes

Support decoding Fast proof with or without chain ID to accommodate [this change](https://github.com/sedaprotocol/seda-fast/pull/414). This mode is only supported under `fastOnly` mode since core support requires a specific RPC endpoint to be configured.

|   | DP with chain ID configured | DP without chain ID configured |
| ------------- | ------------- | ------------- |
| Fast proof with chain ID  | Chain ID is checked  | Not checked  |
| Fast proof without chain ID  | Not checked  | Not checked  |

I was thinking that we can have this structure until chain ID-based proof is fully removed from all Fast processes in production. Then, we can remove chain ID-based proof check from data proxy as well.

## Testing

Added unit tests using test vectors created from Fast repo.

## Related PRs and Issues

Closes: #145
