### PR TITLE
PM Insights refactor

### DIFF
--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "2.11.1",
+	"version": "2.12.0",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",

--- a/workspace/data-proxy/src/config/pm-insights-module-config.ts
+++ b/workspace/data-proxy/src/config/pm-insights-module-config.ts
@@ -29,7 +29,8 @@ export const PmInsightsModuleRouteSchema = v.strictObject({
 	...RouteSchema.entries,
 	type: v.literal("pm-insights"),
 	moduleName: v.string(),
-	upstreamPath: v.string(),
+	/** Template for the issuer symbol, e.g. `{:symbol}` for path `/:symbol`. */
+	fetchFromModule: v.string(),
 });
 
 export type PmInsightsModuleRoute = v.InferOutput<

--- a/workspace/data-proxy/src/modules/pm-insights/README.md
+++ b/workspace/data-proxy/src/modules/pm-insights/README.md
@@ -1,6 +1,6 @@
 # PM Insights module
 
-Proxies issuer prices from the [PM Insights](https://pminsights.com/) API. On startup the module logs in, caches a bearer token, and refreshes it on a schedule. Each proxied request fetches `GET /issuer/{symbol}` and returns only the numeric `price.price` field.
+Proxies requests to the [PM Insights](https://pminsights.com/) API. On startup the module logs in, caches a bearer token, and refreshes it on a schedule. Each proxied request calls the upstream path from `fetchFromModule` with the bearer token and returns the upstream response as-is (status, body, and content type).
 
 ## Environment variables
 
@@ -50,9 +50,16 @@ Both are required; config parsing fails if either is unset. Values are treated a
       "type": "pm-insights",
       "moduleName": "pminsights",
       "path": "/:symbol",
-      "fetchFromModule": "{:symbol}",
+      "fetchFromModule": "issuer/{:symbol}",
       "method": ["GET"]
-    }
+    },
+		{
+			"type": "pm-insights",
+			"moduleName": "pminsights",
+			"path": "/constituents/:sector",
+			"fetchFromModule": "feed/sectors/constituents/{:sector}",
+			"method": ["GET"]
+		}
   ]
 }
 ```
@@ -62,12 +69,11 @@ Both are required; config parsing fails if either is unset. Values are treated a
 | `type` | Must be `"pm-insights"` |
 | `moduleName` | Must match a configured PM Insights module `name` |
 | `path` | Proxy path; use path params as needed |
-| `fetchFromModule` | Issuer symbol template (e.g. `{:symbol}`); substituted from path params |
+| `fetchFromModule` | Upstream path template relative to `baseUrl` (e.g. `issuer/{:symbol}`); substituted from path params. Request query string is forwarded. |
 | `method` | Allowed HTTP methods (typically `["GET"]`) |
 
 Example request after starting the proxy:
 
 ```bash
 curl "http://127.0.0.1:5384/proxy/AVAN08"
-# => 721.35
 ```

--- a/workspace/data-proxy/src/modules/pm-insights/README.md
+++ b/workspace/data-proxy/src/modules/pm-insights/README.md
@@ -1,0 +1,73 @@
+# PM Insights module
+
+Proxies issuer prices from the [PM Insights](https://pminsights.com/) API. On startup the module logs in, caches a bearer token, and refreshes it on a schedule. Each proxied request fetches `GET /issuer/{symbol}` and returns only the numeric `price.price` field.
+
+## Environment variables
+
+Set the env vars named by `emailEnvKey` and `passwordEnvKey` in the module config (defaults in the example below):
+
+| Variable | Purpose |
+| --- | --- |
+| `PM_INSIGHTS_EMAIL` | Account email (sent as `username` to `/login`) |
+| `PM_INSIGHTS_PASSWORD` | Account password |
+
+Both are required; config parsing fails if either is unset. Values are treated as secrets and redacted from logs.
+
+## Module config
+
+```jsonc
+{
+  "modules": [
+    {
+      "type": "pm-insights",
+      "name": "pminsights",
+      "baseUrl": "https://api.pminsights.com/", // optional, this is the default
+      "emailEnvKey": "PM_INSIGHTS_EMAIL",
+      "passwordEnvKey": "PM_INSIGHTS_PASSWORD",
+      "tokenRefreshIntervalMinutes": 50, // optional, default 50
+      "tokenRetryIntervalMinutes": 5 // optional, default 5
+    }
+  ]
+}
+```
+
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `name` | yes | — | Module id referenced by routes via `moduleName` |
+| `type` | yes | — | Must be `"pm-insights"` |
+| `baseUrl` | no | `https://api.pminsights.com/` | PM Insights API base URL |
+| `emailEnvKey` | yes | — | Env var name for the login email |
+| `passwordEnvKey` | yes | — | Env var name for the login password |
+| `tokenRefreshIntervalMinutes` | no | `50` | How often to call `POST /login` to refresh the bearer token (min 1) |
+| `tokenRetryIntervalMinutes` | no | `5` | Retry interval when a refresh login fails (min 1) |
+
+## Route config
+
+```jsonc
+{
+  "routes": [
+    {
+      "type": "pm-insights",
+      "moduleName": "pminsights",
+      "path": "/:symbol",
+      "fetchFromModule": "{:symbol}",
+      "method": ["GET"]
+    }
+  ]
+}
+```
+
+| Field | Description |
+| --- | --- |
+| `type` | Must be `"pm-insights"` |
+| `moduleName` | Must match a configured PM Insights module `name` |
+| `path` | Proxy path; use path params as needed |
+| `fetchFromModule` | Issuer symbol template (e.g. `{:symbol}`); substituted from path params |
+| `method` | Allowed HTTP methods (typically `["GET"]`) |
+
+Example request after starting the proxy:
+
+```bash
+curl "http://127.0.0.1:5384/proxy/AVAN08"
+# => 721.35
+```

