### PR TITLE
Bump version to v2.11.0

### DIFF
--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "2.10.0",
+	"version": "2.11.0",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",


### PR DESCRIPTION
The previous release v2.10.0 was released mistakenly without package.json version bump.