### PR TITLE
Addressing Pyth Lazer "client too slow" error

### DIFF
--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "2.11.0",
+	"version": "2.11.1",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { lagMsFromTimestampUs } from "./pyth-lazer";
+
+describe("lagMsFromTimestampUs", () => {
+	it("returns lag in ms from a microsecond timestamp", () => {
+		const nowMs = 1_700_000_000_500;
+		const timestampUs = (nowMs - 250) * 1000;
+
+		expect(lagMsFromTimestampUs(nowMs, timestampUs)).toBe(250);
+	});
+
+	it("accepts string timestamps", () => {
+		const nowMs = 1_700_000_000_500;
+		const timestampUs = String((nowMs - 100) * 1000);
+
+		expect(lagMsFromTimestampUs(nowMs, timestampUs)).toBe(100);
+	});
+
+	it("returns undefined for missing or invalid timestamps", () => {
+		expect(lagMsFromTimestampUs(1_000, undefined)).toBeUndefined();
+		expect(lagMsFromTimestampUs(1_000, "not-a-number")).toBeUndefined();
+	});
+});

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -9,6 +9,8 @@ import {
 	Effect,
 	Either,
 	Layer,
+	Metric,
+	MetricBoundaries,
 	MutableHashMap,
 	Option,
 	Queue,
@@ -41,6 +43,41 @@ interface PriceFeedWithSymbol extends ParsedFeedPayload {
 	symbol?: string;
 	[HAS_PRICE_KEY]: boolean;
 }
+
+/** Pyth Lazer timestamps are Unix microseconds; returns lag in ms, or undefined if missing/invalid. */
+export const lagMsFromTimestampUs = (
+	nowMs: number,
+	timestampUs: number | string | undefined,
+): number | undefined => {
+	if (timestampUs === undefined) {
+		return undefined;
+	}
+	const us =
+		typeof timestampUs === "string" ? Number(timestampUs) : timestampUs;
+	if (!Number.isFinite(us)) {
+		return undefined;
+	}
+	return nowMs - us / 1000;
+};
+
+/** Metrics for the Pyth Lazer module. */
+const messageLagMs = Metric.histogram(
+	"pyth_lazer_message_lag_ms",
+	MetricBoundaries.fromIterable([
+		1, 2, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000,
+	]),
+	"Lag in ms between Pyth Lazer update timestampUs and local receive time",
+);
+
+const messageHandleDurationMs = Metric.timerWithBoundaries(
+	"pyth_lazer_message_handle_duration_ms",
+	[0.1, 0.25, 0.5, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1_000],
+	"Duration in ms of the Pyth Lazer addMessageListener callback",
+);
+
+const activeSubscriptions = Metric.gauge("pyth_lazer_active_subscriptions", {
+	description: "Number of active Pyth Lazer price feed subscriptions",
+});
 
 export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 	Layer.effect(
@@ -152,16 +189,18 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 								yield* handleStreamUpdatedMessage(message.value.parsed);
 							}
 						}
-					}),
+					}).pipe(Metric.trackDuration(messageHandleDurationMs)),
 				);
 			});
 
 			const handleStreamUpdatedMessage = (message: ParsedPayload) =>
 				Effect.gen(function* () {
-					yield* Effect.logTrace(
-						"Received stream updated message from Pyth Lazer client",
-						message,
-					);
+					const nowMs = yield* Clock.currentTimeMillis;
+					const lagMs = lagMsFromTimestampUs(nowMs, message.timestampUs);
+
+					if (lagMs !== undefined) {
+						yield* Metric.update(messageLagMs, lagMs);
+					}
 
 					for (const priceFeed of message.priceFeeds) {
 						// To make sure that we don't set the price for a price feed that we are not subscribed to
@@ -208,6 +247,11 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 								newSubscriptionId,
 							);
 
+							yield* Metric.set(
+								activeSubscriptions,
+								MutableHashMap.size(subscriptions),
+							);
+
 							lazerClient.subscribe({
 								type: "subscribe",
 								channel: config.channel,
@@ -251,6 +295,11 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 								if (Option.isSome(subscriptionId)) {
 									lazerClient.unsubscribe(subscriptionId.value);
 									MutableHashMap.remove(subscriptions, priceFeedId);
+
+									yield* Metric.set(
+										activeSubscriptions,
+										MutableHashMap.size(subscriptions),
+									);
 
 									const symbol = getSymbolByPriceFeedId(priceFeedId);
 									if (Option.isSome(symbol)) {

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -211,7 +211,7 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 							lazerClient.subscribe({
 								type: "subscribe",
 								channel: config.channel,
-								formats: ["solana"],
+								formats: [],
 								properties: [
 									"bestAskPrice",
 									"bestBidPrice",


### PR DESCRIPTION
## Explanation of Changes

Some attempts at the "client too slow" error we get in Pyth Lazer module:

- Remove binary encoding format setting since we do not deal with binary encoded messages.
- Measure time lag between message timestamp and time at handling the message to get information about end-to-end lag.