### PR TITLE
Volmex REST endpoint support

### DIFF
--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -527,6 +527,50 @@ describe("parseConfig", () => {
 			process.env.VOLMEX_API_KEY = undefined;
 		});
 
+		it("should accept a volmex REST route with upstreamPath", () => {
+			process.env.VOLMEX_API_KEY = "volmex-api-key";
+
+			const [result] = Effect.runSync(
+				parseConfig({
+					routes: [
+						{
+							type: "volmex",
+							moduleName: "volmex",
+							source: "rest",
+							path: "/history",
+							upstreamPath: "/public/history",
+						},
+					],
+					modules: [
+						{
+							type: "volmex",
+							name: "volmex",
+							volmexApiKeyEnvKey: "VOLMEX_API_KEY",
+							wsBaseUrl: "wss://ws.volmex.finance",
+							restBaseUrl: "https://www.volmex.finance",
+						},
+					],
+				}),
+			);
+
+			assertIsOkResult(result);
+			const route = result.value.config.routes[0];
+			expect(route.type).toBe("volmex");
+			if (route.type === "volmex") {
+				expect(route.source).toBe("rest");
+				if (route.source === "rest") {
+					expect(route.upstreamPath).toBe("/public/history");
+				}
+			}
+			const module = result.value.config.modules[0];
+			if (module.type !== "volmex") {
+				throw new Error(`expected volmex, got ${module.type}`);
+			}
+			expect(module.wsBaseUrl).toBe("wss://ws.volmex.finance");
+			expect(module.restBaseUrl).toBe("https://www.volmex.finance");
+			process.env.VOLMEX_API_KEY = undefined;
+		});
+
 		it("should reject a pm-insights module when the email env var is unset", () => {
 			process.env.PM_INSIGHTS_EMAIL = undefined;
 			process.env.PM_INSIGHTS_PASSWORD = "pw";

--- a/workspace/data-proxy/src/config/volmex-module-config.ts
+++ b/workspace/data-proxy/src/config/volmex-module-config.ts
@@ -1,13 +1,26 @@
-import { Effect, type Redacted } from "effect";
+import { Duration, Effect, Option, type Redacted } from "effect";
 import * as v from "valibot";
 import { RouteSchema } from "./route-config";
 
 export const VolmexModuleConfigSchema = v.strictObject({
 	name: v.string(),
-	baseUrl: v.optional(v.string(), "wss://ws-8jh89.volmex.finance"),
+	wsBaseUrl: v.optional(v.string(), "wss://ws-8jh89.volmex.finance"),
+	restBaseUrl: v.optional(
+		v.string(),
+		"https://private-multiregion-8jh89.volmex.finance",
+	),
 	maxSymbolsPerRequest: v.optional(v.number(), 100),
 	volmexApiKeyEnvKey: v.string(),
 	reconnectDelayMs: v.optional(v.number(), 1000),
+	restFetchTimeout: v.pipe(
+		v.optional(v.union([v.number(), v.string()]), "15 seconds"),
+		v.transform((value) =>
+			Option.getOrThrowWith(
+				Duration.decodeUnknown(value),
+				() => new Error("Invalid restFetchTimeout duration"),
+			),
+		),
+	),
 	type: v.literal("volmex"),
 });
 
@@ -16,12 +29,27 @@ export interface VolmexModuleConfig
 	volmexApiKey: Redacted.Redacted<string>;
 }
 
-export const VolmexModuleRouteSchema = v.strictObject({
+const VolmexWsModuleRouteSchema = v.strictObject({
 	...RouteSchema.entries,
 	moduleName: v.string(),
-	fetchFromModule: v.string(),
 	type: v.literal("volmex"),
+	source: v.literal("ws"),
+	fetchFromModule: v.string(),
 });
+
+const VolmexRestModuleRouteSchema = v.strictObject({
+	...RouteSchema.entries,
+	moduleName: v.string(),
+	type: v.literal("volmex"),
+	source: v.literal("rest"),
+	upstreamPath: v.string(),
+});
+
+// REST first so `source: "rest"` does not fall through to the WS schema.
+export const VolmexModuleRouteSchema = v.variant("source", [
+	VolmexRestModuleRouteSchema,
+	VolmexWsModuleRouteSchema,
+]);
 
 export type VolmexModuleRoute = v.InferOutput<typeof VolmexModuleRouteSchema>;
 

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-request.ts
@@ -152,6 +152,8 @@ export const handleMultiRequest = (
 									channel: fetch.channel ?? PYTH_LAZER_DEFAULT_CHANNEL,
 								}
 							: {}),
+						// Volmex multi fetches only target the WS/cache path today.
+						...(fetch.type === "volmex" ? { source: "ws" as const } : {}),
 					} as Route;
 
 					const result = yield* Effect.either(

--- a/workspace/data-proxy/src/modules/volmex/README.md
+++ b/workspace/data-proxy/src/modules/volmex/README.md
@@ -1,6 +1,6 @@
 # Volmex module
 
-Streams Volmex volatility index prices over a Socket.IO WebSocket and serves the latest cached value for requested symbols.
+Streams Volmex volatility index prices over a Socket.IO WebSocket and serves the latest cached value for requested symbols. Routes can also proxy authenticated REST requests.
 
 ## Overview
 
@@ -12,7 +12,10 @@ On startup the module:
 4. Caches every `indices-messages-stream-private` message by `symbol`.
 5. Relies on Socket.IO client reconnection (`reconnection: true`, delay from `reconnectDelayMs`).
 
-HTTP requests resolve symbols from the route’s `fetchFromModule` template (comma-separated) and return the latest cached price for each symbol. If a price is not yet available, the handler waits briefly for an update (shared price-cache timeout: 3 seconds).
+HTTP requests are handled based on the route `source`:
+
+- **`ws`** — resolve symbols from `fetchFromModule` and return the latest cached price for each. If a price is not yet available, the handler waits briefly (shared price-cache timeout: 3 seconds).
+- **`rest`** — proxy the inbound request to `restBaseUrl` + `upstreamPath` with the module JWT as `Authorization: Bearer …`, forwarding allowed query params.
 
 Unlike subscription-based modules, Volmex keeps the latest price for **all** symbols on the stream. The stream is small (on the order of tens of indices / ~50 messages per second), so filtering/idle cleanup is not used.
 
@@ -25,12 +28,13 @@ Unlike subscription-based modules, Volmex keeps the latest price for **all** sym
 | `type` | yes | — | Must be `"volmex"`. |
 | `name` | yes | — | Module name referenced by routes as `moduleName`. |
 | `volmexApiKeyEnvKey` | yes | — | Env var that holds the Volmex JWT. |
-| `baseUrl` | no | `wss://ws-8jh89.volmex.finance` | WebSocket base URL (no trailing slash required). |
-| `maxSymbolsPerRequest` | no | `100` | Max symbols allowed in a single request. |
+| `wsBaseUrl` | no | `wss://ws-8jh89.volmex.finance` | WebSocket base URL (no trailing slash required). |
+| `restBaseUrl` | no | `https://private-multiregion-8jh89.volmex.finance` | REST API base URL for `source: "rest"` routes. |
+| `maxSymbolsPerRequest` | no | `100` | Max symbols allowed in a single WS request. |
 | `reconnectDelayMs` | no | `1000` | Passed to Socket.IO as `reconnectionDelay` (ms between reconnect attempts). |
+| `restFetchTimeout` | no | `15 seconds` | Timeout for REST proxy fetches (`number` ms or duration string). |
 
-
-### Route
+### Route (WebSocket)
 
 | Field | Required | Description |
 | --- | --- | --- |
@@ -38,7 +42,20 @@ Unlike subscription-based modules, Volmex keeps the latest price for **all** sym
 | `moduleName` | yes | Name of a configured Volmex module. |
 | `path` | yes | Proxy path (supports `{:param}` path params). |
 | `method` | no | HTTP method(s); default is `GET`. |
+| `source` | yes | Must be `"ws"` for live cache lookups. |
 | `fetchFromModule` | yes | Template producing one or more comma-separated index symbols. |
+
+### Route (REST proxy)
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `type` | yes | Must be `"volmex"`. |
+| `moduleName` | yes | Name of a configured Volmex module. |
+| `path` | yes | Proxy path (supports path params). |
+| `method` | no | HTTP method(s); default is `GET`. |
+| `source` | yes | Must be `"rest"`. |
+| `upstreamPath` | yes | Upstream path relative to module `restBaseUrl`. Supports `{:param}` templates. |
+| `allowedQueryParams` | no | When set, only these inbound query keys are forwarded upstream. |
 
 ### Example
 
@@ -48,7 +65,8 @@ Unlike subscription-based modules, Volmex keeps the latest price for **all** sym
     {
       "type": "volmex",
       "name": "volmex",
-      "baseUrl": "wss://ws-8jh89.volmex.finance",
+      "wsBaseUrl": "wss://ws-8jh89.volmex.finance",
+      "restBaseUrl": "https://private-multiregion-8jh89.volmex.finance",
       "volmexApiKeyEnvKey": "VOLMEX_API_KEY"
     }
   ],
@@ -56,23 +74,43 @@ Unlike subscription-based modules, Volmex keeps the latest price for **all** sym
     {
       "type": "volmex",
       "moduleName": "volmex",
+      "source": "ws",
       "path": "/:priceSymbol",
       "method": "GET",
       "fetchFromModule": "{:priceSymbol}"
+    },
+    {
+      "type": "volmex",
+      "moduleName": "volmex",
+      "source": "rest",
+      "path": "/history",
+      "method": "GET",
+      "upstreamPath": "/public/history",
+      "allowedQueryParams": ["symbol", "resolution", "from", "to"]
     }
   ]
 }
 ```
 
 ```bash
