### PR TITLE
chore(pyth-lazer): add warn when conn times out

### DIFF
--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -165,7 +165,19 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 			lazerClient.addAllConnectionsDownListener(() =>
 				Runtime.runSync(
 					runtime,
-					Effect.logFatal("All connections are down for Pyth Lazer client"),
+					Effect.logError("All connections are down for Pyth Lazer client"),
+				),
+			);
+
+			lazerClient.addConnectionTimeoutListener((connectionIndex, endpoint) =>
+				Runtime.runSync(
+					runtime,
+					Effect.logWarning("Connection timeout for Pyth Lazer client").pipe(
+						Effect.annotateLogs({
+							connectionIndex,
+							endpoint,
+						}),
+					),
 				),
 			);
 


### PR DESCRIPTION
Minor changes on pyth lazer module logs:

- Modify fatal for error when all connections are down because it might restart them (and it happens quite frequently)
- Add warn log for connection timeouts (it should allow us to see if there are heartbeat problems)