### PR TITLE
Fix: multi skipped symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,8 @@ A **multi** route fans out to several module handlers in one request. Each entry
 - **`body`** — forwarded to modules that expect a request body (for example Hydromancer `assetContext`).
 - Sub-fetch failures are **non-fatal**: the failing source appears as an `{ "error": "...", "status": ... }` entry; other sources still resolve. The multi route itself returns HTTP `200`.
 - Fetch `name` values must be **unique** within a route (validated at startup).
+- A path element of **`_`** means "no asset for this source" and is dropped before templates are filled, so `/multi/BTC,_,SOL/1,2,3/BTC,ETH,SOL` asks the first source for BTC and SOL only. Only whole elements count, so `BTC_USD` is unaffected.
+- A fetch whose param is left **entirely empty** is skipped without calling its module; its entry is `[]` for the price modules, `{}` for Hydromancer, `null` for `pm-insights` and `chainlink-streams`. `_` and `sources` compose: `sources` selects, `_` subtracts.
 
 Example — Binance spot, Lighter perp ticker, and Hydromancer asset context in one call:
 
@@ -439,6 +441,9 @@ Test locally (disable proof verification for easier debugging):
 
 ```bash
 curl -s "http://127.0.0.1:5384/proxy/multi/BTC/1/BTC" | jq .
+
+# Skip Binance for this request
+curl -s "http://127.0.0.1:5384/proxy/multi/_/1/BTC" | jq .
 ```
 
 Example response shape:

--- a/workspace/data-proxy/src/config/multi-module-config.ts
+++ b/workspace/data-proxy/src/config/multi-module-config.ts
@@ -17,6 +17,9 @@ export const MULTI_FETCH_TYPES = [
 	"lighter",
 ] as const;
 
+// Callers need a way to leave a gap; an empty path segment does not route.
+export const EMPTY_PARAM_TOKEN = "_";
+
 // A single sub-request inside a multi route. `fetchFromModule` and `body` are
 // templates filled from the inbound request path params via replaceParams; the
 // resolved value is forwarded to the target module's own handler.

--- a/workspace/data-proxy/src/config/multi-module-config.ts
+++ b/workspace/data-proxy/src/config/multi-module-config.ts
@@ -20,6 +20,21 @@ export const MULTI_FETCH_TYPES = [
 // Callers need a way to leave a gap; an empty path segment does not route.
 export const EMPTY_PARAM_TOKEN = "_";
 
+export const EMPTY_RESPONSE_BY_TYPE: Record<
+	(typeof MULTI_FETCH_TYPES)[number],
+	unknown
+> = {
+	binance: [],
+	lighter: [],
+	dxfeed: [],
+	volmex: [],
+	"pyth-lazer": [],
+	"lo-tech": [],
+	hydromancer: {},
+	"pm-insights": null,
+	"chainlink-streams": null,
+};
+
 // A single sub-request inside a multi route. `fetchFromModule` and `body` are
 // templates filled from the inbound request path params via replaceParams; the
 // resolved value is forwarded to the target module's own handler.

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
@@ -5,7 +5,7 @@ import {
 	FailedToHandleRequest,
 	type ModuleHandlers,
 } from "../../modules/module";
-import { handleMultiRequest } from "./handle-multi-request";
+import { handleMultiRequest, sanitizeParams } from "./handle-multi-request";
 
 const handlers = (
 	handleRequest: ModuleHandlers["handleRequest"],
@@ -335,5 +335,40 @@ describe("handleMultiRequest", () => {
 			const body = (await response.json()) as { error: string };
 			expect(body.error).toContain("no sources selected");
 		});
+	});
+});
+
+describe("sanitizeParams", () => {
+	it("drops whole-element placeholder tokens from a comma list", () => {
+		expect(sanitizeParams({ symbol: "BTC,_,SOL" })).toEqual({
+			symbol: "BTC,SOL",
+		});
+	});
+
+	it("empties a param that is only the placeholder", () => {
+		expect(sanitizeParams({ symbol: "_" })).toEqual({ symbol: "" });
+	});
+
+	it("leaves the placeholder alone inside a larger element", () => {
+		expect(sanitizeParams({ symbol: "BTC_USD,wstETH_1" })).toEqual({
+			symbol: "BTC_USD,wstETH_1",
+		});
+	});
+
+	it("strips surrounding whitespace before matching the token", () => {
+		expect(sanitizeParams({ symbol: "BTC, _ ,SOL" })).toEqual({
+			symbol: "BTC,SOL",
+		});
+	});
+
+	it("leaves params without the token untouched", () => {
+		expect(sanitizeParams({ market: "1,2,3", tk: "BTC" })).toEqual({
+			market: "1,2,3",
+			tk: "BTC",
+		});
+	});
+
+	it("handles an empty params map", () => {
+		expect(sanitizeParams({})).toEqual({});
 	});
 });

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
@@ -53,21 +53,16 @@ const runRaw = (
 	route: MultiModuleRoute,
 	map: Map<string, ModuleHandlers>,
 	url = "http://localhost/multi/BTC/1",
+	params: Record<string, string> = { symbol: "BTC", index: "1" },
 ) =>
-	Effect.runPromise(
-		handleMultiRequest(
-			route,
-			{ symbol: "BTC", index: "1" },
-			new Request(url),
-			map,
-		),
-	);
+	Effect.runPromise(handleMultiRequest(route, params, new Request(url), map));
 
 const run = (
 	route: MultiModuleRoute,
 	map: Map<string, ModuleHandlers>,
 	url?: string,
-) => runRaw(route, map, url).then((res) => res.json());
+	params?: Record<string, string>,
+) => runRaw(route, map, url, params).then((res) => res.json());
 
 describe("handleMultiRequest", () => {
 	it("fills each fetch template from the request params and keys results by name", async () => {
@@ -341,6 +336,148 @@ describe("handleMultiRequest", () => {
 			expect(response.status).toBe(400);
 			const body = (await response.json()) as { error: string };
 			expect(body.error).toContain("no sources selected");
+		});
+	});
+
+	describe("empty param token", () => {
+		const countingEcho = () => {
+			let calls = 0;
+			return {
+				handlers: handlers((route, _params, _request, body) => {
+					calls++;
+					return Effect.succeed(
+						new Response(
+							JSON.stringify({
+								fetchFromModule:
+									"fetchFromModule" in route
+										? route.fetchFromModule
+										: undefined,
+								body,
+							}),
+							{ status: 200 },
+						),
+					);
+				}),
+				calls: () => calls,
+			};
+		};
+
+		const binanceRoute = () =>
+			makeRoute([
+				{
+					name: "binance",
+					moduleName: "bin",
+					type: "binance",
+					fetchFromModule: "{:symbol}",
+				},
+				{
+					name: "lighter",
+					moduleName: "lig",
+					type: "lighter",
+					fetchFromModule: "{:index}",
+				},
+			]);
+
+		it("drops placeholder elements and forwards the remaining assets", async () => {
+			const map = new Map<string, ModuleHandlers>([
+				["bin", echoHandlers],
+				["lig", echoHandlers],
+			]);
+
+			const body = await run(binanceRoute(), map, undefined, {
+				symbol: "BTC,_,SOL",
+				index: "1,2,3",
+			});
+
+			expect(body).toEqual({
+				binance: { fetchFromModule: "BTC,SOL" },
+				lighter: { fetchFromModule: "1,2,3" },
+			});
+		});
+
+		it("skips a fetch whose only param is the placeholder without calling the module", async () => {
+			const bin = countingEcho();
+			const lig = countingEcho();
+			const map = new Map<string, ModuleHandlers>([
+				["bin", bin.handlers],
+				["lig", lig.handlers],
+			]);
+
+			const body = (await run(binanceRoute(), map, undefined, {
+				symbol: "_",
+				index: "1",
+			})) as Record<string, unknown>;
+
+			expect(body.binance).toEqual([]);
+			expect(bin.calls()).toBe(0);
+			expect(lig.calls()).toBe(1);
+		});
+
+		it("leaves an underscore inside a symbol untouched", async () => {
+			const map = new Map<string, ModuleHandlers>([
+				["bin", echoHandlers],
+				["lig", echoHandlers],
+			]);
+
+			const body = (await run(binanceRoute(), map, undefined, {
+				symbol: "BTC_USD",
+				index: "1",
+			})) as Record<string, unknown>;
+
+			expect(body.binance).toEqual({ fetchFromModule: "BTC_USD" });
+		});
+
+		it("skips a body-template fetch and returns the hydromancer empty shape", async () => {
+			const hydro = countingEcho();
+			const route = makeRoute([
+				{
+					name: "hydro",
+					moduleName: "hydro",
+					type: "hydromancer",
+					body: '{"type":"assetContext","coins":["{:symbol}"]}',
+				},
+			]);
+			const map = new Map<string, ModuleHandlers>([["hydro", hydro.handlers]]);
+
+			const body = (await run(route, map, undefined, {
+				symbol: "_",
+				index: "1",
+			})) as Record<string, unknown>;
+
+			expect(body.hydro).toEqual({});
+			expect(hydro.calls()).toBe(0);
+		});
+
+		it("intersects with the sources query param", async () => {
+			const map = new Map<string, ModuleHandlers>([
+				["bin", echoHandlers],
+				["lig", echoHandlers],
+			]);
+
+			const body = (await run(
+				binanceRoute(),
+				map,
+				"http://localhost/multi/_/1?sources=binance,lighter",
+				{ symbol: "_", index: "1" },
+			)) as Record<string, unknown>;
+
+			expect(body.binance).toEqual([]);
+			expect(body.lighter).toEqual({ fetchFromModule: "1" });
+		});
+
+		it("returns 200 with every value empty when all params are the placeholder", async () => {
+			const map = new Map<string, ModuleHandlers>([
+				["bin", echoHandlers],
+				["lig", echoHandlers],
+			]);
+
+			const response = await runRaw(binanceRoute(), map, undefined, {
+				symbol: "_",
+				index: "_",
+			});
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ binance: [], lighter: [] });
 		});
 	});
 });

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "bun:test";
 import { Effect } from "effect";
-import type { MultiModuleRoute } from "../../config/multi-module-config";
+import type {
+	MultiFetch,
+	MultiModuleRoute,
+} from "../../config/multi-module-config";
 import {
 	FailedToHandleRequest,
 	type ModuleHandlers,
 } from "../../modules/module";
-import { handleMultiRequest, sanitizeParams } from "./handle-multi-request";
+import {
+	emptyParamsFor,
+	handleMultiRequest,
+	sanitizeParams,
+} from "./handle-multi-request";
 
 const handlers = (
 	handleRequest: ModuleHandlers["handleRequest"],
@@ -370,5 +377,61 @@ describe("sanitizeParams", () => {
 
 	it("handles an empty params map", () => {
 		expect(sanitizeParams({})).toEqual({});
+	});
+});
+
+const fetchOf = (overrides: Partial<MultiFetch>): MultiFetch => ({
+	name: "f",
+	moduleName: "m",
+	type: "binance",
+	...overrides,
+});
+
+describe("emptyParamsFor", () => {
+	it("reports a referenced param that sanitized to empty", () => {
+		const fetch = fetchOf({ fetchFromModule: "{:symbol}" });
+		expect(emptyParamsFor(fetch, { symbol: "", market: "1" })).toEqual([
+			"symbol",
+		]);
+	});
+
+	it("ignores an empty param the fetch does not reference", () => {
+		const fetch = fetchOf({ fetchFromModule: "{:market}" });
+		expect(emptyParamsFor(fetch, { symbol: "", market: "1" })).toEqual([]);
+	});
+
+	it("reports an empty param referenced from a body template", () => {
+		const fetch = fetchOf({
+			type: "hydromancer",
+			body: '{"type":"assetContext","coins":["{:tk}"]}',
+		});
+		expect(emptyParamsFor(fetch, { tk: "" })).toEqual(["tk"]);
+	});
+
+	it("reports every empty referenced param when a fetch uses several", () => {
+		const fetch = fetchOf({ fetchFromModule: "{:symbol}-{:market}" });
+		expect(emptyParamsFor(fetch, { symbol: "", market: "" }).sort()).toEqual([
+			"market",
+			"symbol",
+		]);
+	});
+
+	it("returns nothing when every referenced param has a value", () => {
+		const fetch = fetchOf({ fetchFromModule: "{:symbol}" });
+		expect(emptyParamsFor(fetch, { symbol: "BTC,SOL" })).toEqual([]);
+	});
+
+	it("recognizes both wildcard reference forms", () => {
+		expect(
+			emptyParamsFor(fetchOf({ fetchFromModule: "{*}" }), { "*": "" }),
+		).toEqual(["*"]);
+		expect(
+			emptyParamsFor(fetchOf({ fetchFromModule: "{:*}" }), { "*": "" }),
+		).toEqual(["*"]);
+	});
+
+	it("does not match a reference split across fetchFromModule and body", () => {
+		const fetch = fetchOf({ fetchFromModule: "{:sym", body: "bol}" });
+		expect(emptyParamsFor(fetch, { symbol: "" })).toEqual([]);
 	});
 });

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
@@ -1,9 +1,30 @@
 import { Effect, Either } from "effect";
 import type { Route } from "../../config/config-parser";
-import type { MultiModuleRoute } from "../../config/multi-module-config";
+import {
+	EMPTY_PARAM_TOKEN,
+	type MultiModuleRoute,
+} from "../../config/multi-module-config";
 import { PYTH_LAZER_DEFAULT_CHANNEL } from "../../config/pyth-lazer-module-config";
 import type { ModuleHandlers } from "../../modules/module";
 import { replaceParams } from "../../utils/replace-params";
+
+// Stripping at param level covers fetchFromModule and body alike, without
+// having to parse either format.
+export const sanitizeParams = (
+	params: Record<string, string>,
+): Record<string, string> => {
+	const sanitized: Record<string, string> = {};
+
+	for (const [key, value] of Object.entries(params)) {
+		sanitized[key] = value
+			.split(",")
+			.map((element) => element.trim())
+			.filter((element) => element !== EMPTY_PARAM_TOKEN)
+			.join(",");
+	}
+
+	return sanitized;
+};
 
 // Fans a multi route out to its configured sub-fetches concurrently, forwarding
 // each to its target module's own handler and collecting the raw responses

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
@@ -2,6 +2,7 @@ import { Effect, Either } from "effect";
 import type { Route } from "../../config/config-parser";
 import {
 	EMPTY_PARAM_TOKEN,
+	type MultiFetch,
 	type MultiModuleRoute,
 } from "../../config/multi-module-config";
 import { PYTH_LAZER_DEFAULT_CHANNEL } from "../../config/pyth-lazer-module-config";
@@ -24,6 +25,35 @@ export const sanitizeParams = (
 	}
 
 	return sanitized;
+};
+
+// Scans the raw templates: after substitution an intentionally-emptied param
+// is indistinguishable from one that was never referenced.
+export const emptyParamsFor = (
+	fetch: MultiFetch,
+	sanitized: Record<string, string>,
+): string[] => {
+	const templates = [fetch.fetchFromModule ?? "", fetch.body ?? ""];
+	const empty: string[] = [];
+
+	for (const [key, value] of Object.entries(sanitized)) {
+		if (value.length > 0) {
+			continue;
+		}
+
+		// Mirrors replaceParams, which substitutes both forms for the wildcard.
+		const references = key === "*" ? ["{*}", "{:*}"] : [`{:${key}}`];
+
+		if (
+			templates.some((template) =>
+				references.some((reference) => template.includes(reference)),
+			)
+		) {
+			empty.push(key);
+		}
+	}
+
+	return empty;
 };
 
 // Fans a multi route out to its configured sub-fetches concurrently, forwarding

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
@@ -2,6 +2,7 @@ import { Effect, Either } from "effect";
 import type { Route } from "../../config/config-parser";
 import {
 	EMPTY_PARAM_TOKEN,
+	EMPTY_RESPONSE_BY_TYPE,
 	type MultiFetch,
 	type MultiModuleRoute,
 } from "../../config/multi-module-config";
@@ -67,6 +68,9 @@ export const emptyParamsFor = (
 // pay for the rest (an unlisted symbol otherwise blocks on the price-wait
 // timeout). The param is part of the signed request URL, so selection needs no
 // signing changes. Without the param every configured fetch runs.
+//
+// A `_` path element means "no asset for this source": it is stripped before
+// templates are filled, and a fetch whose param it empties is skipped.
 export const handleMultiRequest = (
 	route: MultiModuleRoute,
 	params: Record<string, string>,
@@ -106,10 +110,18 @@ export const handleMultiRequest = (
 			);
 		}
 
+		const sanitizedParams = sanitizeParams(params);
+
 		const entries = yield* Effect.forEach(
 			selectedFetches,
 			(fetch) =>
 				Effect.gen(function* () {
+					// The price modules would otherwise block on the full
+					// price-wait timeout for a symbol nobody asked for.
+					if (emptyParamsFor(fetch, sanitizedParams).length > 0) {
+						return [fetch.name, EMPTY_RESPONSE_BY_TYPE[fetch.type]] as const;
+					}
+
 					const handlers = moduleHandlers.get(fetch.moduleName);
 					if (!handlers) {
 						return [
@@ -119,10 +131,10 @@ export const handleMultiRequest = (
 					}
 
 					const fetchFromModule = fetch.fetchFromModule
-						? replaceParams(fetch.fetchFromModule, params)
+						? replaceParams(fetch.fetchFromModule, sanitizedParams)
 						: "";
 					const body = fetch.body
-						? replaceParams(fetch.body, params)
+						? replaceParams(fetch.body, sanitizedParams)
 						: undefined;
 
 					const syntheticRoute = {
@@ -143,7 +155,12 @@ export const handleMultiRequest = (
 					} as Route;
 
 					const result = yield* Effect.either(
-						handlers.handleRequest(syntheticRoute, params, request, body),
+						handlers.handleRequest(
+							syntheticRoute,
+							sanitizedParams,
+							request,
+							body,
+						),
 					);
 
 					if (Either.isLeft(result)) {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

So the issue is:

If we didn't need any assets from a source, the request would fail. This could happen in two scenarios:
1. It was the only asset in a group that did not have a source
2. All the assets in a group missed a source

Unlikely, but as seen on staging, it could happen. So IMO better to have then to cause a blip/production issue.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Allows `_` to be sent in place of a skipped asset. As a consequence, this works on `csv` style as well, but the OP only sends a singular `/_/` if the entire group has no assets for that source.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

New tests added.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