--- a/workspace/data-proxy/src/modules/pm-insights/pm-insights.test.ts
+++ b/workspace/data-proxy/src/modules/pm-insights/pm-insights.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { Effect, Either, LogLevel, Logger } from "effect";
+import type { Route } from "../../config/config-parser";
+import type { PmInsightsModuleConfig } from "../../config/pm-insights-module-config";
+import { ModuleService } from "../module";
+import { PmInsightsModuleService, parseIssuerPrice } from "./pm-insights";
+
+const sampleIssuerResponse = {
+	updated_at: "2026-07-13 11:18:46",
+	info: {
+		id: "AVAN08",
+		display_name: "Anthropic",
+	},
+	price: {
+		price: 721.35,
+		is_derived: false,
+		currency: "USD",
+		ytd: 454.31,
+		ytd_roi: 170.13,
+	},
+	volume: {
+		three_months: {
+			bid: 8119675000.0,
+			ask: 20382777500.0,
+		},
+	},
+	valuation: null,
+};
+
+const baseConfig: PmInsightsModuleConfig = {
+	name: "pm-insights",
+	type: "pm-insights",
+	baseUrl: "https://api.pminsights.test/",
+	emailEnvKey: "PM_INSIGHTS_EMAIL",
+	passwordEnvKey: "PM_INSIGHTS_PASSWORD",
+	email: "user@test.com",
+	password: "secret",
+	tokenRefreshIntervalMinutes: 50,
+	tokenRetryIntervalMinutes: 5,
+};
+
+const routeFor = (fetchFromModule: string): Route =>
+	({
+		type: "pm-insights",
+		moduleName: "pm-insights",
+		fetchFromModule,
+		path: "/:symbol",
+		method: ["GET"],
+	}) as unknown as Route;
+
+const quiet = <A, E>(effect: Effect.Effect<A, E>) =>
+	effect.pipe(Logger.withMinimumLogLevel(LogLevel.None));
+
+const callHandle = (
+	config: PmInsightsModuleConfig,
+	params: Record<string, string>,
+	fetchFromModule = "{:symbol}",
+) => {
+	const program = Effect.gen(function* () {
+		const svc = yield* ModuleService;
+		return yield* svc.handleRequest(
+			routeFor(fetchFromModule),
+			params,
+			new Request("http://proxy.local/AVAN08"),
+		);
+	});
+	return Effect.runPromise(
+		quiet(program.pipe(Effect.provide(PmInsightsModuleService(config)))),
+	);
+};
+
+const urlOf = (input: URL | RequestInfo): string =>
+	input instanceof URL
+		? input.toString()
+		: input instanceof Request
+			? input.url
+			: String(input);
+
+const mockPmInsightsFetch = (handlers?: {
+	login?: (init?: RequestInit) => Response | Promise<Response>;
+	issuer?: (url: string, init?: RequestInit) => Response | Promise<Response>;
+}) =>
+	mock(async (input: URL | RequestInfo, init?: RequestInit) => {
+		const url = urlOf(input);
+		if (url.includes("/login")) {
+			return (
+				handlers?.login?.(init) ??
+				new Response(JSON.stringify({ access_token: "test-token" }), {
+					status: 200,
+				})
+			);
+		}
+		if (url.includes("/issuer/")) {
+			return (
+				handlers?.issuer?.(url, init) ??
+				new Response(JSON.stringify(sampleIssuerResponse), { status: 200 })
+			);
+		}
+		throw new Error(`Unexpected fetch: ${url}`);
+	});
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("parseIssuerPrice", () => {
+	it("extracts price.price from an issuer response", () => {
+		const result = parseIssuerPrice(JSON.stringify(sampleIssuerResponse));
+		expect(Either.isRight(result)).toBe(true);
+		if (Either.isRight(result)) {
+			expect(result.right).toBe(721.35);
+		}
+	});
+
+	it("fails when the body is not JSON", () => {
+		const result = parseIssuerPrice("not-json");
+		expect(Either.isLeft(result)).toBe(true);
+		if (Either.isLeft(result)) {
+			expect(result.left.status).toBe(502);
+			expect(result.left.error).toContain("Failed to parse issuer response");
+		}
+	});
+
+	it("fails when price object is missing", () => {
+		const result = parseIssuerPrice(JSON.stringify({ info: { id: "AVAN08" } }));
+		expect(Either.isLeft(result)).toBe(true);
+		if (Either.isLeft(result)) {
+			expect(result.left.error).toContain("missing price object");
+		}
+	});
+
+	it("fails when price.price is not a finite number", () => {
+		const result = parseIssuerPrice(
+			JSON.stringify({ price: { price: "721.35" } }),
+		);
+		expect(Either.isLeft(result)).toBe(true);
+		if (Either.isLeft(result)) {
+			expect(result.left.error).toContain("numeric price.price");
+		}
+	});
+});
+
+describe("PmInsightsModuleService.handleRequest", () => {
+	it("logs in, fetches the issuer, and returns price.price", async () => {
+		const fetchMock = mockPmInsightsFetch({
+			login: (init) => {
+				expect(init?.method).toBe("POST");
+				expect(init?.body).toBe(
+					new URLSearchParams({
+						username: baseConfig.email,
+						password: baseConfig.password,
+					}).toString(),
+				);
+				return new Response(JSON.stringify({ access_token: "test-token" }), {
+					status: 200,
+				});
+			},
+			issuer: (url, init) => {
+				expect(url).toBe("https://api.pminsights.test/issuer/AVAN08");
+				expect(init?.method).toBe("GET");
+				expect((init?.headers as Record<string, string>).Authorization).toBe(
+					"Bearer test-token",
+				);
+				return new Response(JSON.stringify(sampleIssuerResponse), {
+					status: 200,
+				});
+			},
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, { symbol: "AVAN08" });
+		expect(response.status).toBe(200);
+		expect(await response.json()).toBe(721.35);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns 400 when the issuer symbol is missing", async () => {
+		const fetchMock = mockPmInsightsFetch();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, {}, "   ");
+		expect(response.status).toBe(400);
+		// Login still runs during module init; issuer is never fetched.
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(urlOf(fetchMock.mock.calls[0][0] as URL | RequestInfo)).toContain(
+			"/login",
+		);
+	});
+
+	it("passes through upstream 4xx status", async () => {
+		globalThis.fetch = mockPmInsightsFetch({
+			issuer: () => new Response("not found", { status: 404 }),
+		}) as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, { symbol: "AVAN08" });
+		expect(response.status).toBe(404);
+	});
+
+	it("reauthenticates when the issuer responds 400", async () => {
+		const fetchMock = mockPmInsightsFetch({
+			issuer: () => new Response("invalid credentials", { status: 400 }),
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, { symbol: "AVAN08" });
+		expect(response.status).toBe(400);
+		// init login + issuer + reauth login
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(urlOf(fetchMock.mock.calls[0][0] as URL | RequestInfo)).toContain(
+			"/login",
+		);
+		expect(urlOf(fetchMock.mock.calls[1][0] as URL | RequestInfo)).toContain(
+			"/issuer/",
+		);
+		expect(urlOf(fetchMock.mock.calls[2][0] as URL | RequestInfo)).toContain(
+			"/login",
+		);
+	});
+
+	it("returns 504 when the issuer fetch times out", async () => {
+		globalThis.fetch = mockPmInsightsFetch({
+			issuer: () => {
+				const error = new Error("aborted");
+				error.name = "TimeoutError";
+				throw error;
+			},
+		}) as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, { symbol: "AVAN08" });
+		expect(response.status).toBe(504);
+	});
+
+	it("returns 502 when the issuer response shape is invalid", async () => {
+		globalThis.fetch = mockPmInsightsFetch({
+			issuer: () =>
+				new Response(JSON.stringify({ info: { id: "AVAN08" } }), {
+					status: 200,
+				}),
+		}) as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, { symbol: "AVAN08" });
+		expect(response.status).toBe(502);
+	});
+
+	it("dies during module init when login fails", async () => {
+		globalThis.fetch = mockPmInsightsFetch({
+			login: () =>
+				new Response(JSON.stringify({ detail: "Bad Request" }), {
+					status: 400,
+				}),
+		}) as unknown as typeof fetch;
+
+		await expect(
+			callHandle(baseConfig, { symbol: "AVAN08" }),
+		).rejects.toThrow();
+	});
+});

