### PR TITLE
Multi endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Example response shape:
 
 ### Multi endpoint
 
-The **multi endpoint** allows clients to send multiple requests to configured routes (module or upstream) in a single `POST`. Clients specify those requests in the body (see below).
+The **multi endpoint** allows clients to send multiple sub-requests to configured routes (module or upstream) in a single `POST`. Clients specify those sub-requests in the body (see below).
 
 Enable it with the root `multiEndpoint` config (off by default):
 
@@ -472,8 +472,8 @@ Enable it with the root `multiEndpoint` config (off by default):
     "enable": true,
     // POST path under the route group; default is "multi" → /proxy/multi
     "path": "multi",
-    // Max entries in the request body object per call; default is 20
-    "maxRequests": 20,
+    // Max sub-requests in the request body object per call; default is 20
+    "maxSubRequests": 20,
     // Max sub-requests running in parallel within one call; default is 5
     "concurrency": 5
   },
@@ -500,7 +500,7 @@ Enable it with the root `multiEndpoint` config (off by default):
 }
 ```
 
-Request body (object keyed by request id):
+Request body (object keyed by sub-request id):
 
 ```jsonc
 {
@@ -539,9 +539,9 @@ Behavior notes:
 
 - Sub-request failures are **non-fatal**: a failing id appears as `{ "error": "...", "status": ... }`; other ids still resolve. The outer response is still signed as HTTP `200`.
 - Path params are filled the same way as a direct call (`/binance/:symbols` + `/binance/BTC` → `{ symbols: "BTC" }`).
-- Parent request headers are **not** forwarded to sub-requests. Use the per-entry `headers` field when a sub-request needs headers (route-configured headers still apply as usual).
+- Parent request headers are **not** forwarded to sub-requests. Use the per-sub-request `headers` field when a sub-request needs headers (route-configured headers still apply as usual).
 - Legacy `type: "multi"` routes are **not** valid targets (nesting is rejected).
-- Invalid JSON, schema errors, empty body, or exceeding `maxRequests` return HTTP `400`.
+- Invalid JSON, schema errors, empty body, or exceeding `maxSubRequests` return HTTP `400`.
 
 ### Status Endpoint
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Lighter example — numeric market ids (for example `1` for BTC on mainnet):
 
 Module responses include a per-item `__sedaHasPrice` flag (`true` when a price was resolved, `false` on timeout or invalid input). The first request for a new symbol may need a retry while the WebSocket subscription warms up.
 
-#### Multi routes
+#### Multi routes (To be deprecated)
 
 A **multi** route fans out to several module handlers in one request. Each entry in `fetches` runs concurrently; results are merged into a single JSON object keyed by fetch `name`.
 
@@ -458,6 +458,88 @@ Example response shape:
 
 > [!NOTE]
 > Multi routes skip the global `__sedaHasPrice` gate used on single-source routes, because a partial miss on one source is expected and reported inside the combined payload.
+
+### Multi endpoint
+
+The **multi endpoint** allows clients to send multiple requests to configured routes (module or upstream) in a single `POST`. Clients specify those requests in the body (see below).
+
+Enable it with the root `multiEndpoint` config (off by default):
+
+```jsonc
+{
+  "routeGroup": "proxy",
+  "multiEndpoint": {
+    "enable": true,
+    // POST path under the route group; default is "multi" → /proxy/multi
+    "path": "multi",
+    // Max entries in the request body object per call; default is 20
+    "maxRequests": 20,
+    // Max sub-requests running in parallel within one call; default is 5
+    "concurrency": 5
+  },
+  "modules": [
+    { "name": "bin", "type": "binance" },
+    { "name": "lig", "type": "lighter" }
+  ],
+  "routes": [
+    {
+      "type": "binance",
+      "moduleName": "bin",
+      "path": "/binance/:symbols",
+      "method": ["GET"],
+      "fetchFromModule": "{:symbols}"
+    },
+    {
+      "type": "lighter",
+      "moduleName": "lig",
+      "path": "/lighter/:markets",
+      "method": ["GET"],
+      "fetchFromModule": "{:markets}"
+    }
+  ]
+}
+```
+
+Request body (object keyed by request id):
+
+```jsonc
+{
+  "binance": {
+    "path": "/binance/BTCUSDT,ETHUSDT", // Matched against configured route paths
+    "method": "GET", // Optional; default GET
+    "query": { "skipPriceErrors": "true" }, // Optional; forwarded as query string
+    "body": { "type": "assetContext", "coins": "BTC" } // Optional; for POST routes
+  },
+  "lighter": {
+    "path": "/lighter/1,2"
+  }
+}
+```
+
+```bash
+curl -sX POST "http://127.0.0.1:5384/proxy/multi" \
+  -H "content-type: application/json" \
+  --data '{
+    "binance": { "path": "/binance/BTCUSDT,ETHUSDT" },
+    "lighter": { "path": "/lighter/1" }
+  }' | jq .
+```
+
+Example response shape (results keyed by the same ids):
+
+```jsonc
+{
+  "binance": [{ "symbol": "BTCUSDT", "__sedaHasPrice": true, "...": "..." }],
+  "lighter": [{ "marketId": "1", "__sedaHasPrice": true, "...": "..." }]
+}
+```
+
+Behavior notes:
+
+- Sub-request failures are **non-fatal**: a failing id appears as `{ "error": "...", "status": ... }`; other ids still resolve. The outer response is still signed as HTTP `200`.
+- Path params are filled the same way as a direct call (`/binance/:symbols` + `/binance/BTC` → `{ symbols: "BTC" }`).
+- Legacy `type: "multi"` routes are **not** valid targets (nesting is rejected).
+- Invalid JSON, schema errors, empty body, or exceeding `maxRequests` return HTTP `400`.
 
 ### Status Endpoint
 

--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Request body (object keyed by request id):
     "path": "/binance/BTCUSDT,ETHUSDT", // Matched against configured route paths
     "method": "GET", // Optional; default GET
     "query": { "skipPriceErrors": "true" }, // Optional; forwarded as query string
+    "headers": { "x-custom": "value" }, // Optional
     "body": { "type": "assetContext", "coins": "BTC" } // Optional; for POST routes
   },
   "lighter": {
@@ -538,6 +539,7 @@ Behavior notes:
 
 - Sub-request failures are **non-fatal**: a failing id appears as `{ "error": "...", "status": ... }`; other ids still resolve. The outer response is still signed as HTTP `200`.
 - Path params are filled the same way as a direct call (`/binance/:symbols` + `/binance/BTC` → `{ symbols: "BTC" }`).
+- Parent request headers are **not** forwarded to sub-requests. Use the per-entry `headers` field when a sub-request needs headers (route-configured headers still apply as usual).
 - Legacy `type: "multi"` routes are **not** valid targets (nesting is rejected).
 - Invalid JSON, schema errors, empty body, or exceeding `maxRequests` return HTTP `400`.
 

--- a/workspace/data-proxy/package.json
+++ b/workspace/data-proxy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/data-proxy",
 	"main": "./src/index.ts",
-	"version": "3.2.0",
+	"version": "4.0.0",
 	"devDependencies": {
 		"@types/big.js": "^6.2.2",
 		"@types/ws": "^8.18.1",

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -1017,7 +1017,7 @@ describe("parseConfig", () => {
 			expect(result.value.config.multiEndpoint).toEqual({
 				enable: true,
 				path: "multi",
-				maxRequests: 20,
+				maxSubRequests: 20,
 				concurrency: 5,
 			});
 		});

--- a/workspace/data-proxy/src/config-parser.test.ts
+++ b/workspace/data-proxy/src/config-parser.test.ts
@@ -995,6 +995,74 @@ describe("parseConfig", () => {
 		});
 	});
 
+	describe("multi endpoint", () => {
+		it("accepts an enabled multi endpoint", () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					modules: [{ name: "bin", type: "binance" }],
+					multiEndpoint: { enable: true },
+					routes: [
+						{
+							type: "binance",
+							moduleName: "bin",
+							path: "/binance/:symbols",
+							fetchFromModule: "{:symbols}",
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeOkResult();
+			assertIsOkResult(result);
+			expect(result.value.config.multiEndpoint).toEqual({
+				enable: true,
+				path: "multi",
+				maxRequests: 20,
+				concurrency: 5,
+			});
+		});
+
+		it("rejects a route that collides with the multi endpoint path", () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					modules: [],
+					multiEndpoint: { enable: true, path: "multi" },
+					routes: [
+						{
+							path: "/multi",
+							method: ["GET"],
+							upstreamUrl: "https://example.com/multi",
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				"Route /multi collides with multiEndpoint.path; rename the route or multiEndpoint.path",
+			);
+		});
+
+		it("rejects a route that collides after trailing-slash normalization", () => {
+			const [result] = Effect.runSync(
+				parseConfig({
+					modules: [],
+					multiEndpoint: { enable: true, path: "multi" },
+					routes: [
+						{
+							path: "/multi/",
+							method: ["GET"],
+							upstreamUrl: "https://example.com/multi",
+						},
+					],
+				}),
+			);
+
+			expect(result).toBeErrResult(
+				"Route /multi/ collides with multiEndpoint.path; rename the route or multiEndpoint.path",
+			);
+		});
+	});
+
 	describe("fastOnly", () => {
 		it("rejects fastOnly when sedaFast is not enabled", () => {
 			const [result] = Effect.runSync(

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -48,7 +48,7 @@ import { type Modules, ModulesSchema } from "./module-config";
 import {
 	DEFAULT_MULTI_CONCURRENCY,
 	DEFAULT_MULTI_ENDPOINT_PATH,
-	DEFAULT_MULTI_MAX_REQUESTS,
+	DEFAULT_MULTI_MAX_SUB_REQUESTS,
 	MultiEndpointSchema,
 } from "./multi-endpoint-config";
 import {
@@ -186,7 +186,7 @@ const ConfigSchema = v.strictObject(
 		multiEndpoint: v.optional(MultiEndpointSchema, {
 			enable: false,
 			path: DEFAULT_MULTI_ENDPOINT_PATH,
-			maxRequests: DEFAULT_MULTI_MAX_REQUESTS,
+			maxSubRequests: DEFAULT_MULTI_MAX_SUB_REQUESTS,
 			concurrency: DEFAULT_MULTI_CONCURRENCY,
 		}),
 	},

--- a/workspace/data-proxy/src/config/config-parser.ts
+++ b/workspace/data-proxy/src/config/config-parser.ts
@@ -11,6 +11,7 @@ import {
 	DEFAULT_VERIFICATION_MAX_RETRIES,
 	DEFAULT_VERIFICATION_RETRY_DELAY,
 } from "../constants";
+import { normalizePath } from "../utils/match-route-path";
 import { replaceParams } from "../utils/replace-params";
 import {
 	type BinanceModuleRoute,
@@ -44,6 +45,12 @@ import {
 	validateLoTechModuleRoute,
 } from "./lo-tech-module-config";
 import { type Modules, ModulesSchema } from "./module-config";
+import {
+	DEFAULT_MULTI_CONCURRENCY,
+	DEFAULT_MULTI_ENDPOINT_PATH,
+	DEFAULT_MULTI_MAX_REQUESTS,
+	MultiEndpointSchema,
+} from "./multi-endpoint-config";
 import {
 	type MultiModuleRoute,
 	MultiModuleRouteSchema,
@@ -176,6 +183,12 @@ const ConfigSchema = v.strictObject(
 				root: "status",
 			},
 		),
+		multiEndpoint: v.optional(MultiEndpointSchema, {
+			enable: false,
+			path: DEFAULT_MULTI_ENDPOINT_PATH,
+			maxRequests: DEFAULT_MULTI_MAX_REQUESTS,
+			concurrency: DEFAULT_MULTI_CONCURRENCY,
+		}),
 	},
 	UNKNOWN_ATTRIBUTE_ERROR,
 );
@@ -251,6 +264,21 @@ export const parseConfig = (
 				),
 				hasWarnings,
 			];
+		}
+
+		if (config.multiEndpoint.enable) {
+			const multiPath = normalizePath(config.multiEndpoint.path);
+
+			for (const route of config.routes) {
+				if (normalizePath(route.path) === multiPath) {
+					return [
+						Result.err(
+							`Route ${route.path} collides with multiEndpoint.path; rename the route or multiEndpoint.path`,
+						),
+						hasWarnings,
+					];
+				}
+			}
 		}
 
 		// Check if the environment variables required by the status endpoint are available.

--- a/workspace/data-proxy/src/config/multi-endpoint-config.ts
+++ b/workspace/data-proxy/src/config/multi-endpoint-config.ts
@@ -1,0 +1,59 @@
+import * as v from "valibot";
+
+export const DEFAULT_MULTI_ENDPOINT_PATH = "multi";
+export const DEFAULT_MULTI_MAX_REQUESTS = 20;
+export const DEFAULT_MULTI_CONCURRENCY = 5;
+
+export const MultiEndpointSchema = v.strictObject({
+	enable: v.optional(v.boolean(), false),
+	path: v.optional(v.string(), DEFAULT_MULTI_ENDPOINT_PATH),
+	maxRequests: v.optional(
+		v.pipe(
+			v.number(),
+			v.integer(),
+			v.minValue(1, "maxRequests must be a positive integer"),
+		),
+		DEFAULT_MULTI_MAX_REQUESTS,
+	),
+	concurrency: v.optional(
+		v.pipe(
+			v.number(),
+			v.integer(),
+			v.minValue(1, "concurrency must be a positive integer"),
+		),
+		DEFAULT_MULTI_CONCURRENCY,
+	),
+});
+
+export type MultiEndpoint = v.InferOutput<typeof MultiEndpointSchema>;
+
+// A single request inside a multi endpoint body. `path` is matched against the
+// proxy's configured routes (same public paths clients already call one-by-one).
+export const MultiEndpointRequestSchema = v.strictObject({
+	path: v.pipe(v.string(), v.minLength(1, "path must not be empty")),
+	method: v.optional(v.string(), "GET"),
+	query: v.optional(
+		v.record(v.string(), v.union([v.string(), v.array(v.string())])),
+	),
+	// String is forwarded as-is; objects/arrays are JSON-stringified.
+	body: v.optional(v.unknown()),
+});
+
+export type MultiEndpointRequest = v.InferOutput<
+	typeof MultiEndpointRequestSchema
+>;
+
+export const MultiEndpointRequestBodySchema = v.pipe(
+	v.record(
+		v.pipe(v.string(), v.minLength(1, "id must not be empty")),
+		MultiEndpointRequestSchema,
+	),
+	v.check(
+		(entries) => Object.keys(entries).length >= 1,
+		"request body must contain at least one entry",
+	),
+);
+
+export type MultiEndpointRequestBody = v.InferOutput<
+	typeof MultiEndpointRequestBodySchema
+>;

--- a/workspace/data-proxy/src/config/multi-endpoint-config.ts
+++ b/workspace/data-proxy/src/config/multi-endpoint-config.ts
@@ -35,6 +35,8 @@ export const MultiEndpointRequestSchema = v.strictObject({
 	query: v.optional(
 		v.record(v.string(), v.union([v.string(), v.array(v.string())])),
 	),
+	// Optional headers for the request.
+	headers: v.optional(v.record(v.string(), v.string()), {}),
 	// String is forwarded as-is; objects/arrays are JSON-stringified.
 	body: v.optional(v.unknown()),
 });

--- a/workspace/data-proxy/src/config/multi-endpoint-config.ts
+++ b/workspace/data-proxy/src/config/multi-endpoint-config.ts
@@ -1,19 +1,19 @@
 import * as v from "valibot";
 
 export const DEFAULT_MULTI_ENDPOINT_PATH = "multi";
-export const DEFAULT_MULTI_MAX_REQUESTS = 20;
+export const DEFAULT_MULTI_MAX_SUB_REQUESTS = 20;
 export const DEFAULT_MULTI_CONCURRENCY = 5;
 
 export const MultiEndpointSchema = v.strictObject({
 	enable: v.optional(v.boolean(), false),
 	path: v.optional(v.string(), DEFAULT_MULTI_ENDPOINT_PATH),
-	maxRequests: v.optional(
+	maxSubRequests: v.optional(
 		v.pipe(
 			v.number(),
 			v.integer(),
-			v.minValue(1, "maxRequests must be a positive integer"),
+			v.minValue(1, "maxSubRequests must be a positive integer"),
 		),
-		DEFAULT_MULTI_MAX_REQUESTS,
+		DEFAULT_MULTI_MAX_SUB_REQUESTS,
 	),
 	concurrency: v.optional(
 		v.pipe(
@@ -27,32 +27,33 @@ export const MultiEndpointSchema = v.strictObject({
 
 export type MultiEndpoint = v.InferOutput<typeof MultiEndpointSchema>;
 
-// A single request inside a multi endpoint body. `path` is matched against the
-// proxy's configured routes (same public paths clients already call one-by-one).
-export const MultiEndpointRequestSchema = v.strictObject({
+// A single sub-request inside a multi endpoint body. `path` is matched against
+// the proxy's configured routes (same public paths clients already call
+// one-by-one).
+export const MultiEndpointSubRequestSchema = v.strictObject({
 	path: v.pipe(v.string(), v.minLength(1, "path must not be empty")),
 	method: v.optional(v.string(), "GET"),
 	query: v.optional(
 		v.record(v.string(), v.union([v.string(), v.array(v.string())])),
 	),
-	// Optional headers for the request.
+	// Optional headers for the sub-request.
 	headers: v.optional(v.record(v.string(), v.string()), {}),
 	// String is forwarded as-is; objects/arrays are JSON-stringified.
 	body: v.optional(v.unknown()),
 });
 
-export type MultiEndpointRequest = v.InferOutput<
-	typeof MultiEndpointRequestSchema
+export type MultiEndpointSubRequest = v.InferOutput<
+	typeof MultiEndpointSubRequestSchema
 >;
 
 export const MultiEndpointRequestBodySchema = v.pipe(
 	v.record(
 		v.pipe(v.string(), v.minLength(1, "id must not be empty")),
-		MultiEndpointRequestSchema,
+		MultiEndpointSubRequestSchema,
 	),
 	v.check(
 		(entries) => Object.keys(entries).length >= 1,
-		"request body must contain at least one entry",
+		"request body must contain at least one sub-request",
 	),
 );
 

--- a/workspace/data-proxy/src/controllers/proxy/execute-route.ts
+++ b/workspace/data-proxy/src/controllers/proxy/execute-route.ts
@@ -1,0 +1,205 @@
+import { Effect, Match, Option } from "effect";
+import type { Config } from "../../config/config-parser";
+import { HAS_PRICE_KEY } from "../../constants";
+import {
+	FailedToParseResponseBodyError,
+	NotOkUpstreamResponseError,
+	QueryJsonError,
+} from "../../errors";
+import type { ModuleHandlers } from "../../modules/module";
+import { HttpClientService } from "../../services/http-client";
+import { queryJson } from "../../utils/query-json";
+import { createUrlSearchParams } from "../../utils/search-params";
+import { handleMultiRequest } from "./handle-multi-request";
+import { handleUpstreamRequest } from "./handle-upstream-request";
+
+export type ExecuteRouteParams = {
+	route: Config["routes"][number];
+	params: Record<string, string>;
+	request: Request;
+	headers: Record<string, string | undefined>;
+	body: Option.Option<string>;
+	moduleHandlers: ReadonlyMap<string, ModuleHandlers>;
+	routePath: string;
+};
+
+export type ExecuteRouteResult = {
+	responseData: string;
+	upstreamResponse: Response;
+};
+
+// Runs a configured route (module, upstream, or legacy multi) through to a
+// filtered response body — without proof verification or signing. Callers that
+// need those wrap this and apply them once for the outer request.
+export const executeRoute = ({
+	route,
+	params,
+	request,
+	headers,
+	body,
+	moduleHandlers,
+	routePath,
+}: ExecuteRouteParams) =>
+	Effect.gen(function* () {
+		const httpClient = yield* HttpClientService;
+
+		const requestUrl = new URL(request.url);
+		const requestSearchParams = createUrlSearchParams(
+			requestUrl.searchParams,
+			route.allowedQueryParams,
+		);
+
+		const upstreamResponse = yield* Match.value(route).pipe(
+			// TODO(#162): To be deprecated
+			Match.when({ type: "multi" }, (multiModuleRoute) =>
+				Effect.gen(function* () {
+					yield* Effect.logDebug("Handling legacy multi request");
+					return yield* handleMultiRequest(
+						multiModuleRoute,
+						params,
+						request,
+						moduleHandlers,
+					);
+				}),
+			),
+			Match.when({ type: "upstream" }, (upstreamRoute) =>
+				handleUpstreamRequest({
+					route: upstreamRoute,
+					params,
+					headers,
+					body,
+					request,
+					routePath,
+					requestSearchParams,
+				}),
+			),
+			Match.orElse((moduleRoute) =>
+				Effect.gen(function* () {
+					const handlers = moduleHandlers.get(moduleRoute.moduleName);
+					if (!handlers) {
+						return yield* Effect.fail(
+							new NotOkUpstreamResponseError({
+								status: 500,
+								body: `Module ${moduleRoute.moduleName} not found`,
+								routePath,
+							}),
+						);
+					}
+
+					yield* Effect.logDebug(`Handling ${moduleRoute.type} request`);
+
+					return yield* handlers.handleRequest(
+						moduleRoute,
+						params,
+						request,
+						Option.getOrUndefined(body),
+					);
+				}),
+			),
+		);
+
+		if (!upstreamResponse.ok) {
+			const upstreamResponseBody = yield* httpClient
+				.parseBodyAsText(upstreamResponse)
+				.pipe(
+					Effect.mapError(
+						(error) =>
+							new FailedToParseResponseBodyError({
+								error: error.message,
+								status: upstreamResponse.status,
+							}),
+					),
+					Effect.tapError((error) =>
+						Effect.logError(
+							`Upstream response body parsing failed with status: ${upstreamResponse.status} err: ${error}`,
+							{
+								routePath,
+								method: request.method,
+								clientRequestUrl: request.url,
+								upstreamResponseUrl: upstreamResponse.url,
+								routeParams: params,
+								requestBody: Option.getOrUndefined(body),
+							},
+						),
+					),
+				);
+
+			yield* Effect.logError(
+				`Upstream response for route ${routePath} is not ok: ${upstreamResponse.status} body: ${upstreamResponseBody}`,
+				{
+					requestBody: Option.getOrUndefined(body),
+					method: request.method,
+					upstreamUrl: upstreamResponse.url,
+				},
+			);
+
+			return yield* Effect.fail(
+				new NotOkUpstreamResponseError({
+					status: upstreamResponse.status,
+					body: upstreamResponseBody,
+					routePath,
+				}),
+			);
+		}
+
+		yield* Effect.logDebug("Received upstream response", {
+			headers: upstreamResponse.headers,
+		});
+
+		const upstreamTextResponse = yield* httpClient
+			.parseBodyAsText(upstreamResponse)
+			.pipe(
+				Effect.mapError(
+					(error) =>
+						new FailedToParseResponseBodyError({
+							error: error.message,
+							status: upstreamResponse.status,
+						}),
+				),
+			);
+
+		let responseData: string = upstreamTextResponse;
+
+		// TEMP: This is added for older ops who may not handle __sedaHasPrice key in the response.
+		// we should remove this once all ops have updated to the new response format.
+		// Multi routes return arbitrary per-source payloads where a per-source miss
+		// is expected, so the price gate does not apply.
+		if (route.type !== "multi" && !requestSearchParams.has("skipPriceErrors")) {
+			if (upstreamTextResponse.includes(`"${HAS_PRICE_KEY}":false`)) {
+				return yield* Effect.fail(
+					new NotOkUpstreamResponseError({
+						status: 500,
+						body: `Not all symbols have a price: ${upstreamTextResponse}`,
+						routePath,
+					}),
+				);
+			}
+		}
+
+		if (route.jsonPath) {
+			yield* Effect.logDebug(`Applying route JSONpath ${route.jsonPath}`);
+			const data = yield* queryJson(
+				upstreamTextResponse,
+				route.jsonPath,
+				route.useLegacyJsonPath,
+			).pipe(
+				Effect.annotateSpans("type", "route-config"),
+				Effect.mapError(
+					(error) =>
+						new QueryJsonError({
+							error: error.message,
+							data: error.data,
+							type: "config",
+							status: 500,
+						}),
+				),
+			);
+			responseData = JSON.stringify(data);
+			yield* Effect.logDebug("Successfully applied route JSONpath");
+		}
+
+		return {
+			responseData,
+			upstreamResponse,
+		} satisfies ExecuteRouteResult;
+	});

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "bun:test";
+import type { DataProxy } from "@seda-protocol/data-proxy-sdk";
+import { Effect, Option } from "effect";
+import { Maybe } from "true-myth";
+import type { Config } from "../../config/config-parser";
+import {
+	DEFAULT_MULTI_CONCURRENCY,
+	DEFAULT_MULTI_ENDPOINT_PATH,
+	DEFAULT_MULTI_MAX_REQUESTS,
+	type MultiEndpoint,
+} from "../../config/multi-endpoint-config";
+import {
+	DEFAULT_PROXY_ROUTE_GROUP,
+	DEFAULT_VERIFICATION_MAX_RETRIES,
+	DEFAULT_VERIFICATION_RETRY_DELAY,
+} from "../../constants";
+import {
+	FailedToHandleRequest,
+	type ModuleHandlers,
+} from "../../modules/module";
+import { HttpClientService } from "../../services/http-client";
+import {
+	type HandleMultiEndpointRequestParams,
+	handleMultiEndpointRequest,
+} from "./handle-multi-endpoint-request";
+
+const mockDataProxy = {
+	signData: () =>
+		Effect.succeed({
+			signature: "sig",
+			publicKey: "pub",
+			version: "1",
+		}),
+} as unknown as DataProxy;
+
+const handlers = (
+	handleRequest: ModuleHandlers["handleRequest"],
+): ModuleHandlers => ({
+	start: () => Effect.succeed(undefined),
+	handleRequest,
+});
+
+const echoHandlers = handlers((route, params, _request, body) =>
+	Effect.succeed(
+		new Response(
+			JSON.stringify({
+				type: route.type,
+				params,
+				fetchFromModule:
+					"fetchFromModule" in route ? route.fetchFromModule : undefined,
+				body,
+			}),
+			{ status: 200 },
+		),
+	),
+);
+
+const baseConfig = (): Config => ({
+	fastOnly: true,
+	modules: [],
+	routes: [],
+	verificationMaxRetries: DEFAULT_VERIFICATION_MAX_RETRIES,
+	verificationRetryDelay: DEFAULT_VERIFICATION_RETRY_DELAY,
+	routeGroup: DEFAULT_PROXY_ROUTE_GROUP,
+	baseURL: Maybe.nothing(),
+	statusEndpoints: { root: "status" },
+	multiEndpoint: {
+		enable: false,
+		path: DEFAULT_MULTI_ENDPOINT_PATH,
+		maxRequests: DEFAULT_MULTI_MAX_REQUESTS,
+		concurrency: DEFAULT_MULTI_CONCURRENCY,
+	},
+});
+
+const binanceRoute = {
+	type: "binance" as const,
+	moduleName: "bin",
+	path: "/binance/:symbols",
+	method: ["GET"] as string[],
+	fetchFromModule: "{:symbols}",
+	headers: {},
+	useLegacyJsonPath: true,
+	forwardResponseHeaders: new Set<string>(),
+	baseURL: Maybe.nothing(),
+};
+
+const lighterRoute = {
+	type: "lighter" as const,
+	moduleName: "lig",
+	path: "/lighter/:markets",
+	method: ["GET"] as string[],
+	fetchFromModule: "{:markets}",
+	headers: {},
+	useLegacyJsonPath: true,
+	forwardResponseHeaders: new Set<string>(),
+	baseURL: Maybe.nothing(),
+};
+
+const hydromancerRoute = {
+	type: "hydromancer" as const,
+	moduleName: "hydro",
+	path: "/hydromancer/asset-context",
+	method: ["POST"] as string[],
+	headers: {},
+	useLegacyJsonPath: true,
+	forwardResponseHeaders: new Set<string>(),
+	baseURL: Maybe.nothing(),
+};
+
+const runMultiEndpoint = async (
+	body: unknown,
+	moduleHandlers: Map<string, ModuleHandlers>,
+	eligibleRoutes: Config["routes"],
+	multiEndpoint: MultiEndpoint = {
+		enable: true,
+		path: DEFAULT_MULTI_ENDPOINT_PATH,
+		maxRequests: DEFAULT_MULTI_MAX_REQUESTS,
+		concurrency: DEFAULT_MULTI_CONCURRENCY,
+	},
+) => {
+	const params: HandleMultiEndpointRequestParams = {
+		serverOptions: { port: 0, disableProof: true },
+		dataProxy: mockDataProxy,
+		headers: {},
+		body: Option.some(JSON.stringify(body)),
+		path: "/multi",
+		config: baseConfig(),
+		request: new Request("http://localhost/proxy/multi", {
+			method: "POST",
+			body: JSON.stringify(body),
+		}),
+		moduleHandlers,
+		eligibleRoutes,
+		multiEndpoint,
+	};
+
+	return Effect.runPromise(
+		handleMultiEndpointRequest(params).pipe(
+			Effect.provide(HttpClientService.Default()),
+		),
+	);
+};
+
+describe("handleMultiEndpointRequest", () => {
+	it("fans out to matching routes and keys results by id", async () => {
+		const map = new Map<string, ModuleHandlers>([
+			["bin", echoHandlers],
+			["lig", echoHandlers],
+		]);
+
+		const response = await runMultiEndpoint(
+			{
+				binance: { path: "/binance/BTC,ETH" },
+				lighter: { path: "/lighter/1,2" },
+			},
+			map,
+			[binanceRoute, lighterRoute] as Config["routes"],
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			binance: {
+				type: "binance",
+				params: { symbols: "BTC,ETH" },
+				fetchFromModule: "{:symbols}",
+				body: undefined,
+			},
+			lighter: {
+				type: "lighter",
+				params: { markets: "1,2" },
+				fetchFromModule: "{:markets}",
+				body: undefined,
+			},
+		});
+	});
+
+	it("forwards a JSON body to a POST module route", async () => {
+		const map = new Map<string, ModuleHandlers>([["hydro", echoHandlers]]);
+
+		const response = await runMultiEndpoint(
+			{
+				hydro: {
+					path: "/hydromancer/asset-context",
+					method: "POST",
+					body: { type: "assetContext", coins: "BTC,ETH" },
+				},
+			},
+			map,
+			[hydromancerRoute] as Config["routes"],
+		);
+
+		expect(await response.json()).toEqual({
+			hydro: {
+				type: "hydromancer",
+				params: {},
+				fetchFromModule: undefined,
+				body: '{"type":"assetContext","coins":"BTC,ETH"}',
+			},
+		});
+	});
+
+	it("returns a per-id 404 when no route matches", async () => {
+		const response = await runMultiEndpoint(
+			{
+				missing: { path: "/nope/1" },
+			},
+			new Map(),
+			[binanceRoute] as Config["routes"],
+		);
+
+		expect(await response.json()).toEqual({
+			missing: {
+				error: "No configured route matches GET /nope/1",
+				status: 404,
+			},
+		});
+	});
+
+	it("captures a module handler failure as an error entry", async () => {
+		const failing = handlers(() =>
+			Effect.fail(new FailedToHandleRequest({ msg: "boom" })),
+		);
+		const map = new Map<string, ModuleHandlers>([
+			["bin", echoHandlers],
+			["lig", failing],
+		]);
+
+		const response = await runMultiEndpoint(
+			{
+				binance: { path: "/binance/BTC" },
+				lighter: { path: "/lighter/1" },
+			},
+			map,
+			[binanceRoute, lighterRoute] as Config["routes"],
+		);
+
+		const body = (await response.json()) as Record<string, unknown>;
+		expect(body.binance).toEqual({
+			type: "binance",
+			params: { symbols: "BTC" },
+			fetchFromModule: "{:symbols}",
+			body: undefined,
+		});
+		expect(body.lighter).toEqual({
+			error: "Failed to handle request: boom",
+			status: 500,
+		});
+	});
+
+	it("rejects requests that exceed maxRequests", async () => {
+		const response = await runMultiEndpoint(
+			{
+				a: { path: "/binance/BTC" },
+				b: { path: "/binance/ETH" },
+			},
+			new Map([["bin", echoHandlers]]),
+			[binanceRoute] as Config["routes"],
+			{ enable: true, path: "multi", maxRequests: 1, concurrency: 1 },
+		);
+
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { error: string };
+		expect(body.error).toContain("maxRequests");
+	});
+
+	it("rejects invalid JSON with 400", async () => {
+		const response = await Effect.runPromise(
+			handleMultiEndpointRequest({
+				serverOptions: { port: 0, disableProof: true },
+				dataProxy: mockDataProxy,
+				headers: {},
+				body: Option.some("{not-json"),
+				path: "/multi",
+				config: baseConfig(),
+				request: new Request("http://localhost/proxy/multi", {
+					method: "POST",
+					body: "{not-json",
+				}),
+				moduleHandlers: new Map(),
+				eligibleRoutes: [],
+				multiEndpoint: {
+					enable: true,
+					path: DEFAULT_MULTI_ENDPOINT_PATH,
+					maxRequests: DEFAULT_MULTI_MAX_REQUESTS,
+					concurrency: DEFAULT_MULTI_CONCURRENCY,
+				},
+			}).pipe(Effect.provide(HttpClientService.Default())),
+		);
+
+		expect(response.status).toBe(400);
+	});
+});

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.test.ts
@@ -6,7 +6,7 @@ import type { Config } from "../../config/config-parser";
 import {
 	DEFAULT_MULTI_CONCURRENCY,
 	DEFAULT_MULTI_ENDPOINT_PATH,
-	DEFAULT_MULTI_MAX_REQUESTS,
+	DEFAULT_MULTI_MAX_SUB_REQUESTS,
 	type MultiEndpoint,
 } from "../../config/multi-endpoint-config";
 import {
@@ -67,7 +67,7 @@ const baseConfig = (): Config => ({
 	multiEndpoint: {
 		enable: false,
 		path: DEFAULT_MULTI_ENDPOINT_PATH,
-		maxRequests: DEFAULT_MULTI_MAX_REQUESTS,
+		maxSubRequests: DEFAULT_MULTI_MAX_SUB_REQUESTS,
 		concurrency: DEFAULT_MULTI_CONCURRENCY,
 	},
 });
@@ -114,7 +114,7 @@ const runMultiEndpoint = async (
 	multiEndpoint: MultiEndpoint = {
 		enable: true,
 		path: DEFAULT_MULTI_ENDPOINT_PATH,
-		maxRequests: DEFAULT_MULTI_MAX_REQUESTS,
+		maxSubRequests: DEFAULT_MULTI_MAX_SUB_REQUESTS,
 		concurrency: DEFAULT_MULTI_CONCURRENCY,
 	},
 	headers: Record<string, string | undefined> = {},
@@ -226,7 +226,7 @@ describe("handleMultiEndpointRequest", () => {
 		});
 	});
 
-	it("captures a module handler failure as an error entry", async () => {
+	it("captures a module handler failure as a sub-request error", async () => {
 		const failing = handlers(() =>
 			Effect.fail(new FailedToHandleRequest({ msg: "boom" })),
 		);
@@ -257,7 +257,7 @@ describe("handleMultiEndpointRequest", () => {
 		});
 	});
 
-	it("rejects requests that exceed maxRequests", async () => {
+	it("rejects requests that exceed maxSubRequests", async () => {
 		const response = await runMultiEndpoint(
 			{
 				a: { path: "/binance/BTC" },
@@ -265,12 +265,12 @@ describe("handleMultiEndpointRequest", () => {
 			},
 			new Map([["bin", echoHandlers]]),
 			[binanceRoute] as Config["routes"],
-			{ enable: true, path: "multi", maxRequests: 1, concurrency: 1 },
+			{ enable: true, path: "multi", maxSubRequests: 1, concurrency: 1 },
 		);
 
 		expect(response.status).toBe(400);
 		const body = (await response.json()) as { error: string };
-		expect(body.error).toContain("maxRequests");
+		expect(body.error).toContain("maxSubRequests");
 	});
 
 	it("rejects invalid JSON with 400", async () => {
@@ -291,7 +291,7 @@ describe("handleMultiEndpointRequest", () => {
 				multiEndpoint: {
 					enable: true,
 					path: DEFAULT_MULTI_ENDPOINT_PATH,
-					maxRequests: DEFAULT_MULTI_MAX_REQUESTS,
+					maxSubRequests: DEFAULT_MULTI_MAX_SUB_REQUESTS,
 					concurrency: DEFAULT_MULTI_CONCURRENCY,
 				},
 			}).pipe(Effect.provide(HttpClientService.Default())),
@@ -300,7 +300,7 @@ describe("handleMultiEndpointRequest", () => {
 		expect(response.status).toBe(400);
 	});
 
-	it("uses body headers and ignores parent request headers", async () => {
+	it("uses sub-request headers and ignores parent request headers", async () => {
 		let seen: Headers | undefined;
 		const capturing = handlers((_route, _params, request) => {
 			seen = request.headers;

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.test.ts
@@ -117,17 +117,27 @@ const runMultiEndpoint = async (
 		maxRequests: DEFAULT_MULTI_MAX_REQUESTS,
 		concurrency: DEFAULT_MULTI_CONCURRENCY,
 	},
+	headers: Record<string, string | undefined> = {},
 ) => {
+	const bodyText = JSON.stringify(body);
 	const params: HandleMultiEndpointRequestParams = {
 		serverOptions: { port: 0, disableProof: true },
 		dataProxy: mockDataProxy,
-		headers: {},
-		body: Option.some(JSON.stringify(body)),
+		headers: {
+			"content-type": "application/json",
+			"content-length": String(bodyText.length),
+			...headers,
+		},
+		body: Option.some(bodyText),
 		path: "/multi",
 		config: baseConfig(),
 		request: new Request("http://localhost/proxy/multi", {
 			method: "POST",
-			body: JSON.stringify(body),
+			headers: {
+				"content-type": "application/json",
+				"content-length": String(bodyText.length),
+			},
+			body: bodyText,
 		}),
 		moduleHandlers,
 		eligibleRoutes,
@@ -288,5 +298,34 @@ describe("handleMultiEndpointRequest", () => {
 		);
 
 		expect(response.status).toBe(400);
+	});
+
+	it("uses body headers and ignores parent request headers", async () => {
+		let seen: Headers | undefined;
+		const capturing = handlers((_route, _params, request) => {
+			seen = request.headers;
+			return Effect.succeed(
+				new Response(JSON.stringify({ ok: true }), { status: 200 }),
+			);
+		});
+
+		const response = await runMultiEndpoint(
+			{
+				binance: {
+					path: "/binance/BTC",
+					headers: { "x-custom": "from-body" },
+				},
+			},
+			new Map([["bin", capturing]]),
+			[binanceRoute] as Config["routes"],
+			undefined,
+			{ "x-custom": "from-parent", "user-agent": "curl/8.7.1" },
+		);
+
+		expect(response.status).toBe(200);
+		expect(seen?.get("content-length")).toBeNull();
+		expect(seen?.get("content-type")).toBeNull();
+		expect(seen?.get("user-agent")).toBeNull();
+		expect(seen?.get("x-custom")).toBe("from-body");
 	});
 });

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.ts
@@ -1,0 +1,301 @@
+import type { DataProxy } from "@seda-protocol/data-proxy-sdk";
+import { tryParseSync } from "@seda-protocol/utils";
+import { Effect, Either, Option } from "effect";
+import { type Config, getHttpMethods } from "../../config/config-parser";
+import {
+	type MultiEndpoint,
+	type MultiEndpointRequest,
+	type MultiEndpointRequestBody,
+	MultiEndpointRequestBodySchema,
+} from "../../config/multi-endpoint-config";
+import type { ModuleHandlers } from "../../modules/module";
+import type { ProxyServerOptions } from "../../proxy-server";
+import { createSignedResponseHeaders } from "../../utils/create-headers";
+import { maybeToOption } from "../../utils/effect-utils";
+import { matchRoutePath } from "../../utils/match-route-path";
+import { createErrorResponse } from "../create-error-response";
+import { executeRoute } from "./execute-route";
+import { verifyProof } from "./verify-proof";
+
+export type HandleMultiEndpointRequestParams = {
+	serverOptions: ProxyServerOptions;
+	dataProxy: DataProxy;
+	headers: Record<string, string | undefined>;
+	body: Option.Option<string>;
+	path: string;
+	config: Config;
+	request: Request;
+	moduleHandlers: ReadonlyMap<string, ModuleHandlers>;
+	eligibleRoutes: Readonly<Config["routes"]>;
+	multiEndpoint: MultiEndpoint;
+};
+
+const createBadRequestResponse = (error: string) =>
+	new Response(JSON.stringify({ error }), {
+		status: 400,
+		headers: { "Content-Type": "application/json" },
+	});
+
+const serializeRequestBody = (body: unknown): string | undefined => {
+	if (body === undefined) {
+		return undefined;
+	}
+	if (typeof body === "string") {
+		return body;
+	}
+	return JSON.stringify(body);
+};
+
+const findMatchingRoute = (
+	eligibleRoutes: Readonly<Config["routes"]>,
+	path: string,
+	method: string,
+): {
+	route: Config["routes"][number];
+	params: Record<string, string>;
+} | null => {
+	const normalizedMethod = method.toUpperCase();
+
+	for (const route of eligibleRoutes) {
+		// Check if the route supports the requested method.
+		const methods = getHttpMethods(route.method).map((m) => m.toUpperCase());
+		if (!methods.includes(normalizedMethod as (typeof methods)[number])) {
+			continue;
+		}
+
+		// Check if the route matches the requested path.
+		const params = matchRoutePath(route.path, path);
+		if (params !== null) {
+			return { route, params };
+		}
+	}
+
+	return null;
+};
+
+const buildRequest = (
+	parent: Request,
+	entry: MultiEndpointRequest,
+	body: string | undefined,
+): Request => {
+	const url = new URL(parent.url);
+	// Entry paths are route paths (e.g. /binance/BTC), not including the outer
+	// multi endpoint path. Keep the parent origin; replace path + query.
+	const pathname = entry.path.startsWith("/") ? entry.path : `/${entry.path}`;
+	url.pathname = pathname;
+	url.search = "";
+
+	if (entry.query) {
+		for (const [key, value] of Object.entries(entry.query)) {
+			if (Array.isArray(value)) {
+				for (const valueEntry of value) {
+					url.searchParams.append(key, valueEntry);
+				}
+			} else {
+				url.searchParams.set(key, value);
+			}
+		}
+	}
+
+	const init: RequestInit = {
+		method: entry.method.toUpperCase(),
+		headers: parent.headers,
+	};
+
+	if (body !== undefined && init.method !== "GET" && init.method !== "HEAD") {
+		init.body = body;
+	}
+
+	return new Request(url, init);
+};
+
+const runRequest = (
+	entry: MultiEndpointRequest,
+	params: HandleMultiEndpointRequestParams,
+) =>
+	Effect.gen(function* () {
+		const method = entry.method.toUpperCase();
+		const matched = findMatchingRoute(
+			params.eligibleRoutes,
+			entry.path,
+			method,
+		);
+
+		if (!matched) {
+			return {
+				error: `No configured route matches ${method} ${entry.path}`,
+				status: 404,
+			};
+		}
+
+		// Defense in depth: eligibleRoutes already excludes type "multi", but
+		// nesting a multi route would re-enter fan-out without a clear bound.
+		// TODO(#162): Adjust once legacy multi routes are deprecated.
+		if (matched.route.type === "multi") {
+			return {
+				error:
+					"Nesting a multi route in the multi endpoint is not supported; reference the underlying module routes instead",
+				status: 400,
+			};
+		}
+
+		const bodyText = serializeRequestBody(entry.body);
+		const request = buildRequest(params.request, entry, bodyText);
+		const requestHeaders: Record<string, string | undefined> = {
+			...params.headers,
+		};
+
+		const result = yield* Effect.either(
+			executeRoute({
+				route: matched.route,
+				params: matched.params,
+				request,
+				headers: requestHeaders,
+				body: Option.fromNullable(bodyText),
+				moduleHandlers: params.moduleHandlers,
+				routePath: matched.route.path,
+			}),
+		);
+
+		if (Either.isLeft(result)) {
+			const error = result.left;
+			const status =
+				"status" in error && typeof error.status === "number"
+					? error.status
+					: 500;
+			const body =
+				"body" in error && typeof error.body === "string"
+					? error.body
+					: undefined;
+
+			return {
+				error: error.message,
+				status,
+				...(body !== undefined ? { body } : {}),
+			};
+		}
+
+		try {
+			return result.right.responseData.length > 0
+				? JSON.parse(result.right.responseData)
+				: null;
+		} catch {
+			return result.right.responseData;
+		}
+	});
+
+export const handleMultiEndpointRequest = (
+	inputParams: HandleMultiEndpointRequestParams,
+) =>
+	Effect.gen(function* () {
+		const {
+			serverOptions,
+			headers,
+			body,
+			path,
+			config,
+			request,
+			dataProxy,
+			multiEndpoint,
+		} = inputParams;
+
+		if (!serverOptions.disableProof) {
+			yield* verifyProof({ headers, config, dataProxy });
+		} else {
+			yield* Effect.logDebug("Skipping proof verification.");
+		}
+
+		const rawBody = Option.getOrElse(body, () => "");
+		let parsedJson: unknown;
+		try {
+			parsedJson = rawBody.length > 0 ? JSON.parse(rawBody) : null;
+		} catch {
+			return createBadRequestResponse(
+				"Multi endpoint request body must be valid JSON",
+			);
+		}
+
+		const parsedBody = tryParseSync(MultiEndpointRequestBodySchema, parsedJson);
+		if (parsedBody.isErr) {
+			return createBadRequestResponse(
+				parsedBody.error
+					.map((err) => {
+						const key = err.path?.reduce((p, segment) => {
+							return p.concat(".", segment.key as string);
+						}, "");
+						return `${key}: ${err.message}`;
+					})
+					.join("; "),
+			);
+		}
+
+		const multiBody: MultiEndpointRequestBody = parsedBody.value;
+		const requestEntries = Object.entries(multiBody);
+
+		if (requestEntries.length > multiEndpoint.maxRequests) {
+			return createBadRequestResponse(
+				`Request exceeds maxRequests (${multiEndpoint.maxRequests}): got ${requestEntries.length}`,
+			);
+		}
+
+		// Run each request concurrently; results align with requestEntries order.
+		const results = yield* Effect.forEach(
+			requestEntries,
+			([, entry]) => runRequest(entry, inputParams),
+			{ concurrency: multiEndpoint.concurrency },
+		);
+
+		const combined = Object.fromEntries(
+			requestEntries.map(([id], i) => [id, results[i]]),
+		);
+
+		const responseData = JSON.stringify(combined);
+
+		const calledEndpoint = maybeToOption(config.baseURL).pipe(
+			Option.map((t) => {
+				const pathIndex = request.url.indexOf(path);
+				return pathIndex >= 0
+					? `${t}${request.url.slice(pathIndex)}`
+					: `${t}${path}`;
+			}),
+			Option.getOrElse(() => request.url),
+		);
+
+		yield* Effect.logDebug("Signing multi endpoint data", {
+			calledEndpoint,
+			method: request.method,
+			body: rawBody,
+			responseData,
+		});
+
+		const signature = yield* dataProxy.signData(
+			calledEndpoint,
+			request.method,
+			Buffer.from(rawBody, "utf-8"),
+			Buffer.from(responseData, "utf-8"),
+		);
+
+		return new Response(responseData, {
+			headers: createSignedResponseHeaders(signature),
+		});
+	}).pipe(
+		Effect.withSpan("handleMultiEndpointRequest"),
+		Effect.tapError((error) =>
+			Effect.logError(error.message, {
+				headers: inputParams.headers,
+				body: Option.getOrUndefined(inputParams.body),
+				path: inputParams.path,
+				method: inputParams.request.method,
+				requestUrl: inputParams.request.url,
+			}),
+		),
+		// Per-request failures are captured per-id above; only proof/signing
+		// errors surface on the outer effect.
+		Effect.catchTags({
+			VerifyProofError: (error) =>
+				Effect.succeed(createErrorResponse(error, 400)),
+			IneligibleProofError: (error) =>
+				Effect.succeed(createErrorResponse(error, 401)),
+			UnknownError: (error) => Effect.succeed(createErrorResponse(error, 500)),
+		}),
+	);

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.ts
@@ -76,6 +76,7 @@ const findMatchingRoute = (
 const buildRequest = (
 	parent: Request,
 	entry: MultiEndpointRequest,
+	headers: Record<string, string>,
 	body: string | undefined,
 ): Request => {
 	const url = new URL(parent.url);
@@ -99,7 +100,7 @@ const buildRequest = (
 
 	const init: RequestInit = {
 		method: entry.method.toUpperCase(),
-		headers: parent.headers,
+		headers,
 	};
 
 	if (body !== undefined && init.method !== "GET" && init.method !== "HEAD") {
@@ -140,10 +141,13 @@ const runRequest = (
 		}
 
 		const bodyText = serializeRequestBody(entry.body);
-		const request = buildRequest(params.request, entry, bodyText);
-		const requestHeaders: Record<string, string | undefined> = {
-			...params.headers,
-		};
+		const requestHeaders = entry.headers;
+		const request = buildRequest(
+			params.request,
+			entry,
+			requestHeaders,
+			bodyText,
+		);
 
 		const result = yield* Effect.either(
 			executeRoute({
@@ -151,7 +155,10 @@ const runRequest = (
 				params: matched.params,
 				request,
 				headers: requestHeaders,
-				body: Option.fromNullable(bodyText),
+				body:
+					bodyText !== undefined && method !== "GET" && method !== "HEAD"
+						? Option.some(bodyText)
+						: Option.none(),
 				moduleHandlers: params.moduleHandlers,
 				routePath: matched.route.path,
 			}),

--- a/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-multi-endpoint-request.ts
@@ -4,9 +4,9 @@ import { Effect, Either, Option } from "effect";
 import { type Config, getHttpMethods } from "../../config/config-parser";
 import {
 	type MultiEndpoint,
-	type MultiEndpointRequest,
 	type MultiEndpointRequestBody,
 	MultiEndpointRequestBodySchema,
+	type MultiEndpointSubRequest,
 } from "../../config/multi-endpoint-config";
 import type { ModuleHandlers } from "../../modules/module";
 import type { ProxyServerOptions } from "../../proxy-server";
@@ -73,21 +73,23 @@ const findMatchingRoute = (
 	return null;
 };
 
-const buildRequest = (
+const buildSubRequest = (
 	parent: Request,
-	entry: MultiEndpointRequest,
+	subRequest: MultiEndpointSubRequest,
 	headers: Record<string, string>,
 	body: string | undefined,
 ): Request => {
 	const url = new URL(parent.url);
-	// Entry paths are route paths (e.g. /binance/BTC), not including the outer
-	// multi endpoint path. Keep the parent origin; replace path + query.
-	const pathname = entry.path.startsWith("/") ? entry.path : `/${entry.path}`;
+	// Sub-request paths are route paths (e.g. /binance/BTC), not including the
+	// outer multi endpoint path. Keep the parent origin; replace path + query.
+	const pathname = subRequest.path.startsWith("/")
+		? subRequest.path
+		: `/${subRequest.path}`;
 	url.pathname = pathname;
 	url.search = "";
 
-	if (entry.query) {
-		for (const [key, value] of Object.entries(entry.query)) {
+	if (subRequest.query) {
+		for (const [key, value] of Object.entries(subRequest.query)) {
 			if (Array.isArray(value)) {
 				for (const valueEntry of value) {
 					url.searchParams.append(key, valueEntry);
@@ -99,7 +101,7 @@ const buildRequest = (
 	}
 
 	const init: RequestInit = {
-		method: entry.method.toUpperCase(),
+		method: subRequest.method.toUpperCase(),
 		headers,
 	};
 
@@ -110,21 +112,21 @@ const buildRequest = (
 	return new Request(url, init);
 };
 
-const runRequest = (
-	entry: MultiEndpointRequest,
+const runSubRequest = (
+	subRequest: MultiEndpointSubRequest,
 	params: HandleMultiEndpointRequestParams,
 ) =>
 	Effect.gen(function* () {
-		const method = entry.method.toUpperCase();
+		const method = subRequest.method.toUpperCase();
 		const matched = findMatchingRoute(
 			params.eligibleRoutes,
-			entry.path,
+			subRequest.path,
 			method,
 		);
 
 		if (!matched) {
 			return {
-				error: `No configured route matches ${method} ${entry.path}`,
+				error: `No configured route matches ${method} ${subRequest.path}`,
 				status: 404,
 			};
 		}
@@ -140,11 +142,11 @@ const runRequest = (
 			};
 		}
 
-		const bodyText = serializeRequestBody(entry.body);
-		const requestHeaders = entry.headers;
-		const request = buildRequest(
+		const bodyText = serializeRequestBody(subRequest.body);
+		const requestHeaders = subRequest.headers;
+		const request = buildSubRequest(
 			params.request,
-			entry,
+			subRequest,
 			requestHeaders,
 			bodyText,
 		);
@@ -237,23 +239,24 @@ export const handleMultiEndpointRequest = (
 		}
 
 		const multiBody: MultiEndpointRequestBody = parsedBody.value;
-		const requestEntries = Object.entries(multiBody);
+		const subRequestEntries = Object.entries(multiBody);
 
-		if (requestEntries.length > multiEndpoint.maxRequests) {
+		if (subRequestEntries.length > multiEndpoint.maxSubRequests) {
 			return createBadRequestResponse(
-				`Request exceeds maxRequests (${multiEndpoint.maxRequests}): got ${requestEntries.length}`,
+				`Request exceeds maxSubRequests (${multiEndpoint.maxSubRequests}): got ${subRequestEntries.length}`,
 			);
 		}
 
-		// Run each request concurrently; results align with requestEntries order.
+		// Run each sub-request concurrently; results align with
+		// subRequestEntries order.
 		const results = yield* Effect.forEach(
-			requestEntries,
-			([, entry]) => runRequest(entry, inputParams),
+			subRequestEntries,
+			([, subRequest]) => runSubRequest(subRequest, inputParams),
 			{ concurrency: multiEndpoint.concurrency },
 		);
 
 		const combined = Object.fromEntries(
-			requestEntries.map(([id], i) => [id, results[i]]),
+			subRequestEntries.map(([id], i) => [id, results[i]]),
 		);
 
 		const responseData = JSON.stringify(combined);
@@ -296,7 +299,7 @@ export const handleMultiEndpointRequest = (
 				requestUrl: inputParams.request.url,
 			}),
 		),
-		// Per-request failures are captured per-id above; only proof/signing
+		// Per-sub-request failures are captured per-id above; only proof/signing
 		// errors surface on the outer effect.
 		Effect.catchTags({
 			VerifyProofError: (error) =>

--- a/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-proxy-request.ts
@@ -1,25 +1,15 @@
-import { constants, type DataProxy } from "@seda-protocol/data-proxy-sdk";
-import { Effect, Match, Option } from "effect";
+import type { DataProxy } from "@seda-protocol/data-proxy-sdk";
+import { Effect, Option } from "effect";
 import type { Config } from "../../config/config-parser";
-import { HAS_PRICE_KEY, JSON_PATH_HEADER_KEY } from "../../constants";
-import {
-	FailedToParseResponseBodyError,
-	NotOkUpstreamResponseError,
-	QueryJsonError,
-	UpstreamRequestFailedError,
-} from "../../errors";
+import { JSON_PATH_HEADER_KEY } from "../../constants";
+import { QueryJsonError } from "../../errors";
 import type { ModuleHandlers } from "../../modules/module";
-import { ModuleService } from "../../modules/module";
 import type { ProxyServerOptions } from "../../proxy-server";
-import { HttpClientService } from "../../services/http-client";
 import { createSignedResponseHeaders } from "../../utils/create-headers";
 import { maybeToOption } from "../../utils/effect-utils";
 import { queryJson } from "../../utils/query-json";
-import { replaceParams } from "../../utils/replace-params";
-import { createUrlSearchParams } from "../../utils/search-params";
-import { injectSearchParamsInUrl } from "../../utils/url";
 import { createErrorResponse } from "../create-error-response";
-import { handleMultiRequest } from "./handle-multi-request";
+import { executeRoute } from "./execute-route";
 import { verifyProof } from "./verify-proof";
 
 export type HandleProxyRequestParams = {
@@ -40,9 +30,6 @@ export type HandleProxyRequestParams = {
 
 export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 	Effect.gen(function* () {
-		const httpClient = yield* HttpClientService;
-		const moduleService = yield* ModuleService;
-
 		const {
 			serverOptions,
 			headers,
@@ -62,294 +49,17 @@ export const handleProxyRequest = (inputParams: HandleProxyRequestParams) =>
 			yield* Effect.logDebug("Skipping proof verification.");
 		}
 
-		// Parse the request URL to get the search params,
-		// this is to support query params that can be repeated, such as ?one=one&one=two
-		const requestUrl = new URL(request.url);
-		// Add the request search params (?one=two) to the upstream url
-		const requestSearchParams = createUrlSearchParams(
-			requestUrl.searchParams,
-			route.allowedQueryParams,
-		);
-
-		const upstreamResponse = yield* Match.value(route).pipe(
-			Match.when({ type: "pyth-lazer" }, (pythLazerModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling Pyth Lazer request");
-					return yield* moduleService.handleRequest(
-						pythLazerModuleRoute,
-						params,
-						request,
-					);
-				}),
-			),
-			Match.when({ type: "chainlink-streams" }, (chainlinkStreamsModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling Chainlink Streams request");
-					return yield* moduleService.handleRequest(
-						chainlinkStreamsModuleRoute,
-						params,
-						request,
-					);
-				}),
-			),
-			Match.when({ type: "dxfeed" }, (dxFeedModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling dxFeed request");
-					return yield* moduleService.handleRequest(
-						dxFeedModuleRoute,
-						params,
-						request,
-					);
-				}),
-			),
-			Match.when({ type: "hydromancer" }, (hydromancerModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling Hydromancer request");
-					return yield* moduleService.handleRequest(
-						hydromancerModuleRoute,
-						params,
-						request,
-						Option.getOrElse(body, () => ""),
-					);
-				}),
-			),
-			Match.when({ type: "lo-tech" }, (loTechModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling LO:TECH request");
-					return yield* moduleService.handleRequest(
-						loTechModuleRoute,
-						params,
-						request,
-					);
-				}),
-			),
-			Match.when({ type: "volmex" }, (volmexModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling Volmex request");
-					return yield* moduleService.handleRequest(
-						volmexModuleRoute,
-						params,
-						request,
-					);
-				}),
-			),
-			Match.when({ type: "pm-insights" }, (pmInsightsModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling PM Insights request");
-					return yield* moduleService.handleRequest(
-						pmInsightsModuleRoute,
-						params,
-						request,
-					);
-				}),
-			),
-			Match.when({ type: "binance" }, (binanceModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling Binance request");
-					return yield* moduleService.handleRequest(
-						binanceModuleRoute,
-						params,
-						request,
-					);
-				}),
-			),
-			Match.when({ type: "lighter" }, (lighterModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling Lighter request");
-					return yield* moduleService.handleRequest(
-						lighterModuleRoute,
-						params,
-						request,
-					);
-				}),
-			),
-			Match.when({ type: "multi" }, (multiModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling multi request");
-					return yield* handleMultiRequest(
-						multiModuleRoute,
-						params,
-						request,
-						moduleHandlers,
-					);
-				}),
-			),
-			Match.when({ type: "upstream" }, (upstreamModuleRoute) =>
-				Effect.gen(function* () {
-					yield* Effect.logDebug("Handling upstream request");
-					const upstreamHeaders = new Headers();
-
-					const url = replaceParams(upstreamModuleRoute.upstreamUrl, params);
-
-					const upstreamUrl = yield* injectSearchParamsInUrl(
-						url,
-						requestSearchParams,
-					).pipe(Effect.map((url) => url.toString()));
-
-					// Forward all headers sent by the requester
-					for (const [key, value] of Object.entries(headers)) {
-						if (!value || key === constants.PROOF_HEADER_KEY) {
-							continue;
-						}
-						upstreamHeaders.append(key, value);
-					}
-
-					// Inject all configured headers by the data proxy node configuration
-					// Important: configured headers take precedence over headers sent in the request
-					for (const [key, value] of Object.entries(
-						upstreamModuleRoute.headers,
-					)) {
-						upstreamHeaders.set(key, replaceParams(value, params));
-					}
-
-					// Host doesn't match since we are proxying. Returning the upstream host while the URL does not match results
-					// in the client to not return the response.
-					upstreamHeaders.delete("host");
-
-					yield* Effect.logDebug(`Fetching ${upstreamUrl}..`, {
-						headers: upstreamHeaders,
-						body: Option.getOrUndefined(body),
-						upstreamUrl,
-					});
-
-					// Fetch the upstream response and process
-					const upstreamResponse = yield* httpClient
-						.request(upstreamUrl, {
-							method: request.method,
-							headers: upstreamHeaders,
-							body: Option.getOrUndefined(body),
-						})
-						.pipe(
-							Effect.tapError((error) =>
-								Effect.logError("Upstream HTTP request failed", {
-									routePath: path,
-									method: request.method,
-									clientRequestUrl: request.url,
-									upstreamRequestUrl: upstreamUrl,
-									upstreamRequestHeaders: upstreamHeaders,
-									routeParams: params,
-									requestBody: Option.getOrUndefined(body),
-								}),
-							),
-							Effect.mapError(
-								(error) =>
-									new UpstreamRequestFailedError({ error, routePath: path }),
-							),
-						);
-
-					return upstreamResponse;
-				}),
-			),
-			Match.exhaustive,
-		);
-
-		if (!upstreamResponse.ok) {
-			const upstreamResponseBody = yield* httpClient
-				.parseBodyAsText(upstreamResponse)
-				.pipe(
-					// Attach the status to the error.
-					Effect.mapError(
-						(error) =>
-							new FailedToParseResponseBodyError({
-								error: error.message,
-								status: upstreamResponse.status,
-							}),
-					),
-				)
-				.pipe(
-					Effect.tapError((error) =>
-						Effect.logError(
-							`Upstream response body parsing failed with status: ${upstreamResponse.status} err: ${error}`,
-							{
-								routePath: path,
-								method: request.method,
-								clientRequestUrl: request.url,
-								upstreamResponseUrl: upstreamResponse.url,
-								routeParams: params,
-								requestBody: Option.getOrUndefined(body),
-							},
-						),
-					),
-				);
-
-			yield* Effect.logError(
-				`Upstream response for route ${path} is not ok: ${upstreamResponse.status} body: ${upstreamResponseBody}`,
-				{
-					requestBody: Option.getOrUndefined(body),
-					method: request.method,
-					upstreamUrl: upstreamResponse.url,
-				},
-			);
-
-			return yield* Effect.fail(
-				new NotOkUpstreamResponseError({
-					status: upstreamResponse.status,
-					body: upstreamResponseBody,
-					routePath: path,
-				}),
-			);
-		}
-
-		yield* Effect.logDebug("Received upstream response", {
-			headers: upstreamResponse.headers,
+		let { responseData, upstreamResponse } = yield* executeRoute({
+			route,
+			params,
+			request,
+			headers,
+			body,
+			moduleHandlers,
+			routePath: path,
 		});
 
-		const upstreamTextResponse = yield* httpClient
-			.parseBodyAsText(upstreamResponse)
-			.pipe(
-				Effect.mapError(
-					(error) =>
-						new FailedToParseResponseBodyError({
-							error: error.message,
-							status: upstreamResponse.status,
-						}),
-				),
-			);
-
-		// Now we are going to handle jsonPath filtering if configured
-		let responseData: string = upstreamTextResponse;
-
-		// TEMP: This is added for older ops who may not handle __sedaHasPrice key in the response.
-		// we should remove this once all ops have updated to the new response format.
-		// Multi routes return arbitrary per-source payloads where a per-source miss
-		// is expected, so the price gate does not apply.
-		if (route.type !== "multi" && !requestSearchParams.has("skipPriceErrors")) {
-			if (upstreamTextResponse.includes(`"${HAS_PRICE_KEY}":false`)) {
-				return yield* Effect.fail(
-					new NotOkUpstreamResponseError({
-						status: 500,
-						body: `Not all symbols have a price: ${upstreamTextResponse}`,
-						routePath: path,
-					}),
-				);
-			}
-		}
-
-		if (route.jsonPath) {
-			yield* Effect.logDebug(`Applying route JSONpath ${route.jsonPath}`);
-			const data = yield* queryJson(
-				upstreamTextResponse,
-				route.jsonPath,
-				route.useLegacyJsonPath,
-			).pipe(
-				Effect.annotateSpans("type", "route-config"),
-				Effect.mapError(
-					(error) =>
-						new QueryJsonError({
-							error: error.message,
-							data: error.data,
-							type: "config",
-							status: 500,
-						}),
-				),
-			);
-			responseData = JSON.stringify(data);
-			yield* Effect.logDebug("Successfully applied route JSONpath");
-		}
-
-		// Now we are going to handle jsonPath filtering if configured in the request header (by the user)
-		// We apply the JSON path to the data that's exposed by the data proxy.
-		// This allows operators to specify what data is accessible while the data request program can specify what it wants from the accessible data.
+		// Apply header-based JSON path if provided.
 		const jsonPathRequestHeader = Option.fromNullable(
 			headers[JSON_PATH_HEADER_KEY],
 		);

--- a/workspace/data-proxy/src/controllers/proxy/handle-upstream-request.ts
+++ b/workspace/data-proxy/src/controllers/proxy/handle-upstream-request.ts
@@ -1,0 +1,88 @@
+import { constants } from "@seda-protocol/data-proxy-sdk";
+import { Effect, Option } from "effect";
+import type { UpstreamModuleRoute } from "../../config/upstream-module-config";
+import { UpstreamRequestFailedError } from "../../errors";
+import { HttpClientService } from "../../services/http-client";
+import { replaceParams } from "../../utils/replace-params";
+import { injectSearchParamsInUrl } from "../../utils/url";
+
+export type HandleUpstreamRequestParams = {
+	route: UpstreamModuleRoute;
+	params: Record<string, string>;
+	headers: Record<string, string | undefined>;
+	body: Option.Option<string>;
+	request: Request;
+	routePath: string;
+	requestSearchParams: URLSearchParams;
+};
+
+// Builds the upstream URL/headers and fetches. Configured route headers win over
+// forwarded request headers; `host` is dropped so the client accepts the proxy response.
+export const handleUpstreamRequest = ({
+	route,
+	params,
+	headers,
+	body,
+	request,
+	routePath,
+	requestSearchParams,
+}: HandleUpstreamRequestParams) =>
+	Effect.gen(function* () {
+		yield* Effect.logDebug("Handling upstream request");
+		const httpClient = yield* HttpClientService;
+		const upstreamHeaders = new Headers();
+
+		const url = replaceParams(route.upstreamUrl, params);
+
+		const upstreamUrl = yield* injectSearchParamsInUrl(
+			url,
+			requestSearchParams,
+		).pipe(Effect.map((parsedUrl) => parsedUrl.toString()));
+
+		// Forward all headers sent by the requester
+		for (const [key, value] of Object.entries(headers)) {
+			if (!value || key === constants.PROOF_HEADER_KEY) {
+				continue;
+			}
+			upstreamHeaders.append(key, value);
+		}
+
+		// Inject all configured headers by the data proxy node configuration
+		// Important: configured headers take precedence over headers sent in the request
+		for (const [key, value] of Object.entries(route.headers)) {
+			upstreamHeaders.set(key, replaceParams(value, params));
+		}
+
+		// Host doesn't match since we are proxying. Returning the upstream host while the URL does not match results
+		// in the client to not return the response.
+		upstreamHeaders.delete("host");
+
+		yield* Effect.logDebug(`Fetching ${upstreamUrl}..`, {
+			headers: upstreamHeaders,
+			body: Option.getOrUndefined(body),
+			upstreamUrl,
+		});
+
+		return yield* httpClient
+			.request(upstreamUrl, {
+				method: request.method,
+				headers: upstreamHeaders,
+				body: Option.getOrUndefined(body),
+			})
+			.pipe(
+				Effect.tapError(() =>
+					Effect.logError("Upstream HTTP request failed", {
+						routePath,
+						method: request.method,
+						clientRequestUrl: request.url,
+						upstreamRequestUrl: upstreamUrl,
+						upstreamRequestHeaders: upstreamHeaders,
+						routeParams: params,
+						requestBody: Option.getOrUndefined(body),
+					}),
+				),
+				Effect.mapError(
+					(error) => new UpstreamRequestFailedError({ error, routePath }),
+				),
+			);
+	});

--- a/workspace/data-proxy/src/controllers/proxy/verify-proof.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/verify-proof.test.ts
@@ -26,6 +26,12 @@ const fastOnlyConfig: Config = {
 	routeGroup: DEFAULT_PROXY_ROUTE_GROUP,
 	baseURL: Maybe.nothing(),
 	statusEndpoints: { root: "status" },
+	multiEndpoint: {
+		enable: false,
+		path: "multi",
+		maxRequests: 20,
+		concurrency: 5,
+	},
 };
 
 describe("verifyProof", () => {

--- a/workspace/data-proxy/src/controllers/proxy/verify-proof.test.ts
+++ b/workspace/data-proxy/src/controllers/proxy/verify-proof.test.ts
@@ -29,7 +29,7 @@ const fastOnlyConfig: Config = {
 	multiEndpoint: {
 		enable: false,
 		path: "multi",
-		maxRequests: 20,
+		maxSubRequests: 20,
 		concurrency: 5,
 	},
 };

--- a/workspace/data-proxy/src/proxy-server.test.ts
+++ b/workspace/data-proxy/src/proxy-server.test.ts
@@ -945,5 +945,72 @@ describe("proxy server", () => {
 				b: { venue: "b", price: 2 },
 			});
 		});
+
+		it("fans out to a trailing wildcard upstream route", async () => {
+			const coffee = registerHandler("get", "/api/coffee/hot", async () =>
+				HttpResponse.json({ title: "latte" }),
+			);
+
+			await Effect.runPromise(
+				startProxyServer(
+					{
+						verificationMaxRetries: 2,
+						verificationRetryDelay: 1000,
+						routeGroup: "",
+						modules: [],
+						sedaFast: {
+							enable: true,
+							maxProofAgeMs: 1000,
+							allowedClients: [],
+						},
+						statusEndpoints: {
+							root: "status",
+						},
+						multiEndpoint: {
+							enable: true,
+							path: "multi",
+							maxRequests: 20,
+							concurrency: 5,
+						},
+						baseURL: Maybe.nothing(),
+						routes: [
+							{
+								baseURL: Maybe.nothing(),
+								method: "GET",
+								path: "/api/*",
+								upstreamUrl: "https://proxy-upstream.com/api/{*}",
+								forwardResponseHeaders: new Set([]),
+								headers: {},
+								type: "upstream",
+								moduleName: "upstream",
+								useLegacyJsonPath: true,
+							},
+						],
+						fastOnly: false,
+					},
+					dataProxy,
+					{
+						disableProof: true,
+						port: coffee.port,
+					},
+				)
+					.pipe(Effect.scoped)
+					.pipe(Effect.provide(HttpClientService.Default()))
+					.pipe(Logger.withMinimumLogLevel(LogLevel.None)),
+			);
+
+			const response = await fetch(`http://localhost:${coffee.port}/multi`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					coffee: { path: "/api/coffee/hot" },
+				}),
+			});
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({
+				coffee: { title: "latte" },
+			});
+		});
 	});
 });

--- a/workspace/data-proxy/src/proxy-server.test.ts
+++ b/workspace/data-proxy/src/proxy-server.test.ts
@@ -69,6 +69,12 @@ describe("proxy server", () => {
 					statusEndpoints: {
 						root: "status",
 					},
+					multiEndpoint: {
+						enable: false,
+						path: "multi",
+						maxRequests: 20,
+						concurrency: 5,
+					},
 					baseURL: Maybe.nothing(),
 					routes: [
 						{
@@ -132,6 +138,12 @@ describe("proxy server", () => {
 					statusEndpoints: {
 						root: "status",
 					},
+					multiEndpoint: {
+						enable: false,
+						path: "multi",
+						maxRequests: 20,
+						concurrency: 5,
+					},
 					baseURL: Maybe.nothing(),
 					routes: [
 						{
@@ -191,6 +203,12 @@ describe("proxy server", () => {
 						},
 						statusEndpoints: {
 							root: "status",
+						},
+						multiEndpoint: {
+							enable: false,
+							path: "multi",
+							maxRequests: 20,
+							concurrency: 5,
 						},
 						baseURL: Maybe.of("https://seda-data-proxy.com"),
 						routes: [
@@ -265,6 +283,12 @@ describe("proxy server", () => {
 						},
 						statusEndpoints: {
 							root: "status",
+						},
+						multiEndpoint: {
+							enable: false,
+							path: "multi",
+							maxRequests: 20,
+							concurrency: 5,
 						},
 						baseURL: Maybe.of("https://seda-data-proxy.com"),
 						routes: [
@@ -344,6 +368,12 @@ describe("proxy server", () => {
 						statusEndpoints: {
 							root: "status",
 						},
+						multiEndpoint: {
+							enable: false,
+							path: "multi",
+							maxRequests: 20,
+							concurrency: 5,
+						},
 						baseURL: Maybe.nothing(),
 						routes: [
 							{
@@ -415,6 +445,12 @@ describe("proxy server", () => {
 						statusEndpoints: {
 							root: "status",
 						},
+						multiEndpoint: {
+							enable: false,
+							path: "multi",
+							maxRequests: 20,
+							concurrency: 5,
+						},
 						baseURL: Maybe.nothing(),
 						routes: [
 							{
@@ -485,6 +521,12 @@ describe("proxy server", () => {
 					},
 					statusEndpoints: {
 						root: "status",
+					},
+					multiEndpoint: {
+						enable: false,
+						path: "multi",
+						maxRequests: 20,
+						concurrency: 5,
 					},
 					baseURL: Maybe.nothing(),
 					routes: [
@@ -562,6 +604,12 @@ describe("proxy server", () => {
 						},
 						statusEndpoints: {
 							root: "status",
+						},
+						multiEndpoint: {
+							enable: false,
+							path: "multi",
+							maxRequests: 20,
+							concurrency: 5,
 						},
 						baseURL: Maybe.nothing(),
 						routes: [
@@ -657,6 +705,12 @@ describe("proxy server", () => {
 						statusEndpoints: {
 							root: "status",
 						},
+						multiEndpoint: {
+							enable: false,
+							path: "multi",
+							maxRequests: 20,
+							concurrency: 5,
+						},
 						baseURL: Maybe.nothing(),
 						routes: [
 							{
@@ -730,6 +784,12 @@ describe("proxy server", () => {
 								secret: "secret",
 							},
 						},
+						multiEndpoint: {
+							enable: false,
+							path: "multi",
+							maxRequests: 20,
+							concurrency: 5,
+						},
 						baseURL: Maybe.nothing(),
 						routes: [
 							{
@@ -797,6 +857,92 @@ describe("proxy server", () => {
 					requests: 0,
 					errors: 0,
 				},
+			});
+		});
+	});
+
+	describe("multi endpoint", () => {
+		it("fans out POST /multi to configured upstream routes by path", async () => {
+			const a = registerHandler("get", "/prices/a", async () =>
+				HttpResponse.json({ venue: "a", price: 1 }),
+			);
+			const b = registerHandler("get", "/prices/b", async () =>
+				HttpResponse.json({ venue: "b", price: 2 }),
+			);
+
+			await Effect.runPromise(
+				startProxyServer(
+					{
+						verificationMaxRetries: 2,
+						verificationRetryDelay: 1000,
+						routeGroup: "",
+						modules: [],
+						sedaFast: {
+							enable: true,
+							maxProofAgeMs: 1000,
+							allowedClients: [],
+						},
+						statusEndpoints: {
+							root: "status",
+						},
+						multiEndpoint: {
+							enable: true,
+							path: "multi",
+							maxRequests: 20,
+							concurrency: 5,
+						},
+						baseURL: Maybe.nothing(),
+						routes: [
+							{
+								baseURL: Maybe.nothing(),
+								method: "GET",
+								path: "/prices/a",
+								upstreamUrl: a.upstreamUrl,
+								forwardResponseHeaders: new Set([]),
+								headers: {},
+								type: "upstream",
+								moduleName: "upstream",
+								useLegacyJsonPath: true,
+							},
+							{
+								baseURL: Maybe.nothing(),
+								method: "GET",
+								path: "/prices/b",
+								upstreamUrl: b.upstreamUrl,
+								forwardResponseHeaders: new Set([]),
+								headers: {},
+								type: "upstream",
+								moduleName: "upstream",
+								useLegacyJsonPath: true,
+							},
+						],
+						fastOnly: false,
+					},
+					dataProxy,
+					{
+						disableProof: true,
+						port: a.port,
+					},
+				)
+					.pipe(Effect.scoped)
+					.pipe(Effect.provide(HttpClientService.Default()))
+					.pipe(Logger.withMinimumLogLevel(LogLevel.None)),
+			);
+
+			const response = await fetch(`http://localhost:${a.port}/multi`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					a: { path: "/prices/a" },
+					b: { path: "/prices/b" },
+				}),
+			});
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get(constants.SIGNATURE_HEADER_KEY)).toBeTruthy();
+			expect(await response.json()).toEqual({
+				a: { venue: "a", price: 1 },
+				b: { venue: "b", price: 2 },
 			});
 		});
 	});

--- a/workspace/data-proxy/src/proxy-server.test.ts
+++ b/workspace/data-proxy/src/proxy-server.test.ts
@@ -72,7 +72,7 @@ describe("proxy server", () => {
 					multiEndpoint: {
 						enable: false,
 						path: "multi",
-						maxRequests: 20,
+						maxSubRequests: 20,
 						concurrency: 5,
 					},
 					baseURL: Maybe.nothing(),
@@ -141,7 +141,7 @@ describe("proxy server", () => {
 					multiEndpoint: {
 						enable: false,
 						path: "multi",
-						maxRequests: 20,
+						maxSubRequests: 20,
 						concurrency: 5,
 					},
 					baseURL: Maybe.nothing(),
@@ -207,7 +207,7 @@ describe("proxy server", () => {
 						multiEndpoint: {
 							enable: false,
 							path: "multi",
-							maxRequests: 20,
+							maxSubRequests: 20,
 							concurrency: 5,
 						},
 						baseURL: Maybe.of("https://seda-data-proxy.com"),
@@ -287,7 +287,7 @@ describe("proxy server", () => {
 						multiEndpoint: {
 							enable: false,
 							path: "multi",
-							maxRequests: 20,
+							maxSubRequests: 20,
 							concurrency: 5,
 						},
 						baseURL: Maybe.of("https://seda-data-proxy.com"),
@@ -371,7 +371,7 @@ describe("proxy server", () => {
 						multiEndpoint: {
 							enable: false,
 							path: "multi",
-							maxRequests: 20,
+							maxSubRequests: 20,
 							concurrency: 5,
 						},
 						baseURL: Maybe.nothing(),
@@ -448,7 +448,7 @@ describe("proxy server", () => {
 						multiEndpoint: {
 							enable: false,
 							path: "multi",
-							maxRequests: 20,
+							maxSubRequests: 20,
 							concurrency: 5,
 						},
 						baseURL: Maybe.nothing(),
@@ -525,7 +525,7 @@ describe("proxy server", () => {
 					multiEndpoint: {
 						enable: false,
 						path: "multi",
-						maxRequests: 20,
+						maxSubRequests: 20,
 						concurrency: 5,
 					},
 					baseURL: Maybe.nothing(),
@@ -608,7 +608,7 @@ describe("proxy server", () => {
 						multiEndpoint: {
 							enable: false,
 							path: "multi",
-							maxRequests: 20,
+							maxSubRequests: 20,
 							concurrency: 5,
 						},
 						baseURL: Maybe.nothing(),
@@ -708,7 +708,7 @@ describe("proxy server", () => {
 						multiEndpoint: {
 							enable: false,
 							path: "multi",
-							maxRequests: 20,
+							maxSubRequests: 20,
 							concurrency: 5,
 						},
 						baseURL: Maybe.nothing(),
@@ -787,7 +787,7 @@ describe("proxy server", () => {
 						multiEndpoint: {
 							enable: false,
 							path: "multi",
-							maxRequests: 20,
+							maxSubRequests: 20,
 							concurrency: 5,
 						},
 						baseURL: Maybe.nothing(),
@@ -888,7 +888,7 @@ describe("proxy server", () => {
 						multiEndpoint: {
 							enable: true,
 							path: "multi",
-							maxRequests: 20,
+							maxSubRequests: 20,
 							concurrency: 5,
 						},
 						baseURL: Maybe.nothing(),
@@ -969,7 +969,7 @@ describe("proxy server", () => {
 						multiEndpoint: {
 							enable: true,
 							path: "multi",
-							maxRequests: 20,
+							maxSubRequests: 20,
 							concurrency: 5,
 						},
 						baseURL: Maybe.nothing(),

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -184,8 +184,8 @@ export const startProxyServer = (
 				}
 			});
 
-			// If enabled, multi endpoint fans out to configured module/upstream
-			// routes by path.
+			// If enabled, multi endpoint fans out sub-requests to configured
+			// module/upstream routes by path.
 			const multiEndpoint = config.multiEndpoint;
 			if (multiEndpoint.enable) {
 				const multiPath = multiEndpoint.path.startsWith("/")

--- a/workspace/data-proxy/src/proxy-server.ts
+++ b/workspace/data-proxy/src/proxy-server.ts
@@ -2,11 +2,12 @@ import { randomUUID } from "node:crypto";
 import { opentelemetry } from "@elysia/opentelemetry";
 import node from "@elysiajs/node";
 import { openapi } from "@elysiajs/openapi";
-import { constants, type DataProxy } from "@seda-protocol/data-proxy-sdk";
+import type { DataProxy } from "@seda-protocol/data-proxy-sdk";
 import { Effect, Layer, Match, MutableHashMap, Option, Runtime } from "effect";
 import { Elysia } from "elysia";
 import { type Config, getHttpMethods } from "./config/config-parser";
 import { DATA_PROXY_ID, DEFAULT_PROXY_ROUTE_GROUP } from "./constants";
+import { handleMultiEndpointRequest } from "./controllers/proxy/handle-multi-endpoint-request";
 import { handleProxyRequest } from "./controllers/proxy/handle-proxy-request";
 import { BinanceModuleService } from "./modules/binance/binance";
 import { ChainlinkStreamsModuleService } from "./modules/chainlink-streams/chainlink-streams";
@@ -14,16 +15,13 @@ import { DxFeedModuleService } from "./modules/dxfeed/dxfeed";
 import { HydromancerModuleService } from "./modules/hydromancer/hydromancer";
 import { LighterModuleService } from "./modules/lighter/lighter";
 import { LoTechModuleService } from "./modules/lo-tech/lo-tech";
-import {
-	EmptyModuleService,
-	type ModuleHandlers,
-	ModuleService,
-} from "./modules/module";
+import { type ModuleHandlers, ModuleService } from "./modules/module";
 import { PmInsightsModuleService } from "./modules/pm-insights/pm-insights";
 import { PythLazerModuleService } from "./modules/pyth-lazer/pyth-lazer";
 import { VolmexModuleService } from "./modules/volmex/volmex";
 import type { HttpClientService } from "./services/http-client";
 import { StatusContext, statusPlugin } from "./status-plugin";
+import { createOptionsResponse } from "./utils/create-headers";
 import { withIncomingTrace } from "./utils/with-incoming-trace";
 
 export interface ProxyServerOptions {
@@ -171,6 +169,11 @@ export const startProxyServer = (
 			),
 		);
 		const proxyGroup = config.routeGroup ?? DEFAULT_PROXY_ROUTE_GROUP;
+		const optionsHandler = () =>
+			createOptionsResponse(
+				dataProxy.publicKey.toString("hex"),
+				dataProxy.version,
+			);
 
 		server.group(proxyGroup, (app) => {
 			// Only update the status context in routes that are part of the proxy group
@@ -181,15 +184,73 @@ export const startProxyServer = (
 				}
 			});
 
+			// If enabled, multi endpoint fans out to configured module/upstream
+			// routes by path.
+			const multiEndpoint = config.multiEndpoint;
+			if (multiEndpoint.enable) {
+				const multiPath = multiEndpoint.path.startsWith("/")
+					? multiEndpoint.path
+					: `/${multiEndpoint.path}`;
+
+				// Legacy multi routes are not valid targets.
+				// TODO(#162): Adjust once legacy multi routes are deprecated.
+				const eligibleRoutes = config.routes.filter(
+					(route) => route.type !== "multi",
+				);
+
+				app.route("OPTIONS", multiPath, optionsHandler);
+
+				app.route(
+					"POST",
+					multiPath,
+					async ({ headers, body, path, requestId, request }) => {
+						const annotations = {
+							requestId,
+							method: request.method,
+							path,
+						};
+						return Runtime.runPromise(
+							runtime,
+							Effect.gen(function* () {
+								const requestBody = Option.fromNullable(
+									body as string | undefined,
+								);
+
+								return yield* handleMultiEndpointRequest({
+									serverOptions,
+									headers,
+									body: requestBody,
+									path,
+									request,
+									config,
+									dataProxy,
+									moduleHandlers,
+									eligibleRoutes,
+									multiEndpoint,
+								});
+							}).pipe(
+								withIncomingTrace,
+								Effect.annotateLogs(annotations),
+								Effect.annotateSpans(annotations),
+							),
+						);
+					},
+					{
+						config: {},
+						parse: ({ request }) => request.text(),
+					},
+				);
+
+				Runtime.runSync(
+					runtime,
+					Effect.logInfo(
+						`Multi endpoint: POST /${proxyGroup.replace(/\/$/, "")}/${multiPath.replace(/^\//, "")}`,
+					),
+				);
+			}
+
 			for (const route of config.routes) {
-				app.route("OPTIONS", route.path, () => {
-					const headers = new Headers({
-						[constants.PUBLIC_KEY_HEADER_KEY]:
-							dataProxy.publicKey.toString("hex"),
-						[constants.SIGNATURE_VERSION_HEADER_KEY]: dataProxy.version,
-					});
-					return new Response(null, { headers });
-				});
+				app.route("OPTIONS", route.path, optionsHandler);
 
 				// A route can have multiple methods attach to it
 				const routeMethods = getHttpMethods(route.method);
@@ -211,11 +272,6 @@ export const startProxyServer = (
 										body as string | undefined,
 									);
 
-									const moduleLayer = MutableHashMap.get(
-										modules,
-										route.moduleName,
-									).pipe(Option.getOrElse(() => EmptyModuleService));
-
 									return yield* handleProxyRequest({
 										serverOptions,
 										headers,
@@ -227,7 +283,7 @@ export const startProxyServer = (
 										config,
 										dataProxy,
 										moduleHandlers,
-									}).pipe(Effect.provide(moduleLayer));
+									});
 								}).pipe(
 									withIncomingTrace,
 									Effect.annotateLogs(annotations),

--- a/workspace/data-proxy/src/utils/create-headers.ts
+++ b/workspace/data-proxy/src/utils/create-headers.ts
@@ -7,6 +7,15 @@ export function createDefaultResponseHeaders() {
 	return headers;
 }
 
+export function createOptionsResponse(publicKeyHex: string, version: string) {
+	return new Response(null, {
+		headers: {
+			[constants.PUBLIC_KEY_HEADER_KEY]: publicKeyHex,
+			[constants.SIGNATURE_VERSION_HEADER_KEY]: version,
+		},
+	});
+}
+
 export function createSignedResponseHeaders(
 	signature: SignedData,
 	headers = new Headers(),

--- a/workspace/data-proxy/src/utils/match-route-path.test.ts
+++ b/workspace/data-proxy/src/utils/match-route-path.test.ts
@@ -67,4 +67,32 @@ describe("matchRoutePath", () => {
 			symbols: "BTC",
 		});
 	});
+
+	it("captures a trailing wildcard remainder", () => {
+		expect(matchRoutePath("/*", "/people/1")).toEqual({ "*": "people/1" });
+		expect(matchRoutePath("/upstream/*", "/upstream/coffee/hot")).toEqual({
+			"*": "coffee/hot",
+		});
+	});
+
+	it("captures an empty wildcard when only the prefix matches", () => {
+		expect(matchRoutePath("/*", "/")).toEqual({ "*": "" });
+		expect(matchRoutePath("/upstream/*", "/upstream")).toEqual({ "*": "" });
+	});
+
+	it("captures params before a trailing wildcard", () => {
+		expect(matchRoutePath("/:coinA/*", "/btc/orderbook/depth")).toEqual({
+			coinA: "btc",
+			"*": "orderbook/depth",
+		});
+	});
+
+	it("does not match when a wildcard prefix differs", () => {
+		expect(matchRoutePath("/upstream/*", "/other/x")).toBeNull();
+	});
+
+	it("does not treat a non-trailing * as a wildcard", () => {
+		expect(matchRoutePath("/a/*/b", "/a/x/b")).toBeNull();
+		expect(matchRoutePath("/a/*/b", "/a/*/b")).toEqual({});
+	});
 });

--- a/workspace/data-proxy/src/utils/match-route-path.test.ts
+++ b/workspace/data-proxy/src/utils/match-route-path.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { matchRoutePath, normalizePath } from "./match-route-path";
+
+describe("normalizePath", () => {
+	it("adds a leading slash and strips trailing slashes", () => {
+		expect(normalizePath("multi")).toBe("/multi");
+		expect(normalizePath("/multi/")).toBe("/multi");
+		expect(normalizePath("/multi///")).toBe("/multi");
+	});
+
+	it("keeps the root path as a single slash", () => {
+		expect(normalizePath("/")).toBe("/");
+		expect(normalizePath("")).toBe("/");
+	});
+});
+
+describe("matchRoutePath", () => {
+	it("matches a static path", () => {
+		expect(matchRoutePath("/health", "/health")).toEqual({});
+	});
+
+	it("does not match a static path", () => {
+		expect(matchRoutePath("/health", "/healths")).toBeNull();
+	});
+
+	it("captures path params", () => {
+		expect(matchRoutePath("/binance/:symbols", "/binance/BTC,ETH")).toEqual({
+			symbols: "BTC,ETH",
+		});
+	});
+
+	it("does not match a path involving a param", () => {
+		expect(matchRoutePath("/binance/:symbols", "/binances/BTC,ETH")).toBeNull();
+	});
+
+	it("matches when the pattern has no leading slash", () => {
+		expect(matchRoutePath("quote/:symbols", "/quote/AAPL")).toEqual({
+			symbols: "AAPL",
+		});
+	});
+
+	it("matches when the request path has no leading slash", () => {
+		expect(matchRoutePath("/quote/:symbols", "quote/AAPL")).toEqual({
+			symbols: "AAPL",
+		});
+	});
+
+	it("returns null when segment counts differ", () => {
+		expect(matchRoutePath("/a/:b", "/a/b/c")).toBeNull();
+	});
+
+	it("returns null when a static segment differs", () => {
+		expect(matchRoutePath("/binance/:symbols", "/lighter/1")).toBeNull();
+	});
+
+	it("decodes URI-encoded param values", () => {
+		expect(matchRoutePath("/x/:v", "/x/a%2Cb")).toEqual({ v: "a,b" });
+	});
+
+	it("returns null when a param has malformed percent-encoding", () => {
+		expect(matchRoutePath("/x/:v", "/x/%ZZ")).toBeNull();
+		expect(matchRoutePath("/x/:v", "/x/%")).toBeNull();
+	});
+
+	it("treats trailing slashes as equivalent", () => {
+		expect(matchRoutePath("/binance/:symbols/", "/binance/BTC")).toEqual({
+			symbols: "BTC",
+		});
+	});
+});

--- a/workspace/data-proxy/src/utils/match-route-path.ts
+++ b/workspace/data-proxy/src/utils/match-route-path.ts
@@ -1,0 +1,49 @@
+// Matches a request path against a configured route path pattern and
+// captures `:param` segments into a params object (empty when none).
+// Returns null when the path does not match.
+export const matchRoutePath = (
+	pattern: string,
+	path: string,
+): Record<string, string> | null => {
+	const patternParts = splitPath(pattern);
+	const pathParts = splitPath(path);
+
+	if (patternParts.length !== pathParts.length) {
+		return null;
+	}
+
+	const params: Record<string, string> = {};
+
+	for (let i = 0; i < patternParts.length; i++) {
+		const patternPart = patternParts[i];
+		const pathPart = pathParts[i];
+
+		if (patternPart.startsWith(":")) {
+			const key = patternPart.slice(1);
+			if (key.length === 0) {
+				return null;
+			}
+			try {
+				params[key] = decodeURIComponent(pathPart);
+			} catch {
+				// decodeURIComponent throws on invalid characters.
+				return null;
+			}
+			continue;
+		}
+
+		if (patternPart !== pathPart) {
+			return null;
+		}
+	}
+
+	return params;
+};
+
+// Ensures a leading `/` and strips trailing `/`s (except for root `/`).
+export const normalizePath = (path: string): string => {
+	const withLeading = path.startsWith("/") ? path : `/${path}`;
+	return withLeading.length > 1 ? withLeading.replace(/\/+$/, "") : withLeading;
+};
+
+const splitPath = (path: string): string[] => normalizePath(path).split("/");

--- a/workspace/data-proxy/src/utils/match-route-path.ts
+++ b/workspace/data-proxy/src/utils/match-route-path.ts
@@ -1,5 +1,6 @@
 // Matches a request path against a configured route path pattern and
-// captures `:param` segments into a params object (empty when none).
+// captures :param and trailing * values provided by the path into a
+// params object (empty when none).
 // Returns null when the path does not match.
 export const matchRoutePath = (
 	pattern: string,
@@ -8,10 +9,42 @@ export const matchRoutePath = (
 	const patternParts = splitPath(pattern);
 	const pathParts = splitPath(path);
 
+	if (
+		patternParts.length > 0 &&
+		patternParts[patternParts.length - 1] === "*"
+	) {
+		const prefixParts = patternParts.slice(0, -1);
+		if (pathParts.length < prefixParts.length) {
+			return null;
+		}
+
+		const params = matchSegments(prefixParts, pathParts);
+		if (params === null) {
+			return null;
+		}
+
+		// Capture the remainder of the path as the `*` value.
+		// Leave it URI-encoded so path remainder can be forwarded to upstream
+		// as-is. Named `:param` values are decoded because they are treated as
+		// data we extract and use ourselves.
+		params["*"] = pathParts.slice(prefixParts.length).join("/");
+
+		return params;
+	}
+
 	if (patternParts.length !== pathParts.length) {
 		return null;
 	}
 
+	return matchSegments(patternParts, pathParts);
+};
+
+// Matches patternParts against the corresponding leading pathParts segments.
+// Named `:param` values are URI-decoded; static segments must match exactly.
+const matchSegments = (
+	patternParts: string[],
+	pathParts: string[],
+): Record<string, string> | null => {
 	const params: Record<string, string> = {};
 
 	for (let i = 0; i < patternParts.length; i++) {
@@ -26,7 +59,7 @@ export const matchRoutePath = (
 			try {
 				params[key] = decodeURIComponent(pathPart);
 			} catch {
-				// decodeURIComponent throws on invalid characters.
+				// decodeURIComponent throws on invalid percent-encoding.
 				return null;
 			}
 			continue;


### PR DESCRIPTION
## Motivation

Support multi routing (multiple sub-requests across different modules in a single request) with minimal additional configuration.

## Explanation of Changes

If multi endpoint is enabled in the config, users can start making requests like:
```bash
curl -sS -X POST 'http://127.0.0.1:5384/proxy/multi' \
  -H 'content-type: application/json' \
  -d '{
    "requests": [
      { "id": "binance-futures", "path": "/binance-futures/BTCUSDT,ETHUSDT" },
      { "id": "lighter", "path": "/lighter/1,0" },
      {
        "id": "hydromancer",
        "path": "/hydromancer/asset-context",
        "method": "POST",
        "body": { "type": "assetContext", "coins": "BTC,ETH" }
      }
    ]
  }'
```
`path` is matched against the proxy's configured routes, just like paths clients already call one-by-one.

We keep the existing multi route structure until the infra is upgraded. We obviously block calling a multi route through the multi endpoint.

## Testing

