### PR TITLE
Pyth Lazer module refactor

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,14 @@
+name: 🧹 Git Checks
+on: [pull_request]
+
+jobs:
+  block_fixup:
+    name: "Block Fixup Commit Merge"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🛃 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 💂 Block Fixup Commit Merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "2.13.1",
+	"version": "3.0.0",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",

--- a/workspace/data-proxy/src/config/multi-module-config.ts
+++ b/workspace/data-proxy/src/config/multi-module-config.ts
@@ -1,4 +1,5 @@
 import * as v from "valibot";
+import { PythLazerChannelSchema } from "./pyth-lazer-module-config";
 import { RouteSchema } from "./route-config";
 
 // Module types a multi fetch can target. These are the modules backed by a
@@ -26,6 +27,8 @@ export const MultiFetchSchema = v.strictObject({
 	fetchFromModule: v.optional(v.string()),
 	body: v.optional(v.string()),
 	allowedQueryParams: v.optional(v.array(v.string())),
+	// Used only when type is pyth-lazer.
+	channel: v.optional(PythLazerChannelSchema),
 });
 
 export type MultiFetch = v.InferOutput<typeof MultiFetchSchema>;

--- a/workspace/data-proxy/src/config/pyth-lazer-module-config.ts
+++ b/workspace/data-proxy/src/config/pyth-lazer-module-config.ts
@@ -1,6 +1,18 @@
+import type { Channel } from "@pythnetwork/pyth-lazer-sdk";
 import { Duration, Effect, Option } from "effect";
 import * as v from "valibot";
 import { RouteSchema } from "./route-config";
+
+export const PYTH_LAZER_DEFAULT_CHANNEL = "fixed_rate@200ms" as const;
+
+const PYTH_LAZER_CHANNELS = [
+	"real_time",
+	"fixed_rate@50ms",
+	"fixed_rate@200ms",
+	"fixed_rate@1000ms",
+] as const satisfies readonly Channel[];
+
+export const PythLazerChannelSchema = v.picklist(PYTH_LAZER_CHANNELS);
 
 export const PythLazerModuleConfigSchema = v.strictObject({
 	name: v.string(),
@@ -8,16 +20,8 @@ export const PythLazerModuleConfigSchema = v.strictObject({
 		v.object({
 			name: v.string(),
 			id: v.number(),
+			channel: v.optional(PythLazerChannelSchema, PYTH_LAZER_DEFAULT_CHANNEL),
 		}),
-	),
-	channel: v.optional(
-		v.picklist([
-			"real_time",
-			"fixed_rate@50ms",
-			"fixed_rate@1000ms",
-			"fixed_rate@200ms",
-		]),
-		"fixed_rate@200ms",
 	),
 	maxFeedsPerRequest: v.optional(v.number(), 100),
 	pythLazerApiKeyEnvKey: v.string(),
@@ -51,6 +55,7 @@ export const PythLazerModuleRouteSchema = v.strictObject({
 	...RouteSchema.entries,
 	moduleName: v.string(),
 	fetchFromModule: v.string(),
+	channel: v.optional(PythLazerChannelSchema, PYTH_LAZER_DEFAULT_CHANNEL),
 	type: v.literal("pyth-lazer"),
 });
 

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
@@ -15,11 +15,16 @@ const handlers = (
 });
 
 // Echoes back what the synthetic route/body carried so tests can assert the
-// templates were filled and forwarded.
+// templates were filled and forwarded. `fetchFromModule` is not on every Route
+// variant (e.g. upstream, hydromancer), so narrow before reading it.
 const echoHandlers = handlers((route, _params, _request, body) =>
 	Effect.succeed(
 		new Response(
-			JSON.stringify({ fetchFromModule: route.fetchFromModule, body }),
+			JSON.stringify({
+				fetchFromModule:
+					"fetchFromModule" in route ? route.fetchFromModule : undefined,
+				body,
+			}),
 			{ status: 200 },
 		),
 	),
@@ -102,6 +107,46 @@ describe("handleMultiRequest", () => {
 				fetchFromModule: "",
 				body: '{"type":"assetContext","coins":["BTC"]}',
 			},
+		});
+	});
+
+	it("forwards Pyth channels and defaults them to fixed 200ms", async () => {
+		const route = makeRoute([
+			{
+				name: "default",
+				moduleName: "pyth",
+				type: "pyth-lazer",
+				fetchFromModule: "1",
+			},
+			{
+				name: "realtime",
+				moduleName: "pyth",
+				type: "pyth-lazer",
+				fetchFromModule: "1",
+				channel: "real_time",
+			},
+		]);
+		const pythHandlers = handlers((syntheticRoute) =>
+			Effect.succeed(
+				new Response(
+					JSON.stringify({
+						channel:
+							syntheticRoute.type === "pyth-lazer"
+								? syntheticRoute.channel
+								: undefined,
+					}),
+					{ status: 200 },
+				),
+			),
+		);
+
+		const body = await run(
+			route,
+			new Map<string, ModuleHandlers>([["pyth", pythHandlers]]),
+		);
+		expect(body).toEqual({
+			default: { channel: "fixed_rate@200ms" },
+			realtime: { channel: "real_time" },
 		});
 	});
 
@@ -209,7 +254,12 @@ describe("handleMultiRequest", () => {
 					calls++;
 					return Effect.succeed(
 						new Response(
-							JSON.stringify({ fetchFromModule: route.fetchFromModule }),
+							JSON.stringify({
+								fetchFromModule:
+									"fetchFromModule" in route
+										? route.fetchFromModule
+										: undefined,
+							}),
 							{ status: 200 },
 						),
 					);

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
@@ -1,6 +1,7 @@
 import { Effect, Either } from "effect";
 import type { Route } from "../../config/config-parser";
 import type { MultiModuleRoute } from "../../config/multi-module-config";
+import { PYTH_LAZER_DEFAULT_CHANNEL } from "../../config/pyth-lazer-module-config";
 import type { ModuleHandlers } from "../../modules/module";
 import { replaceParams } from "../../utils/replace-params";
 
@@ -83,6 +84,11 @@ export const handleMultiRequest = (
 						headers: {},
 						useLegacyJsonPath: true,
 						forwardResponseHeaders: new Set<string>(),
+						...(fetch.type === "pyth-lazer"
+							? {
+									channel: fetch.channel ?? PYTH_LAZER_DEFAULT_CHANNEL,
+								}
+							: {}),
 					} as Route;
 
 					const result = yield* Effect.either(

--- a/workspace/data-proxy/src/modules/pyth-lazer/README.md
+++ b/workspace/data-proxy/src/modules/pyth-lazer/README.md
@@ -1,0 +1,184 @@
+# Pyth Lazer module
+
+Streams Pyth Lazer price feeds over a redundant WebSocket pool and serves the latest cached value for requested feed IDs or symbols.
+
+## Overview
+
+On startup the module:
+
+1. Creates a `PythLazerClient` with a pool of WebSocket connections to Pyth Lazer.
+2. Subscribes to every entry in `priceFeedIds`. 
+3. Caches inbound `streamUpdated` messages keyed by `(channel, priceFeedId)`.
+4. Idle-unsubscribes feeds that have not been requested within `priceFeedsCleanupTtl`.
+
+HTTP requests resolve `fetchFromModule` to one or more comma-separated feed IDs or symbols, subscribe on the route’s `channel` if needed, and return the latest cached price for each. If a price is not yet available, the handler waits briefly for an update (shared price-cache timeout: 3 seconds).
+
+Subscriptions are isolated per channel: the same feed on `fixed_rate@200ms` and `real_time` are separate cache entries and WebSocket subscriptions.
+
+## Configuration
+
+### Module
+
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `type` | yes | — | Must be `"pyth-lazer"`. |
+| `name` | yes | — | Module name referenced by routes as `moduleName`. |
+| `pythLazerApiKeyEnvKey` | yes | — | Env var that holds the Pyth Lazer API token. |
+| `priceFeedIds` | yes | — | Feeds to subscribe to on start. Each entry: `name`, `id`, optional `channel` (defaults to `fixed_rate@200ms`). |
+| `maxFeedsPerRequest` | no | `100` | Max feed IDs / symbols allowed in a single request. |
+| `priceFeedsCleanupTtl` | no | `"1 hour"` | Idle time before an unused subscription is cleaned up. |
+| `priceFeedsCleanupInterval` | no | `"30 seconds"` | How often idle cleanup runs. |
+
+### Route
+
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `type` | yes | — | Must be `"pyth-lazer"`. |
+| `moduleName` | yes | — | Name of a configured Pyth Lazer module. |
+| `path` | yes | — | Proxy path (supports `{:param}` path params). |
+| `method` | no | `GET` | HTTP method(s). |
+| `fetchFromModule` | yes | — | Template producing one or more comma-separated feed IDs or symbols. |
+| `channel` | no | `fixed_rate@200ms` | Channel used for this route’s subscriptions and cache lookups. |
+
+### Multi-route fetch
+
+When a `multi` route targets this module, each fetch may set its own `channel` (defaults to `fixed_rate@200ms` if omitted):
+
+```jsonc
+{
+  "type": "multi",
+  "path": "/:symbol",
+  "fetches": [
+    {
+      "name": "pyth_200ms",
+      "moduleName": "pyth",
+      "type": "pyth-lazer",
+      "fetchFromModule": "{:symbol}" // default (fixed_rate@200ms)
+    },
+    {
+      "name": "pyth_realtime",
+      "moduleName": "pyth",
+      "type": "pyth-lazer",
+      "fetchFromModule": "{:symbol}",
+      "channel": "real_time" // overrides the default
+    }
+  ]
+}
+```
+
+### Example Configuration 
+
+```jsonc
+{
+  "modules": [
+    {
+      "type": "pyth-lazer",
+      "name": "pyth",
+      "pythLazerApiKeyEnvKey": "PYTH_LAZER_API_KEY",
+      "priceFeedIds": [
+        { "name": "BTC/USD", "id": 1 },
+        { "name": "ETH/USD", "id": 2, "channel": "real_time" }
+      ]
+    }
+  ],
+  "routes": [
+    {
+      "type": "pyth-lazer",
+      "moduleName": "pyth",
+      "path": "/200ms/:symbol",
+      "method": "GET",
+      "fetchFromModule": "{:symbol}",
+      "channel": "fixed_rate@200ms"
+    },
+    {
+      "type": "pyth-lazer",
+      "moduleName": "pyth",
+      "path": "/realtime/:symbol",
+      "method": "GET",
+      "fetchFromModule": "{:symbol}",
+      "channel": "real_time"
+    }
+  ]
+}
+```
+
+
+## Request and Response
+
+Example requests against the example configuration above:
+
+```bash
+# Feed ID on fixed_rate@200ms
+curl -s "http://127.0.0.1:5384/proxy/200ms/1" | jq .
+
+# Same feed on real_time
+curl -s "http://127.0.0.1:5384/proxy/realtime/1" | jq .
+
+# Symbol (resolved via Pyth metadata)
+curl -s "http://127.0.0.1:5384/proxy/200ms/Crypto.BTC%2FUSD" | jq .
+
+# Multiple feeds (comma-separated)
+curl -s "http://127.0.0.1:5384/proxy/200ms/1,2" | jq .
+```
+
+Successful responses are a JSON array. Example for `GET /proxy/200ms/1,2`:
+
+```json
+[
+  {
+    "priceFeedId": 1,
+    "price": "6657080819622",
+    "bestBidPrice": "6656513616670",
+    "bestAskPrice": "6657472370813",
+    "publisherCount": 19,
+    "exponent": -8,
+    "confidence": 2188501708,
+    "marketSession": "regular",
+    "emaPrice": "6648715700000",
+    "emaConfidence": 1953158920,
+    "feedUpdateTimestamp": 1784678955400000,
+    "symbol": "1",
+    "__sedaHasPrice": true
+  },
+  {
+    "priceFeedId": 2,
+    "price": "193228893674",
+    "bestBidPrice": "193227483680",
+    "bestAskPrice": "193255500075",
+    "publisherCount": 20,
+    "exponent": -8,
+    "confidence": 48018423,
+    "marketSession": "regular",
+    "emaPrice": "192356325000",
+    "emaConfidence": 64887569,
+    "feedUpdateTimestamp": 1784678955800000,
+    "symbol": "2",
+    "__sedaHasPrice": true
+  }
+]
+```
+
+On a wait timeout, the entry still appears with `__sedaHasPrice: false` and without price fields:
+
+```json
+{
+  "priceFeedId": 77777,
+  "symbol": "77777",
+  "__sedaHasPrice": false
+}
+```
+
+| Field | Present when | Description |
+| --- | --- | --- |
+| `priceFeedId` | always | Numeric Pyth Lazer feed ID. |
+| `symbol` | always | The raw request token (ID or symbol string from `fetchFromModule`). |
+| Pyth feed fields | `__sedaHasPrice: true` | Fields from the stream (`price`, `bestBidPrice`, `bestAskPrice`, `exponent`, `confidence`, funding / EMA fields, etc.). |
+| `__sedaHasPrice` | always | `true` when a cached price was returned; `false` on wait timeout / miss. |
+
+Requests with more feeds than `maxFeedsPerRequest` return HTTP 400.
+
+
+## Notes
+
+- Numeric path tokens are treated as feed IDs; non-numeric tokens are resolved to IDs via the Pyth metadata service and cached in-process.
+- Pyth Lazer docs: https://docs.pyth.network/lazer

--- a/workspace/data-proxy/src/modules/pyth-lazer/errors.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/errors.ts
@@ -39,3 +39,27 @@ export function extractPriceFeedIdFromErrorMessage(
 
 	return Option.none();
 }
+
+/** Extracts a loggable message from WS Error / ErrorEvent-like values. */
+export const pythLazerErrorMessage = (error: unknown): string => {
+	if (
+		typeof error === "object" &&
+		error !== null &&
+		"message" in error &&
+		typeof error.message === "string"
+	) {
+		return error.message;
+	}
+	return String(error);
+};
+
+/**
+ * Keeps the WebSocket URL for debugging but strips credentials from the text.
+ * Pyth Lazer puts the API key in `?ACCESS_TOKEN=` (browser) or Bearer headers.
+ */
+export const redactPythLazerSecrets = (text: string): string => {
+	const output = text
+		.replaceAll(/([?&]ACCESS_TOKEN=)[^&\s'"]+/gi, "$1<redacted>")
+		.replaceAll(/(Bearer\s+)\S+/gi, "$1<redacted>");
+	return output;
+};

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { lagMsFromTimestampUs } from "./pyth-lazer";
+import * as v from "valibot";
+import {
+	PythLazerModuleConfigSchema,
+	PythLazerModuleRouteSchema,
+} from "../../config/pyth-lazer-module-config";
+import { lagMsFromTimestampUs, priceFeedSubscriptionKey } from "./pyth-lazer";
 
 describe("lagMsFromTimestampUs", () => {
 	it("returns lag in ms from a microsecond timestamp", () => {
@@ -19,5 +24,25 @@ describe("lagMsFromTimestampUs", () => {
 	it("returns undefined for missing or invalid timestamps", () => {
 		expect(lagMsFromTimestampUs(1_000, undefined)).toBeUndefined();
 		expect(lagMsFromTimestampUs(1_000, "not-a-number")).toBeUndefined();
+	});
+});
+
+describe("priceFeedSubscriptionKey", () => {
+	it("formats as channel:feedId", () => {
+		expect(priceFeedSubscriptionKey(1, "fixed_rate@200ms")).toBe(
+			"fixed_rate@200ms:1",
+		);
+	});
+
+	it("isolates the same feed across different channels", () => {
+		expect(priceFeedSubscriptionKey(1, "fixed_rate@50ms")).not.toBe(
+			priceFeedSubscriptionKey(1, "fixed_rate@200ms"),
+		);
+	});
+
+	it("isolates different feeds on the same channel", () => {
+		expect(priceFeedSubscriptionKey(1, "real_time")).not.toBe(
+			priceFeedSubscriptionKey(2, "real_time"),
+		);
 	});
 });

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import * as v from "valibot";
-import {
-	PythLazerModuleConfigSchema,
-	PythLazerModuleRouteSchema,
-} from "../../config/pyth-lazer-module-config";
+import { pythLazerErrorMessage, redactPythLazerSecrets } from "./errors";
 import { lagMsFromTimestampUs, priceFeedSubscriptionKey } from "./pyth-lazer";
 
 describe("lagMsFromTimestampUs", () => {
@@ -43,6 +39,37 @@ describe("priceFeedSubscriptionKey", () => {
 	it("isolates different feeds on the same channel", () => {
 		expect(priceFeedSubscriptionKey(1, "real_time")).not.toBe(
 			priceFeedSubscriptionKey(2, "real_time"),
+		);
+	});
+});
+
+describe("redactPythLazerSecrets", () => {
+	it("keeps the WebSocket host/path and redacts ACCESS_TOKEN", () => {
+		const message =
+			"WebSocket connection to 'wss://pyth-lazer-x.dourolabs.app/v1/stream?ACCESS_TOKEN=secret-token' failed: Failed to connect";
+
+		expect(redactPythLazerSecrets(message)).toBe(
+			"WebSocket connection to 'wss://pyth-lazer-x.dourolabs.app/v1/stream?ACCESS_TOKEN=<redacted>' failed: Failed to connect",
+		);
+	});
+
+	it("redacts Bearer tokens and raw api key values", () => {
+		const apiKey = "raw-api-key-value";
+		expect(redactPythLazerSecrets(`Authorization: Bearer ${apiKey}`)).toBe(
+			"Authorization: Bearer <redacted>",
+		);
+	});
+});
+
+describe("pythLazerErrorMessage", () => {
+	it("reads message from ErrorEvent-like objects", () => {
+		expect(
+			pythLazerErrorMessage({
+				message:
+					"WebSocket connection to 'wss://example/v1/stream' failed: Failed to connect",
+			}),
+		).toBe(
+			"WebSocket connection to 'wss://example/v1/stream' failed: Failed to connect",
 		);
 	});
 });

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -28,6 +28,8 @@ import { createPriceCache } from "../shared/price-cache";
 import {
 	FailedToHandlePythLazerRequestError,
 	extractPriceFeedIdFromErrorMessage,
+	pythLazerErrorMessage,
+	redactPythLazerSecrets,
 } from "./errors";
 import { getPriceIdBySymbol } from "./get-symbol-price-id";
 
@@ -152,14 +154,20 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 								"wss://pyth-lazer-2.dourolabs.app/v1/stream",
 							],
 							onWebSocketPoolError: (error) => {
-								Runtime.runSync(
-									runtime,
-									Effect.logError("Error in Pyth Lazer client web socket pool"),
+								const safeMessage = redactPythLazerSecrets(
+									pythLazerErrorMessage(error),
 								);
 
-								const priceFeedId = extractPriceFeedIdFromErrorMessage(
-									`${error}`,
+								Runtime.runSync(
+									runtime,
+									Effect.logError(
+										"Error in Pyth Lazer client web socket pool",
+										{ message: safeMessage },
+									),
 								);
+
+								const priceFeedId =
+									extractPriceFeedIdFromErrorMessage(safeMessage);
 
 								// If price feed id is given, then set the cache to error
 								// for all subscriptions to this price feed id.
@@ -172,25 +180,24 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 											priceFeedIdFromSubscriptionKey(key) === priceFeedId.value
 												? priceCache.setPriceToError(
 														key,
-														`(${Option.getOrElse(symbol, () => "Unknown/Symbol")}) ${error}`,
+														`(${Option.getOrElse(symbol, () => "Unknown/Symbol")}) ${safeMessage}`,
 													)
 												: Effect.void,
 										),
 									);
 								}
-
-								// For some reason the error is encoded to an empty object, the regular console.error does show the actual error
-								console.error(error);
 							},
 							onWebSocketError: (error) => {
+								const safeMessage = redactPythLazerSecrets(
+									pythLazerErrorMessage(error),
+								);
+
 								Runtime.runSync(
 									runtime,
 									Effect.logError("Error in Pyth Lazer client web socket", {
-										error,
+										message: safeMessage,
 									}),
 								);
-
-								console.error(error);
 							},
 						},
 					}),

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -1,4 +1,5 @@
 import {
+	type Channel,
 	type ParsedFeedPayload,
 	type ParsedPayload,
 	PythLazerClient,
@@ -38,6 +39,21 @@ export class FailedToCreateLazerClientError extends Data.TaggedError(
 
 type PriceFeedId = number;
 type PriceFeedSymbol = string;
+type PriceFeedSubscriptionKey = `${Channel}:${PriceFeedId}`;
+
+interface PriceFeedSubscription {
+	channel: Channel;
+	priceFeedId: PriceFeedId;
+}
+
+export const priceFeedSubscriptionKey = (
+	priceFeedId: PriceFeedId,
+	channel: Channel,
+): PriceFeedSubscriptionKey => `${channel}:${priceFeedId}`;
+
+const priceFeedIdFromSubscriptionKey = (
+	key: PriceFeedSubscriptionKey,
+): PriceFeedId => Number(key.slice(key.lastIndexOf(":") + 1));
 
 interface PriceFeedWithSymbol extends ParsedFeedPayload {
 	symbol?: string;
@@ -86,21 +102,33 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 			yield* Effect.logInfo("Initializing Pyth Lazer module");
 			const runtime = yield* Effect.runtime();
 			const priceCache = yield* createPriceCache<
-				PriceFeedId,
+				PriceFeedSubscriptionKey,
 				ParsedFeedPayload
 			>();
 			// The timestamp of the last request to the price feed
 			const lastRequestToPriceFeed = MutableHashMap.empty<
-				PriceFeedId,
+				PriceFeedSubscriptionKey,
 				number
 			>();
-			const newPriceFeedRequests = yield* Queue.unbounded<PriceFeedId>();
-			// price feed id -> subscription id
-			const subscriptions = MutableHashMap.empty<PriceFeedId, number>();
-			const symbolsToId = MutableHashMap.empty<PriceFeedSymbol, PriceFeedId>();
+			const newPriceFeedRequests =
+				yield* Queue.unbounded<PriceFeedSubscription>();
+			// channel + price feed id -> subscription id
+			const subscriptions = MutableHashMap.empty<
+				PriceFeedSubscriptionKey,
+				number
+			>();
+			// subscription id -> channel, used to route incoming updates to the correct cache
+			const subscriptionChannels = MutableHashMap.empty<number, Channel>();
+			// symbol -> price feed id, to support requests with symbols
+			const symbolToFeedId = MutableHashMap.empty<
+				PriceFeedSymbol,
+				PriceFeedId
+			>();
 
 			const getSymbolByPriceFeedId = (priceFeedId: PriceFeedId) => {
-				for (const [symbol, id] of MutableHashMap.fromIterable(symbolsToId)) {
+				for (const [symbol, id] of MutableHashMap.fromIterable(
+					symbolToFeedId,
+				)) {
 					if (id === priceFeedId) {
 						return Option.some(symbol);
 					}
@@ -132,14 +160,20 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 									`${error}`,
 								);
 
+								// If price feed id is given, then set the cache to error
+								// for all subscriptions to this price feed id.
 								if (Option.isSome(priceFeedId)) {
 									const symbol = getSymbolByPriceFeedId(priceFeedId.value);
 
 									Runtime.runSync(
 										runtime,
-										priceCache.setPriceToError(
-											priceFeedId.value,
-											`(${Option.getOrElse(symbol, () => "Unknown/Symbol")}) ${error}`,
+										Effect.forEach(subscriptions, ([key]) =>
+											priceFeedIdFromSubscriptionKey(key) === priceFeedId.value
+												? priceCache.setPriceToError(
+														key,
+														`(${Option.getOrElse(symbol, () => "Unknown/Symbol")}) ${error}`,
+													)
+												: Effect.void,
 										),
 									);
 								}
@@ -198,15 +232,29 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 									});
 								}
 
-								yield* handleStreamUpdatedMessage(message.value.parsed);
+								yield* handleStreamUpdatedMessage(
+									message.value.subscriptionId,
+									message.value.parsed,
+								);
 							}
 						}
 					}).pipe(Metric.trackDuration(messageHandleDurationMs)),
 				);
 			});
 
-			const handleStreamUpdatedMessage = (message: ParsedPayload) =>
+			const handleStreamUpdatedMessage = (
+				subscriptionId: number,
+				message: ParsedPayload,
+			) =>
 				Effect.gen(function* () {
+					const channel = MutableHashMap.get(
+						subscriptionChannels,
+						subscriptionId,
+					);
+					if (Option.isNone(channel)) {
+						return;
+					}
+
 					const nowMs = yield* Clock.currentTimeMillis;
 					const lagMs = lagMsFromTimestampUs(nowMs, message.timestampUs);
 
@@ -215,13 +263,17 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 					}
 
 					for (const priceFeed of message.priceFeeds) {
+						const key = priceFeedSubscriptionKey(
+							priceFeed.priceFeedId,
+							channel.value,
+						);
 						// To make sure that we don't set the price for a price feed that we are not subscribed to
 						// otherwise requests may get an outdated price
-						if (!MutableHashMap.has(subscriptions, priceFeed.priceFeedId)) {
+						if (!MutableHashMap.has(subscriptions, key)) {
 							continue;
 						}
 
-						yield* priceCache.setPrice(priceFeed.priceFeedId, priceFeed);
+						yield* priceCache.setPrice(key, priceFeed);
 					}
 				});
 
@@ -231,32 +283,45 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 
 					const now = yield* Clock.currentTimeMillis;
 					for (const priceFeed of config.priceFeedIds) {
-						yield* newPriceFeedRequests.offer(priceFeed.id);
+						const subscription = {
+							channel: priceFeed.channel,
+							priceFeedId: priceFeed.id,
+						};
+						const key = priceFeedSubscriptionKey(
+							subscription.priceFeedId,
+							subscription.channel,
+						);
+						yield* newPriceFeedRequests.offer(subscription);
 						// Add a request timestamp so it is tracked in the cleanup interval
-						MutableHashMap.set(lastRequestToPriceFeed, priceFeed.id, now);
+						MutableHashMap.set(lastRequestToPriceFeed, key, now);
 					}
 
 					yield* Effect.forkDaemon(
 						Effect.gen(function* () {
-							const newPriceFeedId = yield* newPriceFeedRequests.take;
+							const newPriceFeed = yield* newPriceFeedRequests.take;
+							const key = priceFeedSubscriptionKey(
+								newPriceFeed.priceFeedId,
+								newPriceFeed.channel,
+							);
 
-							if (MutableHashMap.has(subscriptions, newPriceFeedId)) {
+							if (MutableHashMap.has(subscriptions, key)) {
 								yield* Effect.logDebug(
-									`Price feed ${newPriceFeedId} is already subscribed`,
+									`Price feed ${newPriceFeed.priceFeedId} is already subscribed to ${newPriceFeed.channel}`,
 								);
 								return;
 							}
 
 							yield* Effect.logInfo(
-								`Subscribing to price feed ${newPriceFeedId}`,
+								`Subscribing to price feed ${newPriceFeed.priceFeedId} on ${newPriceFeed.channel}`,
 							);
 
 							const newSubscriptionId = subscriptionId++;
 
+							MutableHashMap.set(subscriptions, key, newSubscriptionId);
 							MutableHashMap.set(
-								subscriptions,
-								newPriceFeedId,
+								subscriptionChannels,
 								newSubscriptionId,
+								newPriceFeed.channel,
 							);
 
 							yield* Metric.set(
@@ -266,7 +331,7 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 
 							lazerClient.subscribe({
 								type: "subscribe",
-								channel: config.channel,
+								channel: newPriceFeed.channel,
 								formats: [],
 								properties: [
 									"bestAskPrice",
@@ -284,7 +349,7 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 									"publisherCount",
 								],
 								subscriptionId: newSubscriptionId,
-								priceFeedIds: [newPriceFeedId],
+								priceFeedIds: [newPriceFeed.priceFeedId],
 								// Recommended by Pyth case a previously valid feed id becomes invalid (delisting, id changed, etc.)
 								ignoreInvalidFeedIds: true,
 							});
@@ -295,32 +360,41 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 						lastRequest: lastRequestToPriceFeed,
 						ttl: config.priceFeedsCleanupTtl,
 						interval: config.priceFeedsCleanupInterval,
-						onExpire: (priceFeedId) =>
+						onExpire: (key) =>
 							Effect.gen(function* () {
-								yield* Effect.logInfo(`Cleaning up price feed ${priceFeedId}`);
-								yield* priceCache.deletePrice(priceFeedId);
+								const priceFeedId = priceFeedIdFromSubscriptionKey(key);
+								yield* Effect.logInfo(`Cleaning up price feed ${key}`);
+								yield* priceCache.deletePrice(key);
 
-								const subscriptionId = MutableHashMap.get(
-									subscriptions,
-									priceFeedId,
-								);
+								const subscriptionId = MutableHashMap.get(subscriptions, key);
 								if (Option.isSome(subscriptionId)) {
 									lazerClient.unsubscribe(subscriptionId.value);
-									MutableHashMap.remove(subscriptions, priceFeedId);
+									MutableHashMap.remove(subscriptions, key);
+									MutableHashMap.remove(
+										subscriptionChannels,
+										subscriptionId.value,
+									);
 
 									yield* Metric.set(
 										activeSubscriptions,
 										MutableHashMap.size(subscriptions),
 									);
 
-									const symbol = getSymbolByPriceFeedId(priceFeedId);
-									if (Option.isSome(symbol)) {
-										MutableHashMap.remove(symbolsToId, symbol.value);
+									// If there are no other subscriptions to this price feed id under
+									// different channels, then remove the symbol to price feed id mapping.
+									const hasOtherRate = Array.from(subscriptions).some(
+										([subscriptionKey]) =>
+											priceFeedIdFromSubscriptionKey(subscriptionKey) ===
+											priceFeedId,
+									);
+									if (!hasOtherRate) {
+										const symbol = getSymbolByPriceFeedId(priceFeedId);
+										if (Option.isSome(symbol)) {
+											MutableHashMap.remove(symbolToFeedId, symbol.value);
+										}
 									}
 
-									yield* Effect.logInfo(
-										`Unsubscribed from price feed ${priceFeedId}`,
-									);
+									yield* Effect.logInfo(`Unsubscribed from price feed ${key}`);
 								}
 							}),
 					});
@@ -363,7 +437,7 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 						if (Number.isNaN(Number(symbolOrId))) {
 							// Let's check if the symbol exists otherwise
 							const cachedSymbolToPriceFeedId = MutableHashMap.get(
-								symbolsToId,
+								symbolToFeedId,
 								symbolOrId,
 							);
 
@@ -377,7 +451,7 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 								lazerClient,
 							);
 
-							MutableHashMap.set(symbolsToId, symbolOrId, priceFeedId);
+							MutableHashMap.set(symbolToFeedId, symbolOrId, priceFeedId);
 							priceFeedIds.push(priceFeedId);
 						} else {
 							priceFeedIds.push(Number(symbolOrId));
@@ -389,18 +463,26 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 
 					// First subscribe to all the symbols that we have not subscribed to yet
 					for (const priceFeedId of priceFeedIds) {
-						if (!MutableHashMap.has(lastRequestToPriceFeed, priceFeedId)) {
-							yield* newPriceFeedRequests.offer(priceFeedId);
+						const key = priceFeedSubscriptionKey(priceFeedId, route.channel);
+						if (!MutableHashMap.has(lastRequestToPriceFeed, key)) {
+							yield* newPriceFeedRequests.offer({
+								channel: route.channel,
+								priceFeedId,
+							});
 						}
 
-						MutableHashMap.set(lastRequestToPriceFeed, priceFeedId, now);
+						MutableHashMap.set(lastRequestToPriceFeed, key, now);
 					}
 
 					// Now since the subscriptions are in-flight, we can fetch the prices concurrently.
 					const results = yield* Effect.forEach(
 						priceFeedIds,
 						(priceFeedId) =>
-							Effect.either(priceCache.getOrWaitPrice(priceFeedId)),
+							Effect.either(
+								priceCache.getOrWaitPrice(
+									priceFeedSubscriptionKey(priceFeedId, route.channel),
+								),
+							),
 						{ concurrency: "unbounded" },
 					);
 

--- a/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
+++ b/workspace/data-proxy/src/modules/pyth-lazer/pyth-lazer.ts
@@ -145,6 +145,7 @@ export const PythLazerModuleService = (config: PythLazerModuleConfig) =>
 						token: config.pythLazerApiKey,
 						metadataServiceUrl: "https://pyth.dourolabs.app",
 						webSocketPoolConfig: {
+							numConnections: 3,
 							urls: [
 								"wss://pyth-lazer-0.dourolabs.app/v1/stream",
 								"wss://pyth-lazer-1.dourolabs.app/v1/stream",


### PR DESCRIPTION
- Support multiple channels per module instance through config refactoring.
  - A single module can now support multiple routes with different channels.
- Configures number of connections for Pyth Client at 3 to match the three URLs we use. Pyth SDK had been using its default value of 4.
- Adds module README
- Redact API key from error message from the SDK that we log