--- a/workspace/data-proxy/src/modules/pm-insights/pm-insights.test.ts
+++ b/workspace/data-proxy/src/modules/pm-insights/pm-insights.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
-import { Effect, Either, LogLevel, Logger } from "effect";
+import { Effect, LogLevel, Logger } from "effect";
 import type { Route } from "../../config/config-parser";
 import type { PmInsightsModuleConfig } from "../../config/pm-insights-module-config";
 import { ModuleService } from "../module";
-import { PmInsightsModuleService, parseIssuerPrice } from "./pm-insights";
+import { PmInsightsModuleService } from "./pm-insights";
 
 const sampleIssuerResponse = {
 	updated_at: "2026-07-13 11:18:46",
@@ -54,14 +54,15 @@ const quiet = <A, E>(effect: Effect.Effect<A, E>) =>
 const callHandle = (
 	config: PmInsightsModuleConfig,
 	params: Record<string, string>,
-	fetchFromModule = "{:symbol}",
+	fetchFromModule = "issuer/{:symbol}",
+	requestUrl = "http://proxy.local/AVAN08",
 ) => {
 	const program = Effect.gen(function* () {
 		const svc = yield* ModuleService;
 		return yield* svc.handleRequest(
 			routeFor(fetchFromModule),
 			params,
-			new Request("http://proxy.local/AVAN08"),
+			new Request(requestUrl),
 		);
 	});
 	return Effect.runPromise(
@@ -76,9 +77,10 @@ const urlOf = (input: URL | RequestInfo): string =>
 			? input.url
 			: String(input);
 
+// TODO: Use dependency injection to mock the HTTP client instead of mutating the global fetch.
 const mockPmInsightsFetch = (handlers?: {
 	login?: (init?: RequestInit) => Response | Promise<Response>;
-	issuer?: (url: string, init?: RequestInit) => Response | Promise<Response>;
+	upstream?: (url: string, init?: RequestInit) => Response | Promise<Response>;
 }) =>
 	mock(async (input: URL | RequestInfo, init?: RequestInit) => {
 		const url = urlOf(input);
@@ -90,11 +92,14 @@ const mockPmInsightsFetch = (handlers?: {
 				})
 			);
 		}
+		if (handlers?.upstream) {
+			return handlers.upstream(url, init);
+		}
 		if (url.includes("/issuer/")) {
-			return (
-				handlers?.issuer?.(url, init) ??
-				new Response(JSON.stringify(sampleIssuerResponse), { status: 200 })
-			);
+			return new Response(JSON.stringify(sampleIssuerResponse), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
 		}
 		throw new Error(`Unexpected fetch: ${url}`);
 	});
@@ -105,45 +110,8 @@ afterEach(() => {
 	globalThis.fetch = originalFetch;
 });
 
-describe("parseIssuerPrice", () => {
-	it("extracts price.price from an issuer response", () => {
-		const result = parseIssuerPrice(JSON.stringify(sampleIssuerResponse));
-		expect(Either.isRight(result)).toBe(true);
-		if (Either.isRight(result)) {
-			expect(result.right).toBe(721.35);
-		}
-	});
-
-	it("fails when the body is not JSON", () => {
-		const result = parseIssuerPrice("not-json");
-		expect(Either.isLeft(result)).toBe(true);
-		if (Either.isLeft(result)) {
-			expect(result.left.status).toBe(502);
-			expect(result.left.error).toContain("Failed to parse issuer response");
-		}
-	});
-
-	it("fails when price object is missing", () => {
-		const result = parseIssuerPrice(JSON.stringify({ info: { id: "AVAN08" } }));
-		expect(Either.isLeft(result)).toBe(true);
-		if (Either.isLeft(result)) {
-			expect(result.left.error).toContain("missing price object");
-		}
-	});
-
-	it("fails when price.price is not a finite number", () => {
-		const result = parseIssuerPrice(
-			JSON.stringify({ price: { price: "721.35" } }),
-		);
-		expect(Either.isLeft(result)).toBe(true);
-		if (Either.isLeft(result)) {
-			expect(result.left.error).toContain("numeric price.price");
-		}
-	});
-});
-
 describe("PmInsightsModuleService.handleRequest", () => {
-	it("logs in, fetches the issuer, and returns price.price", async () => {
+	it("logs in, fetches upstream, and proxies the response body", async () => {
 		const fetchMock = mockPmInsightsFetch({
 			login: (init) => {
 				expect(init?.method).toBe("POST");
@@ -157,7 +125,7 @@ describe("PmInsightsModuleService.handleRequest", () => {
 					status: 200,
 				});
 			},
-			issuer: (url, init) => {
+			upstream: (url, init) => {
 				expect(url).toBe("https://api.pminsights.test/issuer/AVAN08");
 				expect(init?.method).toBe("GET");
 				expect((init?.headers as Record<string, string>).Authorization).toBe(
@@ -165,6 +133,7 @@ describe("PmInsightsModuleService.handleRequest", () => {
 				);
 				return new Response(JSON.stringify(sampleIssuerResponse), {
 					status: 200,
+					headers: { "Content-Type": "application/json" },
 				});
 			},
 		});
@@ -172,41 +141,67 @@ describe("PmInsightsModuleService.handleRequest", () => {
 
 		const response = await callHandle(baseConfig, { symbol: "AVAN08" });
 		expect(response.status).toBe(200);
-		expect(await response.json()).toBe(721.35);
+		expect(await response.json()).toEqual(sampleIssuerResponse);
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
 
-	it("returns 400 when the issuer symbol is missing", async () => {
+	it("forwards request query string to upstream", async () => {
+		const fetchMock = mockPmInsightsFetch({
+			upstream: (url) => {
+				expect(url).toBe("https://api.pminsights.test/issuer/AVAN08?verbose=1");
+				return new Response(JSON.stringify(sampleIssuerResponse), {
+					status: 200,
+				});
+			},
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const response = await callHandle(
+			baseConfig,
+			{ symbol: "AVAN08" },
+			"issuer/{:symbol}",
+			"http://proxy.local/AVAN08?verbose=1",
+		);
+		expect(response.status).toBe(200);
+	});
+
+	it("returns 400 when the upstream path is missing", async () => {
 		const fetchMock = mockPmInsightsFetch();
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 
 		const response = await callHandle(baseConfig, {}, "   ");
 		expect(response.status).toBe(400);
-		// Login still runs during module init; issuer is never fetched.
+		// Login still runs during module init; upstream is never fetched.
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		expect(urlOf(fetchMock.mock.calls[0][0] as URL | RequestInfo)).toContain(
 			"/login",
 		);
 	});
 
-	it("passes through upstream 4xx status", async () => {
+	it("passes through upstream 4xx status and body", async () => {
 		globalThis.fetch = mockPmInsightsFetch({
-			issuer: () => new Response("not found", { status: 404 }),
+			upstream: () =>
+				new Response("not found", {
+					status: 404,
+					headers: { "Content-Type": "text/plain" },
+				}),
 		}) as unknown as typeof fetch;
 
 		const response = await callHandle(baseConfig, { symbol: "AVAN08" });
 		expect(response.status).toBe(404);
+		expect(await response.text()).toBe("not found");
+		expect(response.headers.get("Content-Type")).toBe("text/plain");
 	});
 
-	it("reauthenticates when the issuer responds 400", async () => {
+	it("reauthenticates when the upstream responds 400", async () => {
 		const fetchMock = mockPmInsightsFetch({
-			issuer: () => new Response("invalid credentials", { status: 400 }),
+			upstream: () => new Response("invalid credentials", { status: 400 }),
 		});
 		globalThis.fetch = fetchMock as unknown as typeof fetch;
 
 		const response = await callHandle(baseConfig, { symbol: "AVAN08" });
 		expect(response.status).toBe(400);
-		// init login + issuer + reauth login
+		// init login + upstream + reauth login
 		expect(fetchMock).toHaveBeenCalledTimes(3);
 		expect(urlOf(fetchMock.mock.calls[0][0] as URL | RequestInfo)).toContain(
 			"/login",
@@ -219,9 +214,9 @@ describe("PmInsightsModuleService.handleRequest", () => {
 		);
 	});
 
-	it("returns 504 when the issuer fetch times out", async () => {
+	it("returns 504 when the upstream fetch times out", async () => {
 		globalThis.fetch = mockPmInsightsFetch({
-			issuer: () => {
+			upstream: () => {
 				const error = new Error("aborted");
 				error.name = "TimeoutError";
 				throw error;
@@ -230,18 +225,6 @@ describe("PmInsightsModuleService.handleRequest", () => {
 
 		const response = await callHandle(baseConfig, { symbol: "AVAN08" });
 		expect(response.status).toBe(504);
-	});
-
-	it("returns 502 when the issuer response shape is invalid", async () => {
-		globalThis.fetch = mockPmInsightsFetch({
-			issuer: () =>
-				new Response(JSON.stringify({ info: { id: "AVAN08" } }), {
-					status: 200,
-				}),
-		}) as unknown as typeof fetch;
-
-		const response = await callHandle(baseConfig, { symbol: "AVAN08" });
-		expect(response.status).toBe(502);
 	});
 
 	it("dies during module init when login fails", async () => {

--- a/workspace/data-proxy/src/modules/pm-insights/pm-insights.ts
+++ b/workspace/data-proxy/src/modules/pm-insights/pm-insights.ts
@@ -1,18 +1,44 @@
-import { layer as fetchHttpClientLayer } from "@effect/platform/FetchHttpClient";
-import * as Headers from "@effect/platform/Headers";
-import { text as httpBodyText } from "@effect/platform/HttpBody";
-import { HttpClient } from "@effect/platform/HttpClient";
-import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
-import { type HttpMethod, hasBody } from "@effect/platform/HttpMethod";
 import { Duration, Effect, Either, Layer, Option, Ref, Schedule } from "effect";
 import type { Route } from "../../config/config-parser";
 import type { PmInsightsModuleConfig } from "../../config/pm-insights-module-config";
 import { createErrorResponse } from "../../controllers/create-error-response";
+import {
+	FailedToParseResponseBodyError,
+	HttpClientRequestFailedError,
+} from "../../errors";
+import { HttpClientService } from "../../services/http-client";
 import { replaceParams } from "../../utils/replace-params";
 import { FailedToHandleRequest, ModuleService } from "../module";
 import { FailedToHandlePmInsightsRequestError } from "./errors";
 
 const FETCH_TIMEOUT_MS = 15_000;
+
+function mapHttpClientError(
+	error: unknown,
+	context: string,
+): FailedToHandlePmInsightsRequestError {
+	if (error instanceof FailedToHandlePmInsightsRequestError) {
+		return error;
+	}
+
+	const cause =
+		error instanceof HttpClientRequestFailedError ||
+		error instanceof FailedToParseResponseBodyError
+			? error.error
+			: error;
+
+	if (cause instanceof Error && cause.name === "TimeoutError") {
+		return new FailedToHandlePmInsightsRequestError({
+			error: `${context} timed out after ${FETCH_TIMEOUT_MS}ms`,
+			status: 504,
+		});
+	}
+
+	return new FailedToHandlePmInsightsRequestError({
+		error: `${context}: ${cause}`,
+		status: 502,
+	});
+}
 
 function parseTokenFromLoginBody(text: string): string | undefined {
 	const trimmed = text.trim();
@@ -34,20 +60,49 @@ function parseTokenFromLoginBody(text: string): string | undefined {
 	return undefined;
 }
 
-function normalizeHttpMethod(method: string): HttpMethod {
-	const u = method.toUpperCase();
-	switch (u) {
-		case "GET":
-		case "POST":
-		case "PUT":
-		case "DELETE":
-		case "PATCH":
-		case "HEAD":
-		case "OPTIONS":
-			return u;
-		default:
-			return "GET";
+/**
+ * Extracts the numeric issuer price from a PM Insights `/issuer/{symbol}` response body.
+ */
+export function parseIssuerPrice(
+	responseBody: string,
+): Either.Either<number, FailedToHandlePmInsightsRequestError> {
+	const jsonEither = Either.try(
+		() => JSON.parse(responseBody) as Record<string, unknown>,
+	);
+	if (Either.isLeft(jsonEither)) {
+		return Either.left(
+			new FailedToHandlePmInsightsRequestError({
+				error: `Failed to parse issuer response as JSON: ${jsonEither.left}`,
+				status: 502,
+			}),
+		);
 	}
+
+	const priceSection = jsonEither.right.price;
+	if (
+		typeof priceSection !== "object" ||
+		priceSection === null ||
+		Array.isArray(priceSection)
+	) {
+		return Either.left(
+			new FailedToHandlePmInsightsRequestError({
+				error: "Issuer response missing price object",
+				status: 502,
+			}),
+		);
+	}
+
+	const price = (priceSection as Record<string, unknown>).price;
+	if (typeof price !== "number" || !Number.isFinite(price)) {
+		return Either.left(
+			new FailedToHandlePmInsightsRequestError({
+				error: "Issuer response missing a numeric price.price field",
+				status: 502,
+			}),
+		);
+	}
+
+	return Either.right(price);
 }
 
 export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
@@ -59,6 +114,7 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 				baseUrl: config.baseUrl,
 			});
 
+			const httpClient = yield* HttpClientService;
 			const tokenRef = yield* Ref.make<Option.Option<string>>(Option.none());
 
 			const loginUrl = new URL("login", config.baseUrl).toString();
@@ -69,36 +125,26 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 					password: config.password,
 				}).toString();
 
-				const client = yield* HttpClient;
-				const response = yield* client
-					.post(loginUrl, {
-						body: httpBodyText(body, "application/x-www-form-urlencoded"),
+				const response = yield* httpClient
+					.request(loginUrl, {
+						method: "POST",
+						headers: {
+							"Content-Type": "application/x-www-form-urlencoded",
+						},
+						body,
+						signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 					})
 					.pipe(
-						Effect.timeoutFail({
-							duration: Duration.millis(FETCH_TIMEOUT_MS),
-							onTimeout: () =>
-								new FailedToHandlePmInsightsRequestError({
-									error: `Login timed out after ${FETCH_TIMEOUT_MS}ms`,
-									status: 504,
-								}),
-						}),
-						Effect.mapError((error): FailedToHandlePmInsightsRequestError => {
-							if (error instanceof FailedToHandlePmInsightsRequestError) {
-								return error;
-							}
-							return new FailedToHandlePmInsightsRequestError({
-								error: `Login request failed: ${error}`,
-								status: 502,
-							});
-						}),
+						Effect.mapError((error) =>
+							mapHttpClientError(error, "Login request failed"),
+						),
 					);
 
-				const responseBody = yield* response.text.pipe(
+				const responseBody = yield* httpClient.parseBodyAsText(response).pipe(
 					Effect.mapError(
 						(error) =>
 							new FailedToHandlePmInsightsRequestError({
-								error: `Failed to read login response: ${error}`,
+								error: `Failed to read login response: ${error.error}`,
 								status: 500,
 							}),
 					),
@@ -126,7 +172,7 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 
 				yield* Ref.set(tokenRef, Option.some(token));
 				yield* Effect.logInfo("PM Insights bearer token refreshed");
-			}).pipe(Effect.provide(fetchHttpClientLayer));
+			});
 
 			yield* performLogin.pipe(Effect.orDie);
 
@@ -172,7 +218,7 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 			const handleRequest = (
 				route: Route,
 				params: Record<string, string>,
-				request: Request,
+				_request: Request,
 			) =>
 				Effect.gen(function* () {
 					if (route.type !== "pm-insights") {
@@ -183,24 +229,20 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 						);
 					}
 
-					const signedPath =
-						replaceParams(route.upstreamPath, params) +
-						new URL(request.url).search;
-					const upstreamUrl = new URL(signedPath, config.baseUrl);
-
-					let body = "";
-					if (request.method !== "GET" && request.method !== "HEAD") {
-						body = yield* Effect.tryPromise({
-							try: () => request.clone().text(),
-							catch: () =>
-								new FailedToHandlePmInsightsRequestError({
-									error: "Failed to read request body",
-									status: 400,
-								}),
-						});
+					const symbol = replaceParams(route.fetchFromModule, params).trim();
+					if (!symbol) {
+						return yield* Effect.fail(
+							new FailedToHandlePmInsightsRequestError({
+								error: "Missing issuer symbol",
+								status: 400,
+							}),
+						);
 					}
 
-					const method = normalizeHttpMethod(request.method);
+					const upstreamUrl = new URL(
+						`issuer/${encodeURIComponent(symbol)}`,
+						config.baseUrl,
+					).toString();
 
 					const tokenOpt = yield* Ref.get(tokenRef);
 					if (Option.isNone(tokenOpt)) {
@@ -212,61 +254,37 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 						);
 					}
 
-					const headers: Record<string, string> = {
-						Authorization: `Bearer ${tokenOpt.value}`,
-						Accept: request.headers.get("accept") ?? "application/json",
-						"Content-Type":
-							request.headers.get("content-type") ?? "application/json",
-					};
-
-					const upstreamRequest = !hasBody(method)
-						? HttpClientRequest.make(method)(upstreamUrl, { headers })
-						: HttpClientRequest.make(method)(upstreamUrl, {
-								headers,
-								body: body ? httpBodyText(body) : undefined,
-							});
-
-					yield* Effect.logDebug("Making PM Insights request", {
-						url: upstreamUrl.toString(),
-						method: request.method,
-						path: signedPath,
+					yield* Effect.logDebug("Making PM Insights issuer request", {
+						url: upstreamUrl,
+						symbol,
 					});
 
-					const response = yield* Effect.gen(function* () {
-						const client = yield* HttpClient;
-						return yield* client.execute(upstreamRequest);
-					}).pipe(
-						Effect.provide(fetchHttpClientLayer),
-						Effect.timeoutFail({
-							duration: Duration.millis(FETCH_TIMEOUT_MS),
-							onTimeout: () =>
-								new FailedToHandlePmInsightsRequestError({
-									error: `PM Insights request timed out after ${FETCH_TIMEOUT_MS}ms`,
-									status: 504,
-								}),
-						}),
-						Effect.mapError((error): FailedToHandlePmInsightsRequestError => {
-							if (error instanceof FailedToHandlePmInsightsRequestError) {
-								return error;
-							}
-							return new FailedToHandlePmInsightsRequestError({
-								error: `Failed to fetch from PM Insights: ${error}`,
-								status: 502,
-							});
-						}),
-					);
+					const response = yield* httpClient
+						.request(upstreamUrl, {
+							method: "GET",
+							headers: {
+								Authorization: `Bearer ${tokenOpt.value}`,
+								Accept: "application/json",
+							},
+							signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+						})
+						.pipe(
+							Effect.mapError((error) =>
+								mapHttpClientError(error, "Failed to fetch from PM Insights"),
+							),
+						);
 
-					const responseBody = yield* response.text.pipe(
+					const responseBody = yield* httpClient.parseBodyAsText(response).pipe(
 						Effect.mapError(
 							(error) =>
 								new FailedToHandlePmInsightsRequestError({
-									error: `Failed to read response: ${error}`,
+									error: `Failed to read response: ${error.error}`,
 									status: 500,
 								}),
 						),
 					);
 
-					// PM Insights returns 400 for invalid credentials
+					// PM Insights returns 400 for invalid credentials.
 					if (response.status === 400) {
 						yield* Effect.logWarning(
 							"PM Insights upstream rejected credentials; refreshing login",
@@ -279,29 +297,40 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 						);
 					}
 
-					const upstreamOk = response.status >= 200 && response.status < 300;
-					if (!upstreamOk) {
+					if (response.status < 200 || response.status >= 300) {
 						yield* Effect.logError("PM Insights request failed", {
 							status: response.status,
 							body: responseBody,
+							symbol,
 						});
+						return yield* Effect.fail(
+							new FailedToHandlePmInsightsRequestError({
+								error: `PM Insights issuer request failed with status ${response.status}`,
+								status:
+									response.status >= 400 && response.status < 600
+										? response.status
+										: 502,
+							}),
+						);
 					}
 
-					const upstreamContentType = Option.getOrElse(
-						Headers.get(response.headers, "content-type"),
-						() => "application/json",
-					);
+					const priceEither = parseIssuerPrice(responseBody);
+					if (Either.isLeft(priceEither)) {
+						return yield* Effect.fail(priceEither.left);
+					}
 
 					return yield* Effect.succeed(
-						new Response(responseBody, {
-							status: response.status,
-							headers: { "Content-Type": upstreamContentType },
+						new Response(JSON.stringify(priceEither.right), {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
 						}),
 					);
 				}).pipe(
 					Effect.withSpan("handlePmInsightsRequest"),
 					Effect.catchAll((error) => {
-						return Effect.succeed(createErrorResponse(error, error.status));
+						const status =
+							typeof error.status === "number" ? error.status : 500;
+						return Effect.succeed(createErrorResponse(error, status));
 					}),
 				);
 
@@ -309,5 +338,5 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 				start,
 				handleRequest,
 			};
-		}),
+		}).pipe(Effect.provide(HttpClientService.Default())),
 	);

--- a/workspace/data-proxy/src/modules/pm-insights/pm-insights.ts
+++ b/workspace/data-proxy/src/modules/pm-insights/pm-insights.ts
@@ -60,51 +60,6 @@ function parseTokenFromLoginBody(text: string): string | undefined {
 	return undefined;
 }
 
-/**
- * Extracts the numeric issuer price from a PM Insights `/issuer/{symbol}` response body.
- */
-export function parseIssuerPrice(
-	responseBody: string,
-): Either.Either<number, FailedToHandlePmInsightsRequestError> {
-	const jsonEither = Either.try(
-		() => JSON.parse(responseBody) as Record<string, unknown>,
-	);
-	if (Either.isLeft(jsonEither)) {
-		return Either.left(
-			new FailedToHandlePmInsightsRequestError({
-				error: `Failed to parse issuer response as JSON: ${jsonEither.left}`,
-				status: 502,
-			}),
-		);
-	}
-
-	const priceSection = jsonEither.right.price;
-	if (
-		typeof priceSection !== "object" ||
-		priceSection === null ||
-		Array.isArray(priceSection)
-	) {
-		return Either.left(
-			new FailedToHandlePmInsightsRequestError({
-				error: "Issuer response missing price object",
-				status: 502,
-			}),
-		);
-	}
-
-	const price = (priceSection as Record<string, unknown>).price;
-	if (typeof price !== "number" || !Number.isFinite(price)) {
-		return Either.left(
-			new FailedToHandlePmInsightsRequestError({
-				error: "Issuer response missing a numeric price.price field",
-				status: 502,
-			}),
-		);
-	}
-
-	return Either.right(price);
-}
-
 export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 	Layer.effect(
 		ModuleService,
@@ -218,7 +173,7 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 			const handleRequest = (
 				route: Route,
 				params: Record<string, string>,
-				_request: Request,
+				request: Request,
 			) =>
 				Effect.gen(function* () {
 					if (route.type !== "pm-insights") {
@@ -229,20 +184,18 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 						);
 					}
 
-					const symbol = replaceParams(route.fetchFromModule, params).trim();
-					if (!symbol) {
+					const path = replaceParams(route.fetchFromModule, params).trim();
+					if (!path) {
 						return yield* Effect.fail(
 							new FailedToHandlePmInsightsRequestError({
-								error: "Missing issuer symbol",
+								error: "Missing upstream path",
 								status: 400,
 							}),
 						);
 					}
 
-					const upstreamUrl = new URL(
-						`issuer/${encodeURIComponent(symbol)}`,
-						config.baseUrl,
-					).toString();
+					const upstreamPath = path + new URL(request.url).search;
+					const upstreamUrl = new URL(upstreamPath, config.baseUrl).toString();
 
 					const tokenOpt = yield* Ref.get(tokenRef);
 					if (Option.isNone(tokenOpt)) {
@@ -254,9 +207,9 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 						);
 					}
 
-					yield* Effect.logDebug("Making PM Insights issuer request", {
+					yield* Effect.logDebug("Making PM Insights request", {
 						url: upstreamUrl,
-						symbol,
+						path: upstreamPath,
 					});
 
 					const response = yield* httpClient
@@ -301,28 +254,17 @@ export const PmInsightsModuleService = (config: PmInsightsModuleConfig) =>
 						yield* Effect.logError("PM Insights request failed", {
 							status: response.status,
 							body: responseBody,
-							symbol,
+							path: upstreamPath,
 						});
-						return yield* Effect.fail(
-							new FailedToHandlePmInsightsRequestError({
-								error: `PM Insights issuer request failed with status ${response.status}`,
-								status:
-									response.status >= 400 && response.status < 600
-										? response.status
-										: 502,
-							}),
-						);
-					}
-
-					const priceEither = parseIssuerPrice(responseBody);
-					if (Either.isLeft(priceEither)) {
-						return yield* Effect.fail(priceEither.left);
 					}
 
 					return yield* Effect.succeed(
-						new Response(JSON.stringify(priceEither.right), {
-							status: 200,
-							headers: { "Content-Type": "application/json" },
+						new Response(responseBody, {
+							status: response.status,
+							headers: {
+								"Content-Type":
+									response.headers.get("content-type") ?? "application/json",
+							},
 						}),
 					);
 				}).pipe(


### PR DESCRIPTION
Small refactors before we deploy it

- Confine upstream fetch to the `GET /issuer/{symbol}` endpoint. The module only takes a single symbol as a request parameter per request.
- Added README and request handler tests

Link to PM Insights API docs: https://api.pminsights.com/docs