### PR TITLE
Fail WS session Deferred only on close

### DIFF
--- a/workspace/data-proxy/src/modules/binance/ws-client.test.ts
+++ b/workspace/data-proxy/src/modules/binance/ws-client.test.ts
@@ -123,7 +123,7 @@ class FakeWebSocket extends EventTarget {
 	close(): void {
 		if (this.readyState === FakeWebSocket.CLOSED) return;
 		this.readyState = FakeWebSocket.CLOSED;
-		this.dispatchEvent(new Event("close"));
+		this.dispatchEvent(new CloseEvent("close", { code: 1000, wasClean: true }));
 	}
 
 	triggerOpen(): void {
@@ -135,10 +135,14 @@ class FakeWebSocket extends EventTarget {
 		this.dispatchEvent(new MessageEvent("message", { data }));
 	}
 
-	triggerClose(): void {
+	triggerClose(code = 1000, reason = "", wasClean = true): void {
 		if (this.readyState === FakeWebSocket.CLOSED) return;
 		this.readyState = FakeWebSocket.CLOSED;
-		this.dispatchEvent(new Event("close"));
+		this.dispatchEvent(new CloseEvent("close", { code, reason, wasClean }));
+	}
+
+	triggerError(message = "socket error"): void {
+		this.dispatchEvent(new ErrorEvent("error", { message }));
 	}
 }
 

--- a/workspace/data-proxy/src/modules/binance/ws-client.ts
+++ b/workspace/data-proxy/src/modules/binance/ws-client.ts
@@ -100,7 +100,7 @@ export const createBinanceWS = (
 		const runtime = yield* Effect.runtime<never>();
 		const desiredSymbols = MutableHashMap.empty<string, true>();
 		let currentWS: WebSocket | null = null;
-		let socketError: string | undefined;
+		let unhealthy = false;
 		let controlId = 0;
 		const schedule =
 			options?.reconnectSchedule ?? defaultReconnectSchedule(config);
@@ -117,7 +117,7 @@ export const createBinanceWS = (
 				try {
 					ws.send(frame);
 				} catch (err) {
-					socketError = `ws send failed: ${String(err)}`;
+					unhealthy = true;
 					yield* Effect.logWarning("Binance WS send failed", {
 						error: String(err),
 					});
@@ -162,12 +162,12 @@ export const createBinanceWS = (
 				);
 			});
 
-		const hasError = () => Effect.sync(() => socketError !== undefined);
+		const hasError = () => Effect.sync(() => unhealthy);
 
 		const handleOpen = (ws: WebSocket) =>
 			Effect.gen(function* () {
 				yield* Effect.logInfo("Binance WS open", { name: config.name });
-				socketError = undefined;
+				unhealthy = false;
 				currentWS = ws;
 				const symbols: string[] = [];
 				for (const [symbol] of desiredSymbols) symbols.push(symbol);
@@ -194,19 +194,15 @@ export const createBinanceWS = (
 			);
 		};
 
-		const handleDisconnect = (
-			reason: "close" | "error",
-			closed: Deferred.Deferred<void, "close" | "error">,
-		) =>
+		const handleDisconnect = (closed: Deferred.Deferred<void, void>) =>
 			Effect.gen(function* () {
-				yield* Effect.logWarning("Binance WS disconnected", { reason });
-				socketError = `ws ${reason}`;
+				unhealthy = true;
 				currentWS = null;
-				yield* Deferred.fail(closed, reason);
+				yield* Deferred.fail(closed, undefined);
 			});
 
 		const connectOnce = Effect.gen(function* () {
-			const closed = yield* Deferred.make<void, "close" | "error">();
+			const deferred = yield* Deferred.make<void, void>();
 
 			yield* Effect.logInfo("Binance WS connecting", { name: config.name });
 
@@ -227,20 +223,34 @@ export const createBinanceWS = (
 				if (typeof event.data !== "string") return;
 				Runtime.runSync(runtime, handleInboundMessage(event.data));
 			});
-			ws.addEventListener("close", () => {
-				Runtime.runSync(runtime, handleDisconnect("close", closed));
-			});
 			ws.addEventListener("error", () => {
-				Runtime.runSync(runtime, handleDisconnect("error", closed));
+				unhealthy = true;
+				Runtime.runSync(
+					runtime,
+					Effect.logWarning("Binance WS error event", { name: config.name }),
+				);
+			});
+			ws.addEventListener("close", (event) => {
+				Runtime.runSync(
+					runtime,
+					Effect.gen(function* () {
+						yield* Effect.logWarning("Binance WS disconnected", {
+							code: event.code,
+							closeReason: event.reason,
+							wasClean: event.wasClean,
+						});
+						yield* handleDisconnect(deferred);
+					}),
+				);
 			});
 
-			yield* Deferred.await(closed);
+			yield* Deferred.await(deferred);
 		}).pipe(Effect.scoped);
 
 		const loop = connectOnce.pipe(
-			Effect.tapError((error) =>
+			Effect.tapError(() =>
 				Effect.sync(() => {
-					socketError = `ws connect failed: ${String(error)}`;
+					unhealthy = true;
 				}),
 			),
 			Effect.retry(schedule),

--- a/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/hydromancer.test.ts
@@ -668,7 +668,7 @@ describe("HydromancerModuleService REST fallback when WS is errored", () => {
 			ws.close();
 			yield* Effect.sleep(Duration.millis(0));
 
-			// Request 2: BTC is fresh in cache but socketError forces another REST.
+			// Request 2: BTC is fresh in cache but unhealthy socket forces another REST.
 			yield* svc.handleRequest(route, {}, buildAssetContextRequest(body), body);
 		});
 

--- a/workspace/data-proxy/src/modules/hydromancer/ws-client.test.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/ws-client.test.ts
@@ -134,7 +134,7 @@ class FakeWebSocket extends EventTarget {
 	close(): void {
 		if (this.readyState === FakeWebSocket.CLOSED) return;
 		this.readyState = FakeWebSocket.CLOSED;
-		this.dispatchEvent(new Event("close"));
+		this.dispatchEvent(new CloseEvent("close", { code: 1000, wasClean: true }));
 	}
 
 	triggerOpen(): void {
@@ -146,10 +146,14 @@ class FakeWebSocket extends EventTarget {
 		this.dispatchEvent(new MessageEvent("message", { data }));
 	}
 
-	triggerClose(): void {
+	triggerClose(code = 1000, reason = "", wasClean = true): void {
 		if (this.readyState === FakeWebSocket.CLOSED) return;
 		this.readyState = FakeWebSocket.CLOSED;
-		this.dispatchEvent(new Event("close"));
+		this.dispatchEvent(new CloseEvent("close", { code, reason, wasClean }));
+	}
+
+	triggerError(message = "socket error"): void {
+		this.dispatchEvent(new ErrorEvent("error", { message }));
 	}
 }
 

--- a/workspace/data-proxy/src/modules/hydromancer/ws-client.ts
+++ b/workspace/data-proxy/src/modules/hydromancer/ws-client.ts
@@ -92,7 +92,7 @@ export const createHydromancerWS = (
 		const runtime = yield* Effect.runtime<never>();
 		const desiredCoins = MutableHashMap.empty<string, true>();
 		let currentWS: WebSocket | null = null;
-		let socketError: string | undefined;
+		let unhealthy = false;
 		const schedule =
 			options?.reconnectSchedule ?? defaultReconnectSchedule(config);
 
@@ -103,7 +103,7 @@ export const createHydromancerWS = (
 				try {
 					ws.send(frame);
 				} catch (err) {
-					socketError = `ws send failed: ${String(err)}`;
+					unhealthy = true;
 					yield* Effect.logWarning("Hydromancer WS send failed", {
 						error: String(err),
 					});
@@ -129,12 +129,12 @@ export const createHydromancerWS = (
 				yield* trySend(buildUnsubscribeFrame(coin));
 			});
 
-		const hasError = () => Effect.sync(() => socketError !== undefined);
+		const hasError = () => Effect.sync(() => unhealthy);
 
 		const handleOpen = (ws: WebSocket) =>
 			Effect.gen(function* () {
 				yield* Effect.logInfo("Hydromancer WS open", { name: config.name });
-				socketError = undefined;
+				unhealthy = false;
 				currentWS = ws;
 				for (const [coin] of desiredCoins) {
 					yield* trySend(buildSubscribeFrame(coin));
@@ -152,22 +152,18 @@ export const createHydromancerWS = (
 				yield* cache.set(frame.coin, frame.ctx, now);
 			});
 
-		const handleDisconnect = (
-			reason: "close" | "error",
-			closed: Deferred.Deferred<void, "close" | "error">,
-		) =>
+		const handleDisconnect = (closed: Deferred.Deferred<void, void>) =>
 			Effect.gen(function* () {
-				yield* Effect.logWarning("Hydromancer WS disconnected", { reason });
-				socketError = `ws ${reason}`;
+				unhealthy = true;
 				currentWS = null;
-				yield* Deferred.fail(closed, reason);
+				yield* Deferred.fail(closed, undefined);
 			});
 
 		const connectOnce = Effect.gen(function* () {
 			const wsUrl = `${config.wsUrl}?token=${encodeURIComponent(
 				config.hydromancerApiKey,
 			)}`;
-			const closed = yield* Deferred.make<void, "close" | "error">();
+			const deferred = yield* Deferred.make<void, void>();
 
 			yield* Effect.logInfo("Hydromancer WS connecting", {
 				name: config.name,
@@ -190,20 +186,36 @@ export const createHydromancerWS = (
 				if (typeof event.data !== "string") return;
 				Runtime.runSync(runtime, handleInboundMessage(event.data));
 			});
-			ws.addEventListener("close", () => {
-				Runtime.runSync(runtime, handleDisconnect("close", closed));
-			});
 			ws.addEventListener("error", () => {
-				Runtime.runSync(runtime, handleDisconnect("error", closed));
+				unhealthy = true;
+				Runtime.runSync(
+					runtime,
+					Effect.logWarning("Hydromancer WS error event", {
+						name: config.name,
+					}),
+				);
+			});
+			ws.addEventListener("close", (event) => {
+				Runtime.runSync(
+					runtime,
+					Effect.gen(function* () {
+						yield* Effect.logWarning("Hydromancer WS disconnected", {
+							code: event.code,
+							closeReason: event.reason,
+							wasClean: event.wasClean,
+						});
+						yield* handleDisconnect(deferred);
+					}),
+				);
 			});
 
-			yield* Deferred.await(closed);
+			yield* Deferred.await(deferred);
 		}).pipe(Effect.scoped);
 
 		const loop = connectOnce.pipe(
-			Effect.tapError((error) =>
+			Effect.tapError(() =>
 				Effect.sync(() => {
-					socketError = `ws connect failed: ${String(error)}`;
+					unhealthy = true;
 				}),
 			),
 			Effect.retry(schedule),

--- a/workspace/data-proxy/src/modules/lighter/ws-client.test.ts
+++ b/workspace/data-proxy/src/modules/lighter/ws-client.test.ts
@@ -121,7 +121,7 @@ class FakeWebSocket extends EventTarget {
 	close(): void {
 		if (this.readyState === FakeWebSocket.CLOSED) return;
 		this.readyState = FakeWebSocket.CLOSED;
-		this.dispatchEvent(new Event("close"));
+		this.dispatchEvent(new CloseEvent("close", { code: 1000, wasClean: true }));
 	}
 
 	triggerOpen(): void {
@@ -133,10 +133,14 @@ class FakeWebSocket extends EventTarget {
 		this.dispatchEvent(new MessageEvent("message", { data }));
 	}
 
-	triggerClose(): void {
+	triggerClose(code = 1000, reason = "", wasClean = true): void {
 		if (this.readyState === FakeWebSocket.CLOSED) return;
 		this.readyState = FakeWebSocket.CLOSED;
-		this.dispatchEvent(new Event("close"));
+		this.dispatchEvent(new CloseEvent("close", { code, reason, wasClean }));
+	}
+
+	triggerError(message = "socket error"): void {
+		this.dispatchEvent(new ErrorEvent("error", { message }));
 	}
 }
 

--- a/workspace/data-proxy/src/modules/lighter/ws-client.ts
+++ b/workspace/data-proxy/src/modules/lighter/ws-client.ts
@@ -171,18 +171,14 @@ export const createLighterWS = (
 				yield* cache.setPrice(parsed.marketId, parsed.frame);
 			});
 
-		const handleDisconnect = (
-			reason: "close" | "error",
-			closed: Deferred.Deferred<void, "close" | "error">,
-		) =>
+		const handleDisconnect = (closed: Deferred.Deferred<void, void>) =>
 			Effect.gen(function* () {
-				yield* Effect.logWarning("Lighter WS disconnected", { reason });
 				currentWS = null;
-				yield* Deferred.fail(closed, reason);
+				yield* Deferred.fail(closed, undefined);
 			});
 
 		const connectOnce = Effect.gen(function* () {
-			const closed = yield* Deferred.make<void, "close" | "error">();
+			const deferred = yield* Deferred.make<void, void>();
 
 			yield* Effect.logInfo("Lighter WS connecting", { name: config.name });
 
@@ -203,22 +199,31 @@ export const createLighterWS = (
 				if (typeof event.data !== "string") return;
 				Runtime.runSync(runtime, handleInboundMessage(event.data));
 			});
-			ws.addEventListener("close", () => {
-				Runtime.runSync(runtime, handleDisconnect("close", closed));
-			});
 			ws.addEventListener("error", () => {
-				Runtime.runSync(runtime, handleDisconnect("error", closed));
+				Runtime.runSync(
+					runtime,
+					Effect.logWarning("Lighter WS error event", { name: config.name }),
+				);
+			});
+			ws.addEventListener("close", (event) => {
+				Runtime.runSync(
+					runtime,
+					Effect.gen(function* () {
+						yield* Effect.logWarning("Lighter WS disconnected", {
+							code: event.code,
+							closeReason: event.reason,
+							wasClean: event.wasClean,
+						});
+						yield* handleDisconnect(deferred);
+					}),
+				);
 			});
 
-			yield* Deferred.await(closed);
+			yield* Deferred.await(deferred);
 		}).pipe(Effect.scoped);
 
 		const loop = connectOnce.pipe(
-			Effect.tapError((error) =>
-				Effect.logWarning("Lighter WS connect failed", {
-					error: String(error),
-				}),
-			),
+			Effect.tapError(() => Effect.logWarning("Lighter WS connect failed")),
 			Effect.retry(schedule),
 		);
 


### PR DESCRIPTION
## Explanation of Changes

Instead of calling disconnect on both error and close, log the error separately on error and call disconnect on close only. Also log relevant info on close (JS WebSocket apparently relies on close instead of error for conveying details about an error). Previously, we weren't really logging anything other than whether it's "close" or "error."

Logs on WS disconnect before:

```
2026-07-29T17:50:35.320Z WARN  #9 Lighter WS disconnected
{
  "reason": "close"
}
```

Logs on WS disconnect after:

```
2026-07-29T17:43:34.348Z WARN  #9 Lighter WS disconnected
{
  "code": 1000,
  "closeReason": "read tcp 172.32.106.180:8888->172.31.106.245:28786: i/o timeout",
  "wasClean": false
}
```