-# Single symbol
-curl -s "http://127.0.0.1:5384/proxy/BVIV" | jq .
+# Single symbol (WS cache)
+curl -X GET "http://127.0.0.1:5384/proxy/BVIV" | jq .
 
 # Multiple symbols (comma-separated)
-curl -s "http://127.0.0.1:5384/proxy/BVIV,EVIV,SVIV" | jq .
+curl -X GET "http://127.0.0.1:5384/proxy/BVIV,EVIV,SVIV" | jq .
+
+# Historical bars (REST proxy)
+# Use -G so --data-urlencode becomes query params (GET body is ignored by the proxy)
+curl -sG "http://127.0.0.1:5384/proxy/history" \
+  --data-urlencode "symbol=BVIV" \
+  --data-urlencode "resolution=D" \
+  --data-urlencode "from=1700000000" \
+  --data-urlencode "to=1701000000" | jq .
 ```
 
 ## Response shape
+
+### WebSocket routes
 
 Successful responses are a JSON array. Each item is either a priced update or a miss:
 
@@ -99,6 +137,10 @@ Successful responses are a JSON array. Each item is either a priced update or a 
 | `__sedaHasPrice` | always | `true` when a cached price was returned; `false` on wait timeout / miss. |
 
 Requests with more symbols than `maxSymbolsPerRequest` return HTTP 400.
+
+### REST routes
+
+The upstream status, body, and content type are returned as-is (true proxy). Timeouts map to HTTP 504; transport failures to HTTP 502.
 
 ## Notes
 

--- a/workspace/data-proxy/src/modules/volmex/errors.ts
+++ b/workspace/data-proxy/src/modules/volmex/errors.ts
@@ -4,7 +4,7 @@ export class FailedToHandleVolmexRequestError extends Data.TaggedError(
 	"FailedToHandleVolmexRequestError",
 )<{
 	error: string | unknown;
+	status: number;
 }> {
 	message = `Failed to handle Volmex request: ${this.error}`;
-	status = 400;
 }

--- a/workspace/data-proxy/src/modules/volmex/rest-client.ts
+++ b/workspace/data-proxy/src/modules/volmex/rest-client.ts
@@ -1,0 +1,115 @@
+import { Duration, Effect, Redacted } from "effect";
+import type { VolmexModuleConfig } from "../../config/volmex-module-config";
+import { replaceParams } from "../../utils/replace-params";
+import { createUrlSearchParams } from "../../utils/search-params";
+import { injectSearchParamsInUrl } from "../../utils/url";
+import { FailedToHandleVolmexRequestError } from "./errors";
+
+export type VolmexRestProxyDeps = {
+	config: Pick<
+		VolmexModuleConfig,
+		"volmexApiKey" | "restFetchTimeout" | "restBaseUrl"
+	>;
+	/** Upstream path relative to `config.restBaseUrl`. Supports `{:param}` templates. */
+	upstreamPathTemplate: string;
+	params: Record<string, string>;
+	request: Request;
+	allowedQueryParams?: string[];
+};
+
+const joinRestBaseUrl = (baseUrl: string, path: string): string => {
+	const base = baseUrl.replace(/\/$/, "");
+	const normalizedPath = path.replace(/^\//, "");
+	return `${base}/${normalizedPath}`;
+};
+
+/**
+ * Proxies a GET (or inbound method) to a Volmex REST API URL, attaching the module JWT.
+ * Forwards allowed query params from the inbound request onto the upstream URL.
+ * `upstreamPathTemplate` comes from the route's `upstreamPath` (supports `{:param}`).
+ */
+export const proxyVolmexRestRequest = (
+	deps: VolmexRestProxyDeps,
+): Effect.Effect<Response, FailedToHandleVolmexRequestError> =>
+	Effect.gen(function* () {
+		const {
+			config,
+			upstreamPathTemplate,
+			params,
+			request,
+			allowedQueryParams,
+		} = deps;
+		const timeoutMs = Duration.toMillis(config.restFetchTimeout);
+
+		const pathWithParams = replaceParams(upstreamPathTemplate, params);
+		const urlWithParams = joinRestBaseUrl(config.restBaseUrl, pathWithParams);
+		const requestSearchParams = createUrlSearchParams(
+			new URL(request.url).searchParams,
+			allowedQueryParams,
+		);
+
+		const upstreamUrl = yield* injectSearchParamsInUrl(
+			urlWithParams,
+			requestSearchParams,
+		).pipe(
+			Effect.mapError(
+				(error) =>
+					new FailedToHandleVolmexRequestError({
+						error: `Invalid Volmex upstream URL: ${error.message}`,
+						status: 400,
+					}),
+			),
+		);
+
+		yield* Effect.logDebug("Making Volmex REST request", {
+			url: upstreamUrl.toString(),
+			method: request.method,
+		});
+
+		const response = yield* Effect.tryPromise({
+			try: () =>
+				fetch(upstreamUrl, {
+					method: request.method,
+					headers: {
+						Authorization: `Bearer ${Redacted.value(config.volmexApiKey)}`,
+						Accept: "application/json",
+					},
+					signal: AbortSignal.timeout(timeoutMs),
+				}),
+			catch: (error) => {
+				const isTimeout =
+					error instanceof Error && error.name === "TimeoutError";
+				return new FailedToHandleVolmexRequestError({
+					error: isTimeout
+						? `Volmex REST timed out after ${timeoutMs}ms`
+						: `Failed to fetch from Volmex REST: ${error}`,
+					status: isTimeout ? 504 : 502,
+				});
+			},
+		});
+
+		const responseBody = yield* Effect.tryPromise({
+			try: () => response.text(),
+			catch: (error) =>
+				new FailedToHandleVolmexRequestError({
+					error: `Failed to read Volmex REST response: ${error}`,
+					status: 500,
+				}),
+		});
+
+		if (!response.ok) {
+			yield* Effect.logError("Volmex REST request failed", {
+				status: response.status,
+				body: responseBody,
+				url: upstreamUrl.toString(),
+			});
+		}
+
+		const upstreamContentType =
+			response.headers.get("content-type") ?? "application/json";
+
+		return new Response(responseBody, {
+			status: response.status,
+			headers: { "Content-Type": upstreamContentType },
+		});
+	}).pipe(Effect.withSpan("proxyVolmexRestRequest"));

--- a/workspace/data-proxy/src/modules/volmex/volmex.test.ts
+++ b/workspace/data-proxy/src/modules/volmex/volmex.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { Effect, LogLevel, Logger, Redacted } from "effect";
+import { Duration, Effect, LogLevel, Logger, Redacted } from "effect";
 import * as v from "valibot";
 import {
 	type VolmexModuleConfig,
@@ -79,10 +79,12 @@ const evivPrice = {
 const baseConfig: VolmexModuleConfig = {
 	name: "volmex",
 	type: "volmex",
-	baseUrl: "wss://volmex.test",
+	wsBaseUrl: "wss://volmex.test",
+	restBaseUrl: "https://rest.volmex.test",
 	maxSymbolsPerRequest: 100,
 	volmexApiKeyEnvKey: "VOLMEX_API_KEY",
 	reconnectDelayMs: 60_000,
+	restFetchTimeout: Duration.seconds(15),
 	volmexApiKey: Redacted.make("test.jwt.token"),
 };
 
@@ -90,9 +92,21 @@ const buildRoute = () =>
 	v.parse(VolmexModuleRouteSchema, {
 		type: "volmex",
 		moduleName: "volmex",
+		source: "ws",
 		path: "/price/:symbols",
 		fetchFromModule: "{:symbols}",
 		method: ["GET"],
+	});
+
+const buildRestRoute = (overrides: Record<string, unknown> = {}) =>
+	v.parse(VolmexModuleRouteSchema, {
+		type: "volmex",
+		moduleName: "volmex",
+		source: "rest",
+		path: "/history",
+		upstreamPath: "/v2/history",
+		method: ["GET"],
+		...overrides,
 	});
 
 const dummyRequest = new Request("http://proxy.local/price/x", {
@@ -127,6 +141,8 @@ const completeHandshake = async (socket: FakeSocket) => {
 const quiet = <A, E>(effect: Effect.Effect<A, E>) =>
 	effect.pipe(Logger.withMinimumLogLevel(LogLevel.None));
 
+const originalFetch = globalThis.fetch;
+
 beforeEach(() => {
 	FakeSocket.instances = [];
 });
@@ -135,6 +151,7 @@ afterEach(() => {
 	for (const socket of FakeSocket.instances) {
 		socket.close();
 	}
+	globalThis.fetch = originalFetch;
 });
 
 describe("VolmexModuleService.handleRequest", () => {
@@ -219,5 +236,139 @@ describe("VolmexModuleService.handleRequest", () => {
 
 		const response = await Effect.runPromise(program);
 		expect(response.status).toBe(400);
+	});
+});
+
+describe("VolmexModuleService.handleRequest (REST)", () => {
+	it("proxies to restBaseUrl + upstreamPath with JWT and forwards query params", async () => {
+		const route = buildRestRoute({
+			allowedQueryParams: ["symbol", "resolution", "from", "to"],
+		});
+		const request = new Request(
+			"http://proxy.local/history?symbol=BVIV&resolution=D&from=1&to=2&ignored=x",
+			{ method: "GET" },
+		);
+
+		const fetchMock = mock(
+			async (input: URL | RequestInfo, init?: RequestInit) => {
+				const url =
+					input instanceof URL
+						? input
+						: new URL(typeof input === "string" ? input : input.url);
+				expect(url.origin + url.pathname).toBe(
+					"https://rest.volmex.test/v2/history",
+				);
+				expect(url.searchParams.get("symbol")).toBe("BVIV");
+				expect(url.searchParams.get("resolution")).toBe("D");
+				expect(url.searchParams.get("from")).toBe("1");
+				expect(url.searchParams.get("to")).toBe("2");
+				expect(url.searchParams.has("ignored")).toBe(false);
+				expect(init?.method).toBe("GET");
+				expect((init?.headers as Record<string, string>).Authorization).toBe(
+					"Bearer test.jwt.token",
+				);
+				return new Response(JSON.stringify({ s: "ok", t: [1], c: [42] }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			return yield* svc.handleRequest(route, {}, request);
+		}).pipe(Effect.provide(VolmexModuleService(baseConfig)), quiet);
+
+		const response = await Effect.runPromise(program);
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(await response.json()).toEqual({ s: "ok", t: [1], c: [42] });
+	});
+
+	it("substitutes path params in upstreamPath", async () => {
+		const route = buildRestRoute({
+			path: "/history/:symbol",
+			upstreamPath: "/v2/history/{:symbol}",
+		});
+		const request = new Request("http://proxy.local/history/BVIV", {
+			method: "GET",
+		});
+
+		const fetchMock = mock(async (input: URL | RequestInfo) => {
+			const url =
+				input instanceof URL
+					? input.toString()
+					: typeof input === "string"
+						? input
+						: input.url;
+			expect(url).toBe("https://rest.volmex.test/v2/history/BVIV");
+			return new Response("{}", { status: 200 });
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			return yield* svc.handleRequest(route, { symbol: "BVIV" }, request);
+		}).pipe(Effect.provide(VolmexModuleService(baseConfig)), quiet);
+
+		const response = await Effect.runPromise(program);
+		expect(response.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("passes through upstream 4xx status", async () => {
+		const route = buildRestRoute();
+		const fetchMock = mock(
+			async () => new Response("bad symbol", { status: 400 }),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			return yield* svc.handleRequest(
+				route,
+				{},
+				new Request("http://proxy.local/history", { method: "GET" }),
+			);
+		}).pipe(Effect.provide(VolmexModuleService(baseConfig)), quiet);
+
+		const response = await Effect.runPromise(program);
+		expect(response.status).toBe(400);
+		expect(await response.text()).toBe("bad symbol");
+	});
+
+	it("returns 504 when the upstream fetch times out", async () => {
+		const route = buildRestRoute();
+		const fetchMock = mock(
+			async (_input: URL | RequestInfo, init?: RequestInit) => {
+				const signal = init?.signal;
+				return await new Promise<Response>((_resolve, reject) => {
+					signal?.addEventListener("abort", () => {
+						const error = new Error("aborted");
+						error.name = "TimeoutError";
+						reject(error);
+					});
+				});
+			},
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const config: VolmexModuleConfig = {
+			...baseConfig,
+			restFetchTimeout: Duration.millis(20),
+		};
+
+		const program = Effect.gen(function* () {
+			const svc = yield* ModuleService;
+			return yield* svc.handleRequest(
+				route,
+				{},
+				new Request("http://proxy.local/history", { method: "GET" }),
+			);
+		}).pipe(Effect.provide(VolmexModuleService(config)), quiet);
+
+		const response = await Effect.runPromise(program);
+		expect(response.status).toBe(504);
 	});
 });

--- a/workspace/data-proxy/src/modules/volmex/volmex.ts
+++ b/workspace/data-proxy/src/modules/volmex/volmex.ts
@@ -7,6 +7,7 @@ import { replaceParams } from "../../utils/replace-params";
 import { FailedToHandleRequest, ModuleService } from "../module";
 import { createPriceCache } from "../shared/price-cache";
 import { FailedToHandleVolmexRequestError } from "./errors";
+import { proxyVolmexRestRequest } from "./rest-client";
 import type { VolmexDataPrice, VolmexResponse } from "./schema";
 import { makeVolmexWebSocketService } from "./ws-client";
 
@@ -40,7 +41,7 @@ export const VolmexModuleService = (config: VolmexModuleConfig) =>
 			const handleRequest = (
 				route: Route,
 				params: Record<string, string>,
-				_request: Request,
+				request: Request,
 			) =>
 				Effect.gen(function* () {
 					if (route.type !== "volmex") {
@@ -51,7 +52,20 @@ export const VolmexModuleService = (config: VolmexModuleConfig) =>
 						);
 					}
 
-					yield* Effect.logDebug("Handling Volmex request", { route, params });
+					if (route.source === "rest") {
+						return yield* proxyVolmexRestRequest({
+							config,
+							upstreamPathTemplate: route.upstreamPath,
+							params,
+							request,
+							allowedQueryParams: route.allowedQueryParams,
+						});
+					}
+
+					yield* Effect.logDebug("Handling Volmex WS request", {
+						route,
+						params,
+					});
 
 					const symbols = replaceParams(route.fetchFromModule, params)
 						.split(",")
@@ -63,6 +77,7 @@ export const VolmexModuleService = (config: VolmexModuleConfig) =>
 							createErrorResponse(
 								new FailedToHandleVolmexRequestError({
 									error: `Too many symbols requested, max is ${config.maxSymbolsPerRequest} but got ${symbols.length}`,
+									status: 400,
 								}),
 								400,
 							),
@@ -99,7 +114,9 @@ export const VolmexModuleService = (config: VolmexModuleConfig) =>
 				}).pipe(
 					Effect.withSpan("handleVolmexRequest"),
 					Effect.catchAll((error) => {
-						return Effect.succeed(createErrorResponse(error, error.status));
+						const status =
+							typeof error.status === "number" ? error.status : 500;
+						return Effect.succeed(createErrorResponse(error, status));
 					}),
 				);
 

--- a/workspace/data-proxy/src/modules/volmex/ws-client.ts
+++ b/workspace/data-proxy/src/modules/volmex/ws-client.ts
@@ -10,7 +10,7 @@ const INDICES_STREAM_EVENT = "indices-messages-stream-private";
 export type VolmexWebSocketServiceDeps = {
 	config: Pick<
 		VolmexModuleConfig,
-		"baseUrl" | "volmexApiKey" | "reconnectDelayMs"
+		"wsBaseUrl" | "volmexApiKey" | "reconnectDelayMs"
 	>;
 	runtime: Runtime.Runtime<never>;
 	onPrice: (price: VolmexDataPrice) => Effect.Effect<void>;
@@ -32,7 +32,7 @@ export const makeVolmexWebSocketService = (
 			const socket = yield* Effect.acquireRelease(
 				Effect.try({
 					try: () =>
-						io(config.baseUrl.replace(/\/$/, ""), {
+						io(config.wsBaseUrl.replace(/\/$/, ""), {
 							path: "/socket.io",
 							transports: ["websocket"],
 							query: {
@@ -54,7 +54,7 @@ export const makeVolmexWebSocketService = (
 				Runtime.runSync(
 					runtime,
 					Effect.logInfo("Volmex Socket.IO connected", {
-						url: config.baseUrl,
+						url: config.wsBaseUrl,
 					}),
 				);
 				socket.emit(FETCH_INDICES_EVENT, {});


### PR DESCRIPTION
The route schema for the Volmex module now has two different variants: "ws" and "rest."
For the "rest" variant, the module proxies requests to Volmex REST APIs documented [here](https://private-multiregion-8jh89.volmex.finance/api).

## Explanation of Changes

Given this config:
```json
{
	"routeGroup": "proxy",
	"modules": [
		{
			"type": "volmex",
			"name": "volmex",
			"wsBaseUrl": "wss://ws-8jh89.volmex.finance",
			"restBaseUrl": "https://private-multiregion-8jh89.volmex.finance",
			"volmexApiKeyEnvKey": "VOLMEX_API_KEY"
		}
	],
	"routes": [
		{
			"type": "volmex",
			"moduleName": "volmex",
			"path": "/:priceSymbol", 
			"method": "GET",
			"fetchFromModule": "{:priceSymbol}"
		},
		{
			"type": "volmex",
			"moduleName": "volmex",
			"source": "rest", // defaults to "ws" if omitted
			"path": "/history",
			"method": "GET",
			"upstreamPath": "/public/history",
			"allowedQueryParams": ["symbol", "resolution", "from", "to"]
		}
	]
}
```

one can make requests like:
```bash
curl -sG "http://127.0.0.1:5384/proxy/history" \
  --data-urlencode "symbol=BVIV" \
  --data-urlencode "resolution=D" \
  --data-urlencode "from=1700000000" \
  --data-urlencode "to=1701000000" | jq .

# or equivalently:
curl -sX GET "http://127.0.0.1:5384/proxy/history?symbol=BVIV&resolution=D&from=1670667075&to=1671531075" | jq .
```