### PR TITLE
Bump version to v2.13.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,15 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
 
+      - name: ✅ Verify package.json version matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(jq -r .version workspace/data-proxy/package.json)
+          if [ "$TAG" != "$PKG" ]; then
+            echo "Tag $GITHUB_REF_NAME != package.json version $PKG"
+            exit 1
+          fi
+
       - name: 🔧 Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "2.12.0",
+	"version": "2.13.1",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",


### PR DESCRIPTION
This version bump was missing from v2.13.0 release.

Also adds a check in the release workflow to see if the package.json version matches the tag.