### PR TITLE
Expand comma-separated coins in Hydro request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ A **multi** route fans out to several module handlers in one request. Each entry
 - Sub-fetch failures are **non-fatal**: the failing source appears as an `{ "error": "...", "status": ... }` entry; other sources still resolve. The multi route itself returns HTTP `200`.
 - Fetch `name` values must be **unique** within a route (validated at startup).
 
-Example — Binance spot, Lighter perp ticker, and Hydromancer asset context in one call (see also `configs/config-multi-fetcher.jsonc`):
+Example — Binance spot, Lighter perp ticker, and Hydromancer asset context in one call:
 
 ```jsonc
 {

--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",

--- a/workspace/data-proxy/src/config/hydromancer-module-config.ts
+++ b/workspace/data-proxy/src/config/hydromancer-module-config.ts
@@ -106,7 +106,8 @@ const SingleAssetContextType = v.object({
 });
 const BatchAssetContextType = v.object({
 	type: AssetContextType,
-	coins: v.array(v.string()),
+	// Array of tickers, or a single comma-delimited string (e.g. "BTC,ETH").
+	coins: v.union([v.string(), v.array(v.string())]),
 });
 // Request body the module accepts. Anything else is forwarded to the upstream
 export const AssetContextRequestBodySchema = v.union([

--- a/workspace/data-proxy/src/modules/hydromancer/README.md
+++ b/workspace/data-proxy/src/modules/hydromancer/README.md
@@ -1,0 +1,163 @@
+# Hydromancer module
+
+Caches Hydromancer `activeAssetCtx` updates over WebSocket and serves `assetContext` requests from cache, falling back to a REST endpoint when data is missing or stale. Non-`assetContext` bodies are forwarded to upstream REST as-is.
+
+## Overview
+
+On startup the module:
+
+1. Connects to `wsUrl` with the API key as a `token` query parameter.
+2. Subscribes to every coin in `subscriptionCoins`.
+3. Caches inbound `activeAssetCtx` frames by coin.
+4. Idle-unsubscribes coins that have not been requested within `coinsCleanupTtl` (demand-driven subscriptions from HTTP requests are cleaned up the same way).
+
+For `assetContext` HTTP requests the handler:
+
+1. Parses a single-coin (`coin`) or batch (`coins`) body.
+2. Expands comma-separated values in `coins` (string or string array) into individual tickers (so multi-route path params like `BTC,ETH` work after template substitution). The singular `coin` field is never expanded.
+3. Subscribes to each coin over WebSocket (idempotent).
+4. Serves fresh cache entries when the socket is healthy; otherwise (or on miss) batches a REST `POST /info` for the remaining coins.
+
+Requests with more coins than `maxCoinsPerRequest` return HTTP 400.
+
+## Environment variables
+
+Set the env var named by `hydromancerApiKeyEnvKey`. Config parsing fails if it is unset; the value is treated as a secret and redacted from logs.
+
+| Variable (example) | Purpose |
+| --- | --- |
+| `HYDROMANCER_API_KEY_MAINNET` | Bearer token for WS auth and REST `Authorization` |
+
+## Configuration
+
+### Module
+
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `type` | yes | — | Must be `"hydromancer"`. |
+| `name` | yes | — | Module name referenced by routes as `moduleName`. |
+| `wsUrl` | yes | — | WebSocket URL (e.g. `wss://api.hydromancer.xyz/ws`). |
+| `restBaseUrl` | yes | — | REST base URL (e.g. `https://api.hydromancer.xyz`). |
+| `hydromancerApiKeyEnvKey` | yes | — | Env var that holds the Hydromancer API key. |
+| `subscriptionCoins` | no | `[]` | Coins to subscribe to on start. |
+| `staleAfter` | no | `"10 seconds"` | Max age of a cached ctx before REST refresh. |
+| `maxCoinsPerRequest` | no | `20` | Max coins allowed in a single `assetContext` request. |
+| `coinsCleanupTtl` | no | `"1 hour"` | Idle time before an unused subscription is cleaned up. |
+| `coinsCleanupInterval` | no | `"30 seconds"` | How often idle cleanup runs. |
+| `reconnectMaxBackoff` | no | `"30 seconds"` | Cap on WS reconnect backoff. |
+| `reconnectStableThreshold` | no | `"30 seconds"` | Connected duration before reconnect backoff resets. |
+| `restFetchTimeout` | no | `"15 seconds"` | Timeout for REST `/info` calls. |
+
+### Route
+
+Hydromancer routes do not use `fetchFromModule`. The request body is the Hydromancer `/info` payload.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `type` | yes | Must be `"hydromancer"`. |
+| `moduleName` | yes | Name of a configured Hydromancer module. |
+| `path` | yes | Proxy path (supports `{:param}` path params). |
+| `method` | no | HTTP method(s); typically `POST` for standalone routes that accept a body. |
+
+### Example
+
+```jsonc
+{
+  "modules": [
+    {
+      "type": "hydromancer",
+      "name": "hydro",
+      "wsUrl": "wss://api.hydromancer.xyz/ws",
+      "restBaseUrl": "https://api.hydromancer.xyz",
+      "hydromancerApiKeyEnvKey": "HYDROMANCER_API_KEY_MAINNET",
+      "subscriptionCoins": ["BTC", "ETH"]
+    }
+  ],
+  "routes": [
+    {
+      "type": "hydromancer",
+      "moduleName": "hydro",
+      "path": "/hydro",
+      "method": ["POST"]
+    }
+  ]
+}
+```
+
+```bash
+# Single coin — response is one AssetCtx object (or null)
+curl -s "http://127.0.0.1:5384/proxy/hydro" \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"assetContext","coin":"BTC"}' | jq .
+
+# Batch — response is a map of coin → AssetCtx | null
+curl -s "http://127.0.0.1:5384/proxy/hydro" \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"assetContext","coins":["BTC","ETH"]}' | jq .
+
+# Comma-delimited string (expanded to BTC and ETH; batch response shape)
+curl -s "http://127.0.0.1:5384/proxy/hydro" \
+  -H 'Content-Type: application/json' \
+  -d '{"type":"assetContext","coins":"BTC,ETH"}' | jq .
+```
+
+### Multi-route fetch
+
+On a `multi` route, set `body` to an `assetContext` template. Path params are substituted with `{:param}`:
+
+```jsonc
+{
+  "type": "multi",
+  "path": "/multi/:symbols/:markets/:hydroTickers",
+  "method": ["GET"],
+  "fetches": [
+    {
+      "name": "hydromancer",
+      "moduleName": "hydro",
+      "type": "hydromancer",
+      "body": "{\"type\":\"assetContext\",\"coins\":\"{:hydroTickers}\"}"
+    }
+  ]
+}
+```
+
+```bash
+# hydroTickers becomes coins:"BTC,ETH", then expanded to BTC and ETH
+curl -s "http://127.0.0.1:5384/proxy/multi/BTCUSDT,ETHUSDT/1,2/BTC,ETH" | jq .
+```
+
+## Request body
+
+| Shape | Behavior |
+| --- | --- |
+| `{"type":"assetContext","coin":"..."}` | Single-coin path. Response is one `AssetCtx` (or `null`). The value is used as-is (no comma expansion). |
+| `{"type":"assetContext","coins":["...", "..."]}` | Batch path. Response is `{ [coin]: AssetCtx \| null }`. Comma-separated entries inside the array are expanded. |
+| `{"type":"assetContext","coins":"BTC,ETH"}` | Same batch path; a comma-delimited string is expanded to individual tickers. |
+| Anything else | Forwarded unchanged to `POST {restBaseUrl}/info` with the bearer token. |
+
+## Response shape
+
+### Single (`coin`)
+
+```jsonc
+{
+  "oraclePx": "...",
+  "markPx": "...",
+  "midPx": "...",
+  "impactPxs": ["...", "..."],
+  "openInterest": "..."
+}
+```
+
+Fields may be `null`. If the coin cannot be resolved, the body is `null`.
+
+### Batch (`coins`)
+
+```jsonc
+{
+  "BTC": { "oraclePx": "...", "markPx": "...", "midPx": "...", "impactPxs": [...], "openInterest": "..." },
+  "ETH": null
+}
+```
+
+Unresolved coins stay `null`, matching Hydromancer’s native `/info` batch shape.

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
@@ -210,6 +210,72 @@ describe("HydromancerModuleService.handleRequest (REST batch path)", () => {
 		expect(body).toEqual(btcCtx);
 	});
 
+	it("expands a comma-separated coins entry in request body", async () => {
+		const fetchMock = mock(
+			async (_input: URL | RequestInfo, init?: RequestInit) => {
+				expect(JSON.parse(init?.body as string)).toEqual({
+					type: "assetContext",
+					coins: ["BTC", "ETH"],
+				});
+				return new Response(JSON.stringify({ BTC: btcCtx, ETH: ethCtx }), {
+					status: 200,
+				});
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, ["BTC,ETH"]);
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(await response.json()).toEqual({ BTC: btcCtx, ETH: ethCtx });
+	});
+
+	it("expands a comma-delimited coins string in request body", async () => {
+		const fetchMock = mock(
+			async (_input: URL | RequestInfo, init?: RequestInit) => {
+				expect(JSON.parse(init?.body as string)).toEqual({
+					type: "assetContext",
+					coins: ["BTC", "ETH"],
+				});
+				return new Response(JSON.stringify({ BTC: btcCtx, ETH: ethCtx }), {
+					status: 200,
+				});
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, [], () =>
+			JSON.stringify({ type: "assetContext", coins: "BTC,ETH" }),
+		);
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(await response.json()).toEqual({ BTC: btcCtx, ETH: ethCtx });
+	});
+
+	it("does not expand a comma-separated coin entry in request body", async () => {
+		const fetchMock = mock(
+			async (_input: URL | RequestInfo, init?: RequestInit) => {
+				// Singular `coin` is kept as one literal ticker.
+				expect(JSON.parse(init?.body as string)).toEqual({
+					type: "assetContext",
+					coins: ["BTC,ETH"],
+				});
+				// Upstream treats "BTC,ETH" as an unknown symbol.
+				return new Response(JSON.stringify({ "BTC,ETH": null }), {
+					status: 200,
+				});
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const response = await callHandle(baseConfig, ["BTC,ETH"], (coins) =>
+			JSON.stringify({ type: "assetContext", coin: coins[0] }),
+		);
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(await response.json()).toBeNull();
+	});
+
 	it("keeps null entries for coins that come back null", async () => {
 		globalThis.fetch = mock(
 			async () =>

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.ts
@@ -87,14 +87,23 @@ export const HydromancerModuleService = (config: HydromancerModuleConfig) =>
 						return yield* executeHydromancerRestRequest(config, body);
 					}
 
-					// We need to know if the request is for a single coin or a batch of coins as the response shape is different.
+					// Normalize coins (string or string[]) and expand comma-separated
+					// values (e.g. "BTC,ETH" or ["BTC,ETH"] from multi-route path params).
+					const expandCoins = (tokens: string | string[]) =>
+						(typeof tokens === "string" ? [tokens] : tokens).flatMap((token) =>
+							token
+								.split(",")
+								.map((coin) => coin.trim())
+								.filter((coin) => coin.length > 0),
+						);
+
 					const assetRequest = Match.value(parsedBody.value).pipe(
 						Match.when(
 							{ type: "assetContext", coins: Match.any },
 							(body) =>
 								({
 									type: "batch",
-									coins: body.coins,
+									coins: expandCoins(body.coins),
 								}) as const,
 						),
 						Match.when(


### PR DESCRIPTION

## Motivation

To support module route like the following
```json
{
  "type": "multi",
  "path": "/multi/:hydroTickers",
  "method": ["GET"],
  "fetches": [
    {
      "name": "hydromancer",
      "moduleName": "hydro",
      "type": "hydromancer",
      "body": "{\"type\":\"assetContext\",\"coins\":\"{:hydroTickers}\"}"
    }
  ]
}
```

we need `hydroTickers` given as a path parameter to expand into multiple tickers.

## Explanation of Changes

Expand comma-delimited `coins` values in Hydromancer assetContext bodies into individual tickers.

## Testing

Added some test cases.
