### PR TITLE
feat(multi): let a sources query param prune the fan-out

### DIFF
--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
@@ -37,15 +37,25 @@ const makeRoute = (fetches: MultiModuleRoute["fetches"]): MultiModuleRoute =>
 		forwardResponseHeaders: new Set<string>(),
 	}) as unknown as MultiModuleRoute;
 
-const run = (route: MultiModuleRoute, map: Map<string, ModuleHandlers>) =>
+const runRaw = (
+	route: MultiModuleRoute,
+	map: Map<string, ModuleHandlers>,
+	url = "http://localhost/multi/BTC/1",
+) =>
 	Effect.runPromise(
 		handleMultiRequest(
 			route,
 			{ symbol: "BTC", index: "1" },
-			new Request("http://localhost/multi/BTC/1"),
+			new Request(url),
 			map,
-		).pipe(Effect.flatMap((res) => Effect.promise(() => res.json()))),
+		),
 	);
+
+const run = (
+	route: MultiModuleRoute,
+	map: Map<string, ModuleHandlers>,
+	url?: string,
+) => runRaw(route, map, url).then((res) => res.json());
 
 describe("handleMultiRequest", () => {
 	it("fills each fetch template from the request params and keys results by name", async () => {
@@ -172,6 +182,108 @@ describe("handleMultiRequest", () => {
 			error: "Sub-fetch returned a non-ok response",
 			status: 502,
 			body: { reason: "bad" },
+		});
+	});
+
+	describe("sources query param", () => {
+		const twoVenueRoute = () =>
+			makeRoute([
+				{
+					name: "binance",
+					moduleName: "bin",
+					type: "binance",
+					fetchFromModule: "{:symbol}USDT",
+				},
+				{
+					name: "binance-futures",
+					moduleName: "fut",
+					type: "binance",
+					fetchFromModule: "{:symbol}USDT",
+				},
+			]);
+
+		const countingHandlers = () => {
+			let calls = 0;
+			return {
+				handlers: handlers((route) => {
+					calls++;
+					return Effect.succeed(
+						new Response(
+							JSON.stringify({ fetchFromModule: route.fetchFromModule }),
+							{ status: 200 },
+						),
+					);
+				}),
+				calls: () => calls,
+			};
+		};
+
+		it("runs only the fetches named in sources and skips the rest entirely", async () => {
+			const bin = countingHandlers();
+			const fut = countingHandlers();
+			const map = new Map<string, ModuleHandlers>([
+				["bin", bin.handlers],
+				["fut", fut.handlers],
+			]);
+
+			const body = (await run(
+				twoVenueRoute(),
+				map,
+				"http://localhost/multi/NVDA/110?sources=binance-futures",
+			)) as Record<string, unknown>;
+
+			expect(Object.keys(body)).toEqual(["binance-futures"]);
+			expect(fut.calls()).toBe(1);
+			expect(bin.calls()).toBe(0);
+		});
+
+		it("runs every fetch when the param is absent", async () => {
+			const bin = countingHandlers();
+			const fut = countingHandlers();
+			const map = new Map<string, ModuleHandlers>([
+				["bin", bin.handlers],
+				["fut", fut.handlers],
+			]);
+
+			const body = (await run(twoVenueRoute(), map)) as Record<string, unknown>;
+
+			expect(Object.keys(body).sort()).toEqual(["binance", "binance-futures"]);
+			expect(bin.calls()).toBe(1);
+			expect(fut.calls()).toBe(1);
+		});
+
+		it("rejects an unknown source name with 400", async () => {
+			const map = new Map<string, ModuleHandlers>([
+				["bin", echoHandlers],
+				["fut", echoHandlers],
+			]);
+
+			const response = await runRaw(
+				twoVenueRoute(),
+				map,
+				"http://localhost/multi/BTC/1?sources=binance,kraken",
+			);
+
+			expect(response.status).toBe(400);
+			const body = (await response.json()) as { error: string };
+			expect(body.error).toContain("unknown source(s): kraken");
+		});
+
+		it("rejects an empty sources param with 400", async () => {
+			const map = new Map<string, ModuleHandlers>([
+				["bin", echoHandlers],
+				["fut", echoHandlers],
+			]);
+
+			const response = await runRaw(
+				twoVenueRoute(),
+				map,
+				"http://localhost/multi/BTC/1?sources=",
+			);
+
+			expect(response.status).toBe(400);
+			const body = (await response.json()) as { error: string };
+			expect(body.error).toContain("no sources selected");
 		});
 	});
 });

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
@@ -9,6 +9,12 @@ import { replaceParams } from "../../utils/replace-params";
 // keyed by fetch name. Sub-fetch failures are non-fatal: the failing entry
 // carries an error and the rest still resolve. The combined object is returned
 // as one response for the proxy to sign.
+//
+// A `sources` query param (comma-separated fetch names) restricts the fan-out
+// to the named sub-fetches, so a caller that only wants some venues does not
+// pay for the rest (an unlisted symbol otherwise blocks on the price-wait
+// timeout). The param is part of the signed request URL, so selection needs no
+// signing changes. Without the param every configured fetch runs.
 export const handleMultiRequest = (
 	route: MultiModuleRoute,
 	params: Record<string, string>,
@@ -16,8 +22,40 @@ export const handleMultiRequest = (
 	moduleHandlers: ReadonlyMap<string, ModuleHandlers>,
 ) =>
 	Effect.gen(function* () {
+		const sourcesParam = new URL(request.url).searchParams.get("sources");
+		let selectedFetches = route.fetches;
+
+		if (sourcesParam !== null) {
+			const requested = sourcesParam
+				.split(",")
+				.map((name) => name.trim())
+				.filter((name) => name.length > 0);
+
+			const knownNames = route.fetches.map((fetch) => fetch.name);
+			const unknown = requested.filter((name) => !knownNames.includes(name));
+
+			// A typo in the selection should fail loudly here instead of
+			// surfacing downstream as a confusing "not enough sources" error.
+			if (requested.length === 0 || unknown.length > 0) {
+				const detail =
+					unknown.length > 0
+						? `unknown source(s): ${unknown.join(", ")}`
+						: "no sources selected";
+				return new Response(
+					JSON.stringify({
+						error: `Invalid 'sources' query param: ${detail}. Configured sources: ${knownNames.join(", ")}`,
+					}),
+					{ status: 400, headers: { "Content-Type": "application/json" } },
+				);
+			}
+
+			selectedFetches = route.fetches.filter((fetch) =>
+				requested.includes(fetch.name),
+			);
+		}
+
 		const entries = yield* Effect.forEach(
-			route.fetches,
+			selectedFetches,
 			(fetch) =>
 				Effect.gen(function* () {
 					const handlers = moduleHandlers.get(fetch.moduleName);


### PR DESCRIPTION
A multi route runs every configured sub-fetch on every request, so a feed that only wants some venues still pays for the ones it discards. The worst case is a binance fetch for a symbol its stream does not carry, e.g. an equity perp like NVDAUSDT asked of the spot stream: no frame ever arrives, the fetch blocks the shared 3s price-wait timeout, and since the fan-out is concurrent the whole multi response is pinned at ~3s on every request (the cache never fills for a symbol that never streams, so it is not just a cold-start cost). This is exactly the seda-signal case where the program's `exchanges` input selects venues but the proxy fetched all of them anyway.

This adds a `sources` query param (comma-separated sub-fetch names) that restricts the fan-out to the named fetches. Skipped venues are never invoked and never subscribed, so mismatched symbols stop costing the timeout and stop accumulating dead WS subscriptions. An unknown or empty selection fails at the proxy with a 400 listing the configured source names, so a typo surfaces here rather than downstream as a confusing missing-source error. Requests without the param behave exactly as before, and the param rides in the signed request URL, so response signing and proof verification are unchanged.

Measured on the four-venue route (`/multi/:symbol/:market/:hydroTicker`): `multi/NVDA/110/xyz:NVDA` takes 3.01s without the param and 0.003s with `?sources=binance-futures,lighter,hydromancer`; BTC with no param still runs all four venues unchanged.

- No config or schema changes: valid source values are the route's existing `fetches[].name` list, validated per request.
- seda-signal follow-up (separate repo) appends `?sources=` from its `exchanges` input; the program change is backwards compatible against proxies without this support (param is simply ignored